### PR TITLE
PL-58: Add AuditContext

### DIFF
--- a/main/src/main/java/com/kenshoo/pl/entity/AuditContext.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/AuditContext.java
@@ -1,0 +1,29 @@
+package com.kenshoo.pl.entity;
+
+import java.util.stream.Stream;
+
+/**
+ * A context which provides additional data that should be added to an {@link AuditRecord}.<br>
+ * This data could be used as a way of tagging/grouping the audit records for queries later on.<br>
+ * @see com.kenshoo.pl.entity.annotation.Audited
+ */
+public interface AuditContext {
+
+    /**
+     * @return additional fields (not necessarily from the same entity type) which should be added to an {@link AuditRecord},
+     * to be used for tagging / grouping the records
+     */
+    Stream<? extends EntityField<?, ?>> getTagFields();
+
+
+    /**
+     * Empty implementation in case no additional data is needed
+     */
+    final class EmptyAuditContext implements AuditContext {
+
+        @Override
+        public Stream<? extends EntityField<?, ?>> getTagFields() {
+            return Stream.empty();
+        }
+    }
+}

--- a/main/src/main/java/com/kenshoo/pl/entity/annotation/Audited.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/annotation/Audited.java
@@ -1,5 +1,8 @@
 package com.kenshoo.pl.entity.annotation;
 
+import com.kenshoo.pl.entity.AuditContext;
+import com.kenshoo.pl.entity.AuditContext.EmptyAuditContext;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -12,4 +15,10 @@ import java.lang.annotation.Target;
 @Target({ElementType.TYPE, ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Audited {
+
+    /**
+     * A context which provides additional data that should be added to an {@link com.kenshoo.pl.entity.AuditRecord}.<br>
+     * This attribute is valid for entity-level annotations only, and will be ignored if appearing on fields.
+     */
+    Class<? extends AuditContext> context() default EmptyAuditContext.class;
 }


### PR DESCRIPTION
Adding the `AuditContext` interface which will be used to provide additional fields that should be added to the `AuditRecord` in order to tag/group the records (for example: profileId, advertiserId, etc.)
In this PR adding only the interface and corresponding annotation attribute.
The next PR-s will add the logic for populating the `AuditRecord` accordingly.