### PR TITLE
Pl context fetch by keys and pl condition API

### DIFF
--- a/integration-tests/src/test/java/com/kenshoo/pl/entity/EntitiesFetcherByPLConditionTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/entity/EntitiesFetcherByPLConditionTest.java
@@ -1,5 +1,6 @@
 package com.kenshoo.pl.entity;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.kenshoo.jooq.AbstractDataTable;
 import com.kenshoo.jooq.DataTable;
@@ -359,6 +360,43 @@ public class EntitiesFetcherByPLConditionTest {
                    hasFieldValues(fieldValue(TestEntityType.FIELD1, "Bravo")));
         assertThat(sortedEntities.get(1),
                    hasFieldValues(fieldValue(TestEntityType.FIELD1, "Delta")));
+    }
+
+
+    @Test
+    public void fetchByUniqueKeys() {
+        final PairUniqueKey<TestEntityType, Integer, Integer> uniqueKey= new PairUniqueKey<>(TestEntityType.ID, TestEntityType.TYPE);
+
+        final List<Entity> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
+                ImmutableList.of(uniqueKey.createValue(1, 1), uniqueKey.createValue(2, 1)),
+                PLCondition.TrueCondition,
+                TestEntityType.TYPE, TestEntityType.FIELD1);
+
+        final List<Entity> sortedEntities = entities.stream()
+                .sorted(comparing(entity -> entity.get(TestEntityType.TYPE)))
+                .collect(toList());
+
+        assertThat(sortedEntities.get(0),
+                hasFieldValues(fieldValue(TestEntityType.FIELD1, "Alpha")));
+        assertThat(sortedEntities.get(1),
+                hasFieldValues(fieldValue(TestEntityType.FIELD1, "Bravo")));
+    }
+
+    @Test
+    public void fetchByUniqueKeysAndCondition() {
+        final PairUniqueKey<TestEntityType, Integer, Integer> uniqueKey= new PairUniqueKey<>(TestEntityType.ID, TestEntityType.TYPE);
+
+        final List<Entity> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
+                ImmutableList.of(uniqueKey.createValue(1, 1), uniqueKey.createValue(2, 1)),
+                not(TestEntityType.ID.eq(1)),
+                TestEntityType.TYPE, TestEntityType.FIELD1);
+
+        final List<Entity> sortedEntities = entities.stream()
+                .sorted(comparing(entity -> entity.get(TestEntityType.TYPE)))
+                .collect(toList());
+
+        assertThat(sortedEntities.get(0),
+                hasFieldValues(fieldValue(TestEntityType.FIELD1, "Bravo")));
     }
 
     private static class TestTable extends AbstractDataTable<TestTable> {

--- a/integration-tests/src/test/java/com/kenshoo/pl/entity/EntitiesFetcherByPLConditionTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/entity/EntitiesFetcherByPLConditionTest.java
@@ -26,8 +26,7 @@ import static com.kenshoo.pl.entity.PLCondition.not;
 import static com.kenshoo.pl.entity.annotation.RequiredFieldType.RELATION;
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.toList;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 
 public class EntitiesFetcherByPLConditionTest {
@@ -389,14 +388,15 @@ public class EntitiesFetcherByPLConditionTest {
         final List<Entity> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
                 ImmutableList.of(uniqueKey.createValue(1, 1), uniqueKey.createValue(2, 1)),
                 not(TestEntityType.ID.eq(1)),
-                TestEntityType.TYPE, TestEntityType.FIELD1);
+                TestEntityType.ID, TestEntityType.TYPE, TestEntityType.FIELD1);
 
         final List<Entity> sortedEntities = entities.stream()
                 .sorted(comparing(entity -> entity.get(TestEntityType.TYPE)))
                 .collect(toList());
 
+        assertThat(sortedEntities.size(), is(1));
         assertThat(sortedEntities.get(0),
-                hasFieldValues(fieldValue(TestEntityType.FIELD1, "Bravo")));
+                hasFieldValues(fieldValue(TestEntityType.ID, 2), fieldValue(TestEntityType.FIELD1, "Bravo")));
     }
 
     private static class TestTable extends AbstractDataTable<TestTable> {

--- a/integration-tests/src/test/java/com/kenshoo/pl/entity/PLContextSelectTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/entity/PLContextSelectTest.java
@@ -137,7 +137,7 @@ public class PLContextSelectTest {
         final List<Entity> entities = plContext.select(TestEntityType.ID, TestEntityType.FIELD1)
                 .from(TestEntityType.INSTANCE)
                 .where(PLCondition.TrueCondition)
-                .fetch(ImmutableList.of(uniqueKey.createValue(1)));
+                .fetchByKeys(ImmutableList.of(uniqueKey.createValue(1)));
         assertThat("Incorrect number of entities fetched: ",
                 entities.size(), is(1));
 

--- a/integration-tests/src/test/java/com/kenshoo/pl/entity/PLContextSelectTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/entity/PLContextSelectTest.java
@@ -1,5 +1,6 @@
 package com.kenshoo.pl.entity;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.kenshoo.jooq.AbstractDataTable;
 import com.kenshoo.jooq.DataTable;
@@ -128,6 +129,23 @@ public class PLContextSelectTest {
                                   fieldValue(TestParentEntityType.FIELD1, "ParentAlpha"),
                                   fieldValue(TestParentEntityType.SECONDARY_FIELD1, "ParentSecondaryAlpha")));
     }
