### PR TITLE
Add test for fetch by parent keys

### DIFF
--- a/integration-tests/src/test/java/com/kenshoo/pl/entity/PLContextSelectTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/entity/PLContextSelectTest.java
@@ -146,6 +146,25 @@ public class PLContextSelectTest {
                         fieldValue(TestEntityType.FIELD1, "Alpha")));
     }
 
+    @Test
+    public void selectFromSingleEntityByParentKeys() {
+        final SingleUniqueKey<TestParentEntityType, Integer> uniqueKey = new SingleUniqueKey<>(TestParentEntityType.ID);
+
+        final List<Entity> entities = plContext.select(TestEntityType.ID, TestEntityType.FIELD1)
+                .from(TestEntityType.INSTANCE)
+                .where(PLCondition.TrueCondition)
+                .fetchByKeys(ImmutableList.of(uniqueKey.createValue(1)));
+        assertThat("Incorrect number of entities fetched: ",
+                entities.size(), is(2));
+
+        assertThat(entities.get(0),
+                hasFieldValues(fieldValue(TestEntityType.ID, 1),
+                        fieldValue(TestEntityType.FIELD1, "Alpha")));
+        assertThat(entities.get(1),
+                hasFieldValues(fieldValue(TestEntityType.ID, 2),
+                        fieldValue(TestEntityType.FIELD1, "Bravo")));
+    }
+
 
     @Test(expected = IllegalArgumentException.class)
     public void selectWithoutFieldsShouldThrowException() {

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/fetch/OldEntityFetcher.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/fetch/OldEntityFetcher.java
@@ -17,6 +17,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.*;
 import java.util.function.Predicate;
+import java.util.stream.Stream;
 
 import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
@@ -88,7 +89,8 @@ public class OldEntityFetcher {
         final AliasedKey<?> aliasedKey = new AliasedKey<>(uniqueKey);
 
         final Set<EntityField<?, ?>> requestedFieldsToFetch = ImmutableSet.copyOf(fieldsToFetch);
-        final Set<? extends EntityField<?, ?>> allFieldsToFetch = Sets.union(requestedFieldsToFetch, plCondition.getFields());
+        final Set<EntityField<?, ?>> conditions = Stream.concat(plCondition.getFields().stream(), Arrays.stream(uniqueKey.getFields())).collect(toSet());
+        final Set<? extends EntityField<?, ?>> allFieldsToFetch = Sets.union(requestedFieldsToFetch, conditions);
 
         final SelectJoinStep<Record> query = buildFetchQuery(entityType.getPrimaryTable(), aliasedKey.aliasedFields(), allFieldsToFetch);
         final Condition completeJooqCondition = addVirtualPartitionConditions(entityType, plCondition.getJooqCondition());


### PR DESCRIPTION
Test for  fetch by parent keys

Example:

final List entities = plContext.select(TestEntityType.ID, TestEntityType.FIELD1)
.from(TestEntityType.INSTANCE)
.where(TestEntityType.FIELD1.eq("Alpha"))
.fetchByKeys(**parentKeys**)