+
+    @Test
+    public void selectFromSingleEntityByKeys() {
+        final SingleUniqueKey<TestEntityType, Integer> uniqueKey = new SingleUniqueKey<>(TestEntityType.ID);
+
+        final List<Entity> entities = plContext.select(TestEntityType.ID, TestEntityType.FIELD1)
+                .from(TestEntityType.INSTANCE)
+                .where(PLCondition.TrueCondition)
+                .fetch(ImmutableList.of(uniqueKey.createValue(1)));
+        assertThat("Incorrect number of entities fetched: ",
+                entities.size(), is(1));
+
+        assertThat(entities.get(0),
+                hasFieldValues(fieldValue(TestEntityType.ID, 1),
+                        fieldValue(TestEntityType.FIELD1, "Alpha")));
+    }
+
 
     @Test(expected = IllegalArgumentException.class)
     public void selectWithoutFieldsShouldThrowException() {

--- a/integration-tests/src/test/java/com/kenshoo/pl/entity/PersistenceLayerTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/entity/PersistenceLayerTest.java
@@ -671,9 +671,7 @@ public class PersistenceLayerTest {
         Instant expectedCreationDate = Instant.now();
         CreateResult<EntityForTest, EntityForTest.Key> results = persistenceLayer.create(ImmutableList.of(command), changeFlowConfig().build(), EntityForTest.Key.DEFINITION);
         assertThat(results.hasErrors(), is(false));
-        Map<Identifier<EntityForTest>, Entity> entityMap = entitiesFetcher.fetchEntitiesByKeys(EntityForTest.INSTANCE,
-                                                                                               EntityForTest.Key.DEFINITION,
-                                                                                               singleton(new EntityForTest.Key(newId)),
+        Map<Identifier<EntityForTest>, Entity> entityMap = entitiesFetcher.fetchEntitiesByIds(singleton(new EntityForTest.Key(newId)),
                                                                                                singleton(EntityForTest.CREATION_DATE));
         assertThat(entityMap.size(), is(1));
         Instant actualCreationDate = entityMap.values().iterator().next().get(EntityForTest.CREATION_DATE);

--- a/main/src/main/java/com/kenshoo/pl/entity/FetchFinalStep.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/FetchFinalStep.java
@@ -17,5 +17,5 @@ public interface FetchFinalStep {
      * @param keys the keys to fetch
      * @return the result entities
      */
-    List<Entity> fetch(Collection<? extends Identifier<?>> keys);
+    List<Entity> fetchByKeys(Collection<? extends Identifier<?>> keys);
 }

--- a/main/src/main/java/com/kenshoo/pl/entity/FetchFinalStep.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/FetchFinalStep.java
@@ -1,5 +1,6 @@
 package com.kenshoo.pl.entity;
 
+import java.util.Collection;
 import java.util.List;
 
 public interface FetchFinalStep {
@@ -10,4 +11,11 @@ public interface FetchFinalStep {
      * @return the result entities
      */
     List<Entity> fetch();
+
+    /**
+     * Finish building the query and fetch the results from the DB
+     * @param keys the keys to fetch
+     * @return the result entities
+     */
+    List<Entity> fetch(Collection<? extends Identifier<?>> keys);
 }

--- a/main/src/main/java/com/kenshoo/pl/entity/FluentEntitiesFetcher.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/FluentEntitiesFetcher.java
@@ -38,7 +38,7 @@ class FluentEntitiesFetcher implements FetchFromStep, FetchWhereStep, FetchFinal
         return entitiesFetcher.fetch(entityType, condition, fieldsToFetch);
     }
 
-    public List<Entity> fetch(Collection<? extends Identifier<?>> keys) {
+    public List<Entity> fetchByKeys(Collection<? extends Identifier<?>> keys) {
         return entitiesFetcher.fetch(entityType, keys, condition, fieldsToFetch);
     }
 }

--- a/main/src/main/java/com/kenshoo/pl/entity/FluentEntitiesFetcher.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/FluentEntitiesFetcher.java
@@ -2,7 +2,11 @@ package com.kenshoo.pl.entity;
 
 import com.kenshoo.pl.entity.internal.EntitiesFetcher;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
 
@@ -11,7 +15,8 @@ class FluentEntitiesFetcher implements FetchFromStep, FetchWhereStep, FetchFinal
     private final EntitiesFetcher entitiesFetcher;
     private final EntityField<?, ?>[] fieldsToFetch;
     private EntityType<?> entityType;
-    private PLCondition condition;
+    private PLCondition condition = PLCondition.TrueCondition;
+
 
     FluentEntitiesFetcher(final EntitiesFetcher entitiesFetcher,
                           final EntityField<?, ?>... fieldsToFetch) {
@@ -30,8 +35,10 @@ class FluentEntitiesFetcher implements FetchFromStep, FetchWhereStep, FetchFinal
     }
 
     public List<Entity> fetch() {
-        return entitiesFetcher.fetch(entityType,
-                                     condition,
-                                     fieldsToFetch);
+        return entitiesFetcher.fetch(entityType, condition, fieldsToFetch);
+    }
+
+    public List<Entity> fetch(Collection<? extends Identifier<?>> keys) {
+        return entitiesFetcher.fetch(entityType, keys, condition, fieldsToFetch);
     }
 }

--- a/main/src/main/java/com/kenshoo/pl/entity/PLCondition.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/PLCondition.java
@@ -6,12 +6,16 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.jooq.Condition;
+import org.jooq.impl.DSL;
 
+import java.util.Collections;
 import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
 
 public class PLCondition {
+
+    public static PLCondition TrueCondition = new PLCondition(DSL.trueCondition());
 
     private final Condition jooqCondition;
     private final Set<? extends EntityField<?, ?>> fields;

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/EntitiesFetcher.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/EntitiesFetcher.java
@@ -36,14 +36,6 @@ public class EntitiesFetcher {
         this.oldEntityFetcher = new OldEntityFetcher(dslContext);
     }
 
-    public <E extends EntityType<E>> Map<Identifier<E>, Entity> fetchEntitiesByKeys(final E entityType,
-                                                                                    final UniqueKey<E> uniqueKey,
-                                                                                    final Collection<? extends Identifier<E>> keys,
-                                                                                    final Collection<? extends EntityField<?, ?>> fieldsToFetch) {
-        return fetchEntitiesByIds(keys, fieldsToFetch);
-
-    }
-
     public <E extends EntityType<E>> Map<Identifier<E>, Entity> fetchEntitiesByIds(final Collection<? extends Identifier<E>> ids,
                                                                                    final EntityField<?, ?>... fieldsToFetchArgs) {
         return fetchEntitiesByIds(ids, ImmutableList.copyOf(fieldsToFetchArgs));
@@ -69,6 +61,13 @@ public class EntitiesFetcher {
                               final PLCondition plCondition,
                               final EntityField<?, ?>... fieldsToFetch) {
         return oldEntityFetcher.fetch(entityType, plCondition, fieldsToFetch);
+    }
+
+    public List<Entity> fetch(final EntityType<?> entityType,
+                              final Collection<? extends Identifier<?>> ids,
+                              final PLCondition plCondition,
+                              final EntityField<?, ?>... fieldsToFetch) {
+        return oldEntityFetcher.fetch(entityType, ids, plCondition, fieldsToFetch);
     }
 
     public <E extends EntityType<E>> Map<Identifier<E>, Entity> fetchEntitiesByForeignKeys(E entityType, UniqueKey<E> foreignUniqueKey, Collection<? extends Identifier<E>> keys, Collection<EntityField<?, ?>> fieldsToFetch) {


### PR DESCRIPTION
Introduce new fetch by key API

Example:

final List<Entity> entities = plContext.select(TestEntityType.ID, TestEntityType.FIELD1)
                                               .from(TestEntityType.INSTANCE)
                                               .where(TestEntityType.FIELD1.eq("Alpha"))
                                               .fetchByKeys(keys);
