### PR TITLE
PL-69: Modify generator to populate mandatory fields in AuditRecord

### DIFF
--- a/integration-tests/src/test/java/com/kenshoo/matcher/EntityHasFieldValuesMatcher.java
+++ b/integration-tests/src/test/java/com/kenshoo/matcher/EntityHasFieldValuesMatcher.java
@@ -3,6 +3,7 @@ package com.kenshoo.matcher;
 import com.google.common.collect.ImmutableSet;
 import com.kenshoo.pl.entity.Entity;
 import com.kenshoo.pl.entity.EntityField;
+import com.kenshoo.pl.entity.EntityFieldValue;
 import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
@@ -42,12 +43,12 @@ public class EntityHasFieldValuesMatcher extends TypeSafeMatcher<Entity> {
     }
 
     private String validateField(final Entity actualEntity, final EntityFieldValue fieldValue) {
-        if (!actualEntity.containsField(fieldValue.entityField)) {
-            return "\t\tMissing expected field '" + fieldValue.entityFieldName() + "'";
+        if (!actualEntity.containsField(fieldValue.getField())) {
+            return "\t\tMissing expected field '" + fieldValue.getFieldName() + "'";
         }
-        final Object actualValue = actualEntity.get(fieldValue.entityField);
-        if (!Objects.equals(actualValue, fieldValue.value)) {
-            return "\t\tIncorrect value for field " + fieldValue.entityFieldName() + ": '" + actualValue + "'";
+        final Object actualValue = actualEntity.get(fieldValue.getField());
+        if (!Objects.equals(actualValue, fieldValue.getValue())) {
+            return "\t\tIncorrect value for field " + fieldValue.getFieldName() + ": '" + actualValue + "'";
         }
         return StringUtils.EMPTY;
     }
@@ -58,24 +59,5 @@ public class EntityHasFieldValuesMatcher extends TypeSafeMatcher<Entity> {
 
     public static EntityFieldValue fieldValue(final EntityField<?, ?> entityField, final Object value) {
         return new EntityFieldValue(entityField, value);
-    }
-
-    public static class EntityFieldValue {
-        private final EntityField<?, ?> entityField;
-        private final Object value;
-
-        private EntityFieldValue(final EntityField<?, ?> entityField, final Object value) {
-            this.entityField = entityField;
-            this.value = value;
-        }
-
-        @Override
-        public String toString() {
-            return entityFieldName() + "=" + value;
-        }
-
-        private String entityFieldName() {
-            return entityField.getEntityType().getName() + "." + entityField;
-        }
     }
 }

--- a/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForCreateOneLevelWithMandatoryTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForCreateOneLevelWithMandatoryTest.java
@@ -17,9 +17,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.List;
-import java.util.Objects;
 
-import static com.kenshoo.pl.entity.ChangeOperation.CREATE;
 import static com.kenshoo.pl.entity.matchers.audit.AuditRecordMatchers.*;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
@@ -35,15 +33,22 @@ public class AuditForCreateOneLevelWithMandatoryTest {
     private static final String ANCESTOR_NAME = "ancestorName";
     private static final String ANCESTOR_DESC = "ancestorDesc";
 
+    private static final EntityField<AuditedWithAncestorMandatoryType, Long> ANCESTOR_FK_FIELD = AuditedWithAncestorMandatoryType.ANCESTOR_ID;
+    private static final EntityField<AuditedWithAncestorMandatoryType, String> NAME_FIELD = AuditedWithAncestorMandatoryType.NAME;
+    private static final EntityField<AuditedWithAncestorMandatoryType, String> DESC_FIELD = AuditedWithAncestorMandatoryType.DESC;
+
+    private static final EntityField<NotAuditedAncestorType, String> ANCESTOR_NAME_FIELD = NotAuditedAncestorType.NAME;
+    private static final EntityField<NotAuditedAncestorType, String> ANCESTOR_DESC_FIELD = NotAuditedAncestorType.DESC;
+
     private static final List<DataTable> ALL_TABLES = ImmutableList.of(MainWithAncestorTable.INSTANCE,
                                                                        AncestorTable.INSTANCE);
 
     private PLContext plContext;
     private InMemoryAuditRecordPublisher auditRecordPublisher;
 
-    private ChangeFlowConfig<AuditedWithAncestorMandatoryType> auditedWithAncestorMandatoryConfig;
+    private ChangeFlowConfig<AuditedWithAncestorMandatoryType> mainWithAncestorMandatoryConfig;
 
-    private PersistenceLayer<AuditedWithAncestorMandatoryType> auditedWithAncestorMandatoryPL;
+    private PersistenceLayer<AuditedWithAncestorMandatoryType> mainWithAncestorMandatoryPL;
 
     @Before
     public void setUp() {
@@ -54,9 +59,9 @@ public class AuditForCreateOneLevelWithMandatoryTest {
             .withAuditRecordPublisher(auditRecordPublisher)
             .build();
 
-        auditedWithAncestorMandatoryConfig = flowConfig(AuditedWithAncestorMandatoryType.INSTANCE);
+        mainWithAncestorMandatoryConfig = flowConfig(AuditedWithAncestorMandatoryType.INSTANCE);
 
-        auditedWithAncestorMandatoryPL = persistenceLayer();
+        mainWithAncestorMandatoryPL = persistenceLayer();
 
         ALL_TABLES.forEach(table -> DataTableUtils.createTable(dslContext, table));
 
@@ -74,47 +79,40 @@ public class AuditForCreateOneLevelWithMandatoryTest {
 
     @Test
     public void oneEntity_WithEntityLevelMandatoryFields_AndFieldsInCmd_ShouldCreateMandatoryFieldsAndFieldRecords() {
-        final CreateResult<AuditedWithAncestorMandatoryType, Identifier<AuditedWithAncestorMandatoryType>> createResult =
-            auditedWithAncestorMandatoryPL.create(singletonList(new CreateAuditedWithAncestorMandatoryCommand()
-                                                                    .with(AuditedWithAncestorMandatoryType.ANCESTOR_ID, ANCESTOR_ID)
-                                                                    .with(AuditedWithAncestorMandatoryType.NAME, NAME)
-                                                                    .with(AuditedWithAncestorMandatoryType.DESC, DESC)),
-                                                  auditedWithAncestorMandatoryConfig);
-        final long id = extractIdFromResult(createResult, AuditedWithAncestorMandatoryType.ID);
+        mainWithAncestorMandatoryPL.create(singletonList(createCommand()
+                                                             .with(ANCESTOR_FK_FIELD, ANCESTOR_ID)
+                                                             .with(NAME_FIELD, NAME)
+                                                             .with(DESC_FIELD, DESC)),
+                                           mainWithAncestorMandatoryConfig);
 
         final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
         final AuditRecord<AuditedWithAncestorMandatoryType> auditRecord = typed(auditRecords.get(0));
-        //noinspection unchecked
-        assertThat(auditRecord, allOf(hasEntityType(AuditedWithAncestorMandatoryType.INSTANCE),
-                                      hasEntityId(String.valueOf(id)),
-                                      hasMandatoryFieldValue(NotAuditedAncestorType.NAME, ANCESTOR_NAME),
-                                      hasMandatoryFieldValue(NotAuditedAncestorType.DESC, ANCESTOR_DESC),
-                                      hasOperator(CREATE),
-                                      hasCreatedFieldRecord(AuditedWithAncestorMandatoryType.NAME, NAME),
-                                      hasCreatedFieldRecord(AuditedWithAncestorMandatoryType.DESC, DESC)));
+        assertThat(auditRecord, allOf(hasMandatoryFieldValue(ANCESTOR_NAME_FIELD, ANCESTOR_NAME),
+                                      hasMandatoryFieldValue(ANCESTOR_DESC_FIELD, ANCESTOR_DESC),
+                                      hasCreatedFieldRecord(NAME_FIELD, NAME),
+                                      hasCreatedFieldRecord(DESC_FIELD, DESC)));
+    }
+
+    private CreateAuditedWithAncestorMandatoryCommand createCommand() {
+        return new CreateAuditedWithAncestorMandatoryCommand();
     }
 
     @Test
     public void oneEntity_WithEntityLevelMandatoryFields_AndNoFieldsInCmd_ShouldCreateMandatoryFieldsOnly() {
-        final CreateResult<AuditedWithAncestorMandatoryType, Identifier<AuditedWithAncestorMandatoryType>> createResult =
-            auditedWithAncestorMandatoryPL.create(singletonList(new CreateAuditedWithAncestorMandatoryCommand()
-                                                                    .with(AuditedWithAncestorMandatoryType.ANCESTOR_ID, ANCESTOR_ID)),
-                                                  auditedWithAncestorMandatoryConfig);
-        final long id = extractIdFromResult(createResult, AuditedWithAncestorMandatoryType.ID);
+        mainWithAncestorMandatoryPL.create(singletonList(createCommand()
+                                                             .with(ANCESTOR_FK_FIELD, ANCESTOR_ID)),
+                                           mainWithAncestorMandatoryConfig);
 
         final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
         final AuditRecord<AuditedWithAncestorMandatoryType> auditRecord = typed(auditRecords.get(0));
-        assertThat(auditRecord, allOf(hasEntityType(AuditedWithAncestorMandatoryType.INSTANCE),
-                                      hasEntityId(String.valueOf(id)),
-                                      hasMandatoryFieldValue(NotAuditedAncestorType.NAME, ANCESTOR_NAME),
+        assertThat(auditRecord, allOf(hasMandatoryFieldValue(NotAuditedAncestorType.NAME, ANCESTOR_NAME),
                                       hasMandatoryFieldValue(NotAuditedAncestorType.DESC, ANCESTOR_DESC),
-                                      hasOperator(CREATE),
                                       hasNoFieldRecords()));
     }
 
@@ -124,17 +122,6 @@ public class AuditForCreateOneLevelWithMandatoryTest {
 
     private <E extends EntityType<E>> PersistenceLayer<E> persistenceLayer() {
         return new PersistenceLayer<>(plContext);
-    }
-
-    private <E extends EntityType<E>> long extractIdFromResult(final CreateResult<E, Identifier<E>> createResult,
-                                                               final EntityField<E, Long> idField) {
-        return createResult.getChangeResults().stream()
-                           .map(EntityChangeResult::getCommand)
-                           .map(CreateEntityCommand::getIdentifier)
-                           .filter(Objects::nonNull)
-                           .map(identifier -> identifier.get(idField))
-                           .findFirst()
-                           .orElseThrow(() -> new IllegalStateException("No ids returned by create operation"));
     }
 
     @SuppressWarnings("unchecked")

--- a/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForCreateOneLevelWithMandatoryTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForCreateOneLevelWithMandatoryTest.java
@@ -1,0 +1,144 @@
+package com.kenshoo.pl.audit;
+
+import com.google.common.collect.ImmutableList;
+import com.kenshoo.jooq.DataTable;
+import com.kenshoo.jooq.DataTableUtils;
+import com.kenshoo.jooq.TestJooqConfig;
+import com.kenshoo.pl.audit.commands.CreateAuditedWithAncestorMandatoryCommand;
+import com.kenshoo.pl.entity.*;
+import com.kenshoo.pl.entity.audit.AuditRecord;
+import com.kenshoo.pl.entity.internal.audit.AncestorTable;
+import com.kenshoo.pl.entity.internal.audit.MainWithAncestorTable;
+import com.kenshoo.pl.entity.internal.audit.entitytypes.AuditedWithAncestorMandatoryType;
+import com.kenshoo.pl.entity.internal.audit.entitytypes.NotAuditedAncestorType;
+import org.jooq.DSLContext;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Objects;
+
+import static com.kenshoo.pl.entity.ChangeOperation.CREATE;
+import static com.kenshoo.pl.entity.matchers.audit.AuditRecordMatchers.*;
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+
+public class AuditForCreateOneLevelWithMandatoryTest {
+
+    private static final String NAME = "name";
+    private static final String DESC = "desc";
+    private static final long ANCESTOR_ID = 11L;
+    private static final String ANCESTOR_NAME = "ancestorName";
+    private static final String ANCESTOR_DESC = "ancestorDesc";
+
+    private static final List<DataTable> ALL_TABLES = ImmutableList.of(MainWithAncestorTable.INSTANCE,
+                                                                       AncestorTable.INSTANCE);
+
+    private PLContext plContext;
+    private InMemoryAuditRecordPublisher auditRecordPublisher;
+
+    private ChangeFlowConfig<AuditedWithAncestorMandatoryType> auditedWithAncestorMandatoryConfig;
+
+    private PersistenceLayer<AuditedWithAncestorMandatoryType> auditedWithAncestorMandatoryPL;
+
+    @Before
+    public void setUp() {
+        final DSLContext dslContext = TestJooqConfig.create();
+        auditRecordPublisher = new InMemoryAuditRecordPublisher();
+        plContext = new PLContext.Builder(dslContext)
+            .withFeaturePredicate(__ -> true)
+            .withAuditRecordPublisher(auditRecordPublisher)
+            .build();
+
+        auditedWithAncestorMandatoryConfig = flowConfig(AuditedWithAncestorMandatoryType.INSTANCE);
+
+        auditedWithAncestorMandatoryPL = persistenceLayer();
+
+        ALL_TABLES.forEach(table -> DataTableUtils.createTable(dslContext, table));
+
+        dslContext.insertInto(AncestorTable.INSTANCE)
+                  .set(AncestorTable.INSTANCE.id, ANCESTOR_ID)
+                  .set(AncestorTable.INSTANCE.name, ANCESTOR_NAME)
+                  .set(AncestorTable.INSTANCE.desc, ANCESTOR_DESC)
+                  .execute();
+    }
+
+    @After
+    public void tearDown() {
+        ALL_TABLES.forEach(table -> plContext.dslContext().dropTable(table).execute());
+    }
+
+    @Test
+    public void oneEntity_WithEntityLevelMandatoryFields_AndFieldsInCmd_ShouldCreateMandatoryFieldsAndFieldRecords() {
+        final CreateResult<AuditedWithAncestorMandatoryType, Identifier<AuditedWithAncestorMandatoryType>> createResult =
+            auditedWithAncestorMandatoryPL.create(singletonList(new CreateAuditedWithAncestorMandatoryCommand()
+                                                                    .with(AuditedWithAncestorMandatoryType.ANCESTOR_ID, ANCESTOR_ID)
+                                                                    .with(AuditedWithAncestorMandatoryType.NAME, NAME)
+                                                                    .with(AuditedWithAncestorMandatoryType.DESC, DESC)),
+                                                  auditedWithAncestorMandatoryConfig);
+        final long id = extractIdFromResult(createResult, AuditedWithAncestorMandatoryType.ID);
+
+        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+
+        assertThat("Incorrect number of published records",
+                   auditRecords, hasSize(1));
+        final AuditRecord<AuditedWithAncestorMandatoryType> auditRecord = typed(auditRecords.get(0));
+        //noinspection unchecked
+        assertThat(auditRecord, allOf(hasEntityType(AuditedWithAncestorMandatoryType.INSTANCE),
+                                      hasEntityId(String.valueOf(id)),
+                                      hasMandatoryFieldValue(NotAuditedAncestorType.NAME, ANCESTOR_NAME),
+                                      hasMandatoryFieldValue(NotAuditedAncestorType.DESC, ANCESTOR_DESC),
+                                      hasOperator(CREATE),
+                                      hasCreatedFieldRecord(AuditedWithAncestorMandatoryType.NAME, NAME),
+                                      hasCreatedFieldRecord(AuditedWithAncestorMandatoryType.DESC, DESC)));
+    }
+
+    @Test
+    public void oneEntity_WithEntityLevelMandatoryFields_AndNoFieldsInCmd_ShouldCreateMandatoryFieldsOnly() {
+        final CreateResult<AuditedWithAncestorMandatoryType, Identifier<AuditedWithAncestorMandatoryType>> createResult =
+            auditedWithAncestorMandatoryPL.create(singletonList(new CreateAuditedWithAncestorMandatoryCommand()
+                                                                    .with(AuditedWithAncestorMandatoryType.ANCESTOR_ID, ANCESTOR_ID)),
+                                                  auditedWithAncestorMandatoryConfig);
+        final long id = extractIdFromResult(createResult, AuditedWithAncestorMandatoryType.ID);
+
+        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+
+        assertThat("Incorrect number of published records",
+                   auditRecords, hasSize(1));
+        final AuditRecord<AuditedWithAncestorMandatoryType> auditRecord = typed(auditRecords.get(0));
+        assertThat(auditRecord, allOf(hasEntityType(AuditedWithAncestorMandatoryType.INSTANCE),
+                                      hasEntityId(String.valueOf(id)),
+                                      hasMandatoryFieldValue(NotAuditedAncestorType.NAME, ANCESTOR_NAME),
+                                      hasMandatoryFieldValue(NotAuditedAncestorType.DESC, ANCESTOR_DESC),
+                                      hasOperator(CREATE),
+                                      hasNoFieldRecords()));
+    }
+
+    private <E extends EntityType<E>> ChangeFlowConfig<E> flowConfig(final E entityType) {
+        return ChangeFlowConfigBuilderFactory.newInstance(plContext, entityType).build();
+    }
+
+    private <E extends EntityType<E>> PersistenceLayer<E> persistenceLayer() {
+        return new PersistenceLayer<>(plContext);
+    }
+
+    private <E extends EntityType<E>> long extractIdFromResult(final CreateResult<E, Identifier<E>> createResult,
+                                                               final EntityField<E, Long> idField) {
+        return createResult.getChangeResults().stream()
+                           .map(EntityChangeResult::getCommand)
+                           .map(CreateEntityCommand::getIdentifier)
+                           .filter(Objects::nonNull)
+                           .map(identifier -> identifier.get(idField))
+                           .findFirst()
+                           .orElseThrow(() -> new IllegalStateException("No ids returned by create operation"));
+    }
+
+    @SuppressWarnings("unchecked")
+    private <E extends EntityType<E>> AuditRecord<E> typed(final AuditRecord<?> auditRecord) {
+        return (AuditRecord<E>) auditRecord;
+    }
+}

--- a/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForDeleteOneLevelWithMandatoryTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForDeleteOneLevelWithMandatoryTest.java
@@ -18,8 +18,7 @@ import org.junit.Test;
 
 import java.util.List;
 
-import static com.kenshoo.pl.entity.ChangeOperation.DELETE;
-import static com.kenshoo.pl.entity.matchers.audit.AuditRecordMatchers.*;
+import static com.kenshoo.pl.entity.matchers.audit.AuditRecordMatchers.hasMandatoryFieldValue;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.Matchers.allOf;
@@ -36,6 +35,9 @@ public class AuditForDeleteOneLevelWithMandatoryTest {
     private static final long ANCESTOR_ID = 11L;
     private static final String ANCESTOR_NAME = "ancestorName";
     private static final String ANCESTOR_DESC = "ancestorDesc";
+
+    private static final EntityField<NotAuditedAncestorType, String> ANCESTOR_NAME_FIELD = NotAuditedAncestorType.NAME;
+    private static final EntityField<NotAuditedAncestorType, String> ANCESTOR_DESC_FIELD = NotAuditedAncestorType.DESC;
 
     private static final List<DataTable> ALL_TABLES = ImmutableList.of(MainWithAncestorTable.INSTANCE,
                                                                        AncestorTable.INSTANCE);
@@ -83,7 +85,7 @@ public class AuditForDeleteOneLevelWithMandatoryTest {
 
     @Test
     public void oneEntity_WithEntityLevelMandatoryFields_ShouldCreateRecordWithMandatoryFields() {
-        auditedWithAncestorMandatoryPL.delete(singletonList(new DeleteAuditedWithAncestorMandatoryCommand(ID)),
+        auditedWithAncestorMandatoryPL.delete(singletonList(deleteCommand()),
                                               auditedWithAncestorMandatoryConfig);
 
         final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
@@ -91,12 +93,12 @@ public class AuditForDeleteOneLevelWithMandatoryTest {
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
         final AuditRecord<AuditedWithAncestorMandatoryType> auditRecord = typed(auditRecords.get(0));
-        //noinspection unchecked
-        assertThat(auditRecord, allOf(hasEntityType(AuditedWithAncestorMandatoryType.INSTANCE),
-                                      hasEntityId(String.valueOf(ID)),
-                                      hasMandatoryFieldValue(NotAuditedAncestorType.NAME, ANCESTOR_NAME),
-                                      hasMandatoryFieldValue(NotAuditedAncestorType.DESC, ANCESTOR_DESC),
-                                      hasOperator(DELETE)));
+        assertThat(auditRecord, allOf(hasMandatoryFieldValue(ANCESTOR_NAME_FIELD, ANCESTOR_NAME),
+                                      hasMandatoryFieldValue(ANCESTOR_DESC_FIELD, ANCESTOR_DESC)));
+    }
+
+    private DeleteAuditedWithAncestorMandatoryCommand deleteCommand() {
+        return new DeleteAuditedWithAncestorMandatoryCommand(ID);
     }
 
     private <E extends EntityType<E>> ChangeFlowConfig<E> flowConfig(final E entityType) {

--- a/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForDeleteOneLevelWithMandatoryTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForDeleteOneLevelWithMandatoryTest.java
@@ -1,0 +1,114 @@
+package com.kenshoo.pl.audit;
+
+import com.google.common.collect.ImmutableList;
+import com.kenshoo.jooq.DataTable;
+import com.kenshoo.jooq.DataTableUtils;
+import com.kenshoo.jooq.TestJooqConfig;
+import com.kenshoo.pl.audit.commands.DeleteAuditedWithAncestorMandatoryCommand;
+import com.kenshoo.pl.entity.*;
+import com.kenshoo.pl.entity.audit.AuditRecord;
+import com.kenshoo.pl.entity.internal.audit.AncestorTable;
+import com.kenshoo.pl.entity.internal.audit.MainWithAncestorTable;
+import com.kenshoo.pl.entity.internal.audit.entitytypes.AuditedWithAncestorMandatoryType;
+import com.kenshoo.pl.entity.internal.audit.entitytypes.NotAuditedAncestorType;
+import org.jooq.DSLContext;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static com.kenshoo.pl.entity.ChangeOperation.DELETE;
+import static com.kenshoo.pl.entity.matchers.audit.AuditRecordMatchers.*;
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+
+public class AuditForDeleteOneLevelWithMandatoryTest {
+
+    private static final long ID = 1L;
+    private static final String NAME = "name";
+    private static final String DESC = "desc";
+    private static final String DESC2 = "desc2";
+
+    private static final long ANCESTOR_ID = 11L;
+    private static final String ANCESTOR_NAME = "ancestorName";
+    private static final String ANCESTOR_DESC = "ancestorDesc";
+
+    private static final List<DataTable> ALL_TABLES = ImmutableList.of(MainWithAncestorTable.INSTANCE,
+                                                                       AncestorTable.INSTANCE);
+    private PLContext plContext;
+    private InMemoryAuditRecordPublisher auditRecordPublisher;
+
+    private ChangeFlowConfig<AuditedWithAncestorMandatoryType> auditedWithAncestorMandatoryConfig;
+
+    private PersistenceLayer<AuditedWithAncestorMandatoryType> auditedWithAncestorMandatoryPL;
+
+    @Before
+    public void setUp() {
+        final DSLContext dslContext = TestJooqConfig.create();
+        auditRecordPublisher = new InMemoryAuditRecordPublisher();
+        plContext = new PLContext.Builder(dslContext)
+            .withFeaturePredicate(__ -> true)
+            .withAuditRecordPublisher(auditRecordPublisher)
+            .build();
+
+        auditedWithAncestorMandatoryConfig = flowConfig(AuditedWithAncestorMandatoryType.INSTANCE);
+
+        auditedWithAncestorMandatoryPL = persistenceLayer();
+
+        ALL_TABLES.forEach(table -> DataTableUtils.createTable(dslContext, table));
+
+        dslContext.insertInto(MainWithAncestorTable.INSTANCE)
+                  .set(MainWithAncestorTable.INSTANCE.id, ID)
+                  .set(MainWithAncestorTable.INSTANCE.ancestor_id, ANCESTOR_ID)
+                  .set(MainWithAncestorTable.INSTANCE.name, NAME)
+                  .set(MainWithAncestorTable.INSTANCE.desc, DESC)
+                  .set(MainWithAncestorTable.INSTANCE.desc2, DESC2)
+                  .execute();
+
+        dslContext.insertInto(AncestorTable.INSTANCE)
+                  .set(AncestorTable.INSTANCE.id, ANCESTOR_ID)
+                  .set(AncestorTable.INSTANCE.name, ANCESTOR_NAME)
+                  .set(AncestorTable.INSTANCE.desc, ANCESTOR_DESC)
+                  .execute();
+    }
+
+    @After
+    public void tearDown() {
+        ALL_TABLES.forEach(table -> plContext.dslContext().dropTable(table).execute());
+    }
+
+    @Test
+    public void oneEntity_WithEntityLevelMandatoryFields_ShouldCreateRecordWithMandatoryFields() {
+        auditedWithAncestorMandatoryPL.delete(singletonList(new DeleteAuditedWithAncestorMandatoryCommand(ID)),
+                                              auditedWithAncestorMandatoryConfig);
+
+        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+
+        assertThat("Incorrect number of published records",
+                   auditRecords, hasSize(1));
+        final AuditRecord<AuditedWithAncestorMandatoryType> auditRecord = typed(auditRecords.get(0));
+        //noinspection unchecked
+        assertThat(auditRecord, allOf(hasEntityType(AuditedWithAncestorMandatoryType.INSTANCE),
+                                      hasEntityId(String.valueOf(ID)),
+                                      hasMandatoryFieldValue(NotAuditedAncestorType.NAME, ANCESTOR_NAME),
+                                      hasMandatoryFieldValue(NotAuditedAncestorType.DESC, ANCESTOR_DESC),
+                                      hasOperator(DELETE)));
+    }
+
+    private <E extends EntityType<E>> ChangeFlowConfig<E> flowConfig(final E entityType) {
+        return ChangeFlowConfigBuilderFactory.newInstance(plContext, entityType).build();
+    }
+
+    private <E extends EntityType<E>> PersistenceLayer<E> persistenceLayer() {
+        return new PersistenceLayer<>(plContext);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <E extends EntityType<E>> AuditRecord<E> typed(final AuditRecord<?> auditRecord) {
+        return (AuditRecord<E>) auditRecord;
+    }
+}

--- a/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForUpdateOneLevelWithMandatoryTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForUpdateOneLevelWithMandatoryTest.java
@@ -1,0 +1,135 @@
+package com.kenshoo.pl.audit;
+
+import com.google.common.collect.ImmutableList;
+import com.kenshoo.jooq.DataTable;
+import com.kenshoo.jooq.DataTableUtils;
+import com.kenshoo.jooq.TestJooqConfig;
+import com.kenshoo.pl.audit.commands.UpdateAuditedWithAncestorMandatoryCommand;
+import com.kenshoo.pl.entity.*;
+import com.kenshoo.pl.entity.audit.AuditRecord;
+import com.kenshoo.pl.entity.internal.audit.AncestorTable;
+import com.kenshoo.pl.entity.internal.audit.MainWithAncestorTable;
+import com.kenshoo.pl.entity.internal.audit.entitytypes.AuditedWithAncestorMandatoryType;
+import com.kenshoo.pl.entity.internal.audit.entitytypes.NotAuditedAncestorType;
+import org.jooq.DSLContext;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static com.kenshoo.pl.entity.ChangeOperation.UPDATE;
+import static com.kenshoo.pl.entity.matchers.audit.AuditRecordMatchers.*;
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+
+public class AuditForUpdateOneLevelWithMandatoryTest {
+
+    private static final long ID = 1L;
+    private static final String NAME = "name";
+    private static final String DESC = "desc";
+    private static final String DESC2 = "desc2";
+
+    private static final long ANCESTOR_ID = 11L;
+    private static final String ANCESTOR_NAME = "ancestorName";
+    private static final String ANCESTOR_DESC = "ancestorDesc";
+
+    private static final List<DataTable> ALL_TABLES = ImmutableList.of(MainWithAncestorTable.INSTANCE,
+                                                                       AncestorTable.INSTANCE);
+    public static final String NEW_NAME = "newName";
+    public static final String NEW_DESC = "newDesc";
+    public static final String NEW_DESC2 = "newDesc2";
+
+    private PLContext plContext;
+    private InMemoryAuditRecordPublisher auditRecordPublisher;
+
+    private ChangeFlowConfig<AuditedWithAncestorMandatoryType> auditedWithAncestorMandatoryConfig;
+
+    private PersistenceLayer<AuditedWithAncestorMandatoryType> auditedWithAncestorMandatoryPL;
+
+    @Before
+    public void setUp() {
+        final DSLContext dslContext = TestJooqConfig.create();
+        auditRecordPublisher = new InMemoryAuditRecordPublisher();
+        plContext = new PLContext.Builder(dslContext)
+            .withFeaturePredicate(__ -> true)
+            .withAuditRecordPublisher(auditRecordPublisher)
+            .build();
+
+        auditedWithAncestorMandatoryConfig = flowConfig(AuditedWithAncestorMandatoryType.INSTANCE);
+
+        auditedWithAncestorMandatoryPL = persistenceLayer();
+
+        ALL_TABLES.forEach(table -> DataTableUtils.createTable(dslContext, table));
+
+        dslContext.insertInto(MainWithAncestorTable.INSTANCE)
+                  .set(MainWithAncestorTable.INSTANCE.id, ID)
+                  .set(MainWithAncestorTable.INSTANCE.ancestor_id, ANCESTOR_ID)
+                  .set(MainWithAncestorTable.INSTANCE.name, NAME)
+                  .set(MainWithAncestorTable.INSTANCE.desc, DESC)
+                  .set(MainWithAncestorTable.INSTANCE.desc2, DESC2)
+                  .execute();
+
+        dslContext.insertInto(AncestorTable.INSTANCE)
+                  .set(AncestorTable.INSTANCE.id, ANCESTOR_ID)
+                  .set(AncestorTable.INSTANCE.name, ANCESTOR_NAME)
+                  .set(AncestorTable.INSTANCE.desc, ANCESTOR_DESC)
+                  .execute();
+    }
+
+    @After
+    public void tearDown() {
+        ALL_TABLES.forEach(table -> plContext.dslContext().dropTable(table).execute());
+    }
+
+    @Test
+    public void oneEntity_WithEntityLevelMandatoryFields_AndAllFieldsChanged_ShouldCreateMandatoryFields_AndFieldRecordsForAll() {
+        auditedWithAncestorMandatoryPL.update(singletonList(new UpdateAuditedWithAncestorMandatoryCommand(ID)
+                                                                .with(AuditedWithAncestorMandatoryType.NAME, NEW_NAME)
+                                                                .with(AuditedWithAncestorMandatoryType.DESC, NEW_DESC)
+                                                                .with(AuditedWithAncestorMandatoryType.DESC2, NEW_DESC2)),
+                                              auditedWithAncestorMandatoryConfig);
+
+        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+
+        assertThat("Incorrect number of published records",
+                   auditRecords, hasSize(1));
+        final AuditRecord<AuditedWithAncestorMandatoryType> auditRecord = typed(auditRecords.get(0));
+        //noinspection unchecked
+        assertThat(auditRecord, allOf(hasEntityType(AuditedWithAncestorMandatoryType.INSTANCE),
+                                      hasEntityId(String.valueOf(ID)),
+                                      hasMandatoryFieldValue(NotAuditedAncestorType.NAME, ANCESTOR_NAME),
+                                      hasMandatoryFieldValue(NotAuditedAncestorType.DESC, ANCESTOR_DESC),
+                                      hasOperator(UPDATE),
+                                      hasChangedFieldRecord(AuditedWithAncestorMandatoryType.NAME, NAME, NEW_NAME),
+                                      hasChangedFieldRecord(AuditedWithAncestorMandatoryType.DESC, DESC, NEW_DESC),
+                                      hasChangedFieldRecord(AuditedWithAncestorMandatoryType.DESC2, DESC2, NEW_DESC2)));
+    }
+
+
+    @Test
+    public void auditedEntity_WithEntityLevelMandatoryFields_AndNoFieldsInCmd_ShouldReturnEmpty() {
+        auditedWithAncestorMandatoryPL.update(singletonList(new UpdateAuditedWithAncestorMandatoryCommand(ID)
+                                                                .with(AuditedWithAncestorMandatoryType.ANCESTOR_ID, ANCESTOR_ID)),
+                                              auditedWithAncestorMandatoryConfig);
+        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+
+        assertThat("There should not be any published audit records",
+                   auditRecords, is(empty()));
+    }
+
+    private <E extends EntityType<E>> ChangeFlowConfig<E> flowConfig(final E entityType) {
+        return ChangeFlowConfigBuilderFactory.newInstance(plContext, entityType).build();
+    }
+
+    private <E extends EntityType<E>> PersistenceLayer<E> persistenceLayer() {
+        return new PersistenceLayer<>(plContext);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <E extends EntityType<E>> AuditRecord<E> typed(final AuditRecord<?> auditRecord) {
+        return (AuditRecord<E>) auditRecord;
+    }
+}

--- a/integration-tests/src/test/java/com/kenshoo/pl/audit/commands/CreateAuditedWithAncestorMandatoryCommand.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/audit/commands/CreateAuditedWithAncestorMandatoryCommand.java
@@ -1,0 +1,13 @@
+package com.kenshoo.pl.audit.commands;
+
+import com.kenshoo.pl.entity.CreateEntityCommand;
+import com.kenshoo.pl.entity.EntityCommandExt;
+import com.kenshoo.pl.entity.internal.audit.entitytypes.AuditedWithAncestorMandatoryType;
+
+public class CreateAuditedWithAncestorMandatoryCommand extends CreateEntityCommand<AuditedWithAncestorMandatoryType>
+    implements EntityCommandExt<AuditedWithAncestorMandatoryType, CreateAuditedWithAncestorMandatoryCommand> {
+
+    public CreateAuditedWithAncestorMandatoryCommand() {
+        super(AuditedWithAncestorMandatoryType.INSTANCE);
+    }
+}

--- a/integration-tests/src/test/java/com/kenshoo/pl/audit/commands/DeleteAuditedWithAncestorMandatoryCommand.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/audit/commands/DeleteAuditedWithAncestorMandatoryCommand.java
@@ -1,0 +1,15 @@
+package com.kenshoo.pl.audit.commands;
+
+import com.kenshoo.pl.entity.DeleteEntityCommand;
+import com.kenshoo.pl.entity.EntityCommandExt;
+import com.kenshoo.pl.entity.Identifier;
+import com.kenshoo.pl.entity.SingleUniqueKeyValue;
+import com.kenshoo.pl.entity.internal.audit.entitytypes.AuditedWithAncestorMandatoryType;
+
+public class DeleteAuditedWithAncestorMandatoryCommand extends DeleteEntityCommand<AuditedWithAncestorMandatoryType, Identifier<AuditedWithAncestorMandatoryType>>
+    implements EntityCommandExt<AuditedWithAncestorMandatoryType, DeleteAuditedWithAncestorMandatoryCommand> {
+
+    public DeleteAuditedWithAncestorMandatoryCommand(final long id) {
+        super(AuditedWithAncestorMandatoryType.INSTANCE, new SingleUniqueKeyValue<>(AuditedWithAncestorMandatoryType.ID, id));
+    }
+}

--- a/integration-tests/src/test/java/com/kenshoo/pl/audit/commands/UpdateAuditedWithAncestorMandatoryCommand.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/audit/commands/UpdateAuditedWithAncestorMandatoryCommand.java
@@ -1,0 +1,15 @@
+package com.kenshoo.pl.audit.commands;
+
+import com.kenshoo.pl.entity.EntityCommandExt;
+import com.kenshoo.pl.entity.Identifier;
+import com.kenshoo.pl.entity.SingleUniqueKeyValue;
+import com.kenshoo.pl.entity.UpdateEntityCommand;
+import com.kenshoo.pl.entity.internal.audit.entitytypes.AuditedWithAncestorMandatoryType;
+
+public class UpdateAuditedWithAncestorMandatoryCommand extends UpdateEntityCommand<AuditedWithAncestorMandatoryType, Identifier<AuditedWithAncestorMandatoryType>>
+    implements EntityCommandExt<AuditedWithAncestorMandatoryType, UpdateAuditedWithAncestorMandatoryCommand> {
+
+    public UpdateAuditedWithAncestorMandatoryCommand(final long id) {
+        super(AuditedWithAncestorMandatoryType.INSTANCE, new SingleUniqueKeyValue<>(AuditedWithAncestorMandatoryType.ID, id));
+    }
+}

--- a/main/src/main/java/com/kenshoo/pl/entity/EntityFieldValue.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/EntityFieldValue.java
@@ -1,0 +1,29 @@
+package com.kenshoo.pl.entity;
+
+public class EntityFieldValue {
+    private final EntityField<?, ?> entityField;
+    private final Object value;
+
+    public EntityFieldValue(final EntityField<?, ?> entityField, final Object value) {
+        this.entityField = entityField;
+        this.value = value;
+    }
+
+    public EntityField<?, ?> getField() {
+        return entityField;
+    }
+
+    public Object getValue() {
+        return value;
+    }
+
+
+    public String getFieldName() {
+        return entityField.getEntityType().getName() + "." + entityField;
+    }
+
+    @Override
+    public String toString() {
+        return getFieldName() + "=" + value;
+    }
+}

--- a/main/src/main/java/com/kenshoo/pl/entity/audit/AuditRecord.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/audit/AuditRecord.java
@@ -1,31 +1,38 @@
 package com.kenshoo.pl.entity.audit;
 
 import com.kenshoo.pl.entity.ChangeOperation;
+import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.EntityType;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
 import java.util.Collection;
+import java.util.Map;
+import java.util.Map.Entry;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
 public class AuditRecord<E extends EntityType<E>> {
     private final E entityType;
     private final String entityId;
+    private final Map<? extends EntityField<?, ?>, ?> mandatoryFieldValues;
     private final ChangeOperation operator;
     private final Collection<? extends FieldAuditRecord<E>> fieldRecords;
     private final Collection<? extends AuditRecord<?>> childRecords;
 
     private AuditRecord(final E entityType,
                         final String entityId,
+                        final Map<? extends EntityField<?, ?>, ?> mandatoryFieldValues,
                         final ChangeOperation operator,
                         final Collection<? extends FieldAuditRecord<E>> fieldRecords,
                         final Collection<? extends AuditRecord<?>> childRecords) {
         this.entityType = requireNonNull(entityType, "entityType is required");
         this.entityId = requireNonNull(entityId, "entityId is required");
+        this.mandatoryFieldValues = mandatoryFieldValues;
         this.operator = requireNonNull(operator, "operator is required");
         this.fieldRecords = fieldRecords;
         this.childRecords = childRecords;
@@ -37,6 +44,10 @@ public class AuditRecord<E extends EntityType<E>> {
 
     public String getEntityId() {
         return entityId;
+    }
+
+    public Collection<? extends Entry<? extends EntityField<? ,?>, ?>> getMandatoryFieldValues() {
+        return mandatoryFieldValues.entrySet();
     }
 
     public ChangeOperation getOperator() {
@@ -75,6 +86,7 @@ public class AuditRecord<E extends EntityType<E>> {
         return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
             .append("entityType", entityType.getName())
             .append("entityId", entityId)
+            .append("mandatoryFieldValues", mandatoryFieldValues)
             .append("operator", operator)
             .append("fieldRecords", fieldRecords)
             .append("childRecords", childRecordsToString(maxDepth))
@@ -91,6 +103,7 @@ public class AuditRecord<E extends EntityType<E>> {
     public static class Builder<E extends EntityType<E>> {
         private E entityType;
         private String entityId;
+        private Map<? extends EntityField<?, ?>, ?> mandatoryFieldValues = emptyMap();
         private ChangeOperation operator;
         private Collection<? extends FieldAuditRecord<E>> fieldRecords = emptyList();
         private Collection<? extends AuditRecord<?>> childRecords = emptyList();
@@ -110,6 +123,11 @@ public class AuditRecord<E extends EntityType<E>> {
             return this;
         }
 
+        public Builder<E> withMandatoryFieldValues(final Map<? extends EntityField<?, ?>, ?> fieldValues) {
+            this.mandatoryFieldValues = fieldValues == null ? emptyMap() : fieldValues;
+            return this;
+        }
+
         public Builder<E> withFieldRecords(Collection<? extends FieldAuditRecord<E>> fieldRecords) {
             this.fieldRecords = fieldRecords == null ? emptyList() : fieldRecords;
             return this;
@@ -123,6 +141,7 @@ public class AuditRecord<E extends EntityType<E>> {
         public AuditRecord<E> build() {
             return new AuditRecord<>(entityType,
                                      entityId,
+                                     mandatoryFieldValues,
                                      operator,
                                      fieldRecords,
                                      childRecords);

--- a/main/src/main/java/com/kenshoo/pl/entity/audit/AuditRecord.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/audit/AuditRecord.java
@@ -1,32 +1,29 @@
 package com.kenshoo.pl.entity.audit;
 
 import com.kenshoo.pl.entity.ChangeOperation;
-import com.kenshoo.pl.entity.EntityField;
+import com.kenshoo.pl.entity.EntityFieldValue;
 import com.kenshoo.pl.entity.EntityType;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
 import java.util.Collection;
-import java.util.Map;
-import java.util.Map.Entry;
 
 import static java.util.Collections.emptyList;
-import static java.util.Collections.emptyMap;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
 public class AuditRecord<E extends EntityType<E>> {
     private final E entityType;
     private final String entityId;
-    private final Map<? extends EntityField<?, ?>, ?> mandatoryFieldValues;
+    private final Collection<? extends EntityFieldValue> mandatoryFieldValues;
     private final ChangeOperation operator;
     private final Collection<? extends FieldAuditRecord<E>> fieldRecords;
     private final Collection<? extends AuditRecord<?>> childRecords;
 
     private AuditRecord(final E entityType,
                         final String entityId,
-                        final Map<? extends EntityField<?, ?>, ?> mandatoryFieldValues,
+                        final Collection<? extends EntityFieldValue> mandatoryFieldValues,
                         final ChangeOperation operator,
                         final Collection<? extends FieldAuditRecord<E>> fieldRecords,
                         final Collection<? extends AuditRecord<?>> childRecords) {
@@ -46,8 +43,8 @@ public class AuditRecord<E extends EntityType<E>> {
         return entityId;
     }
 
-    public Collection<? extends Entry<? extends EntityField<? ,?>, ?>> getMandatoryFieldValues() {
-        return mandatoryFieldValues.entrySet();
+    public Collection<? extends EntityFieldValue> getMandatoryFieldValues() {
+        return mandatoryFieldValues;
     }
 
     public ChangeOperation getOperator() {
@@ -103,7 +100,7 @@ public class AuditRecord<E extends EntityType<E>> {
     public static class Builder<E extends EntityType<E>> {
         private E entityType;
         private String entityId;
-        private Map<? extends EntityField<?, ?>, ?> mandatoryFieldValues = emptyMap();
+        private Collection<? extends EntityFieldValue> mandatoryFieldValues = emptyList();
         private ChangeOperation operator;
         private Collection<? extends FieldAuditRecord<E>> fieldRecords = emptyList();
         private Collection<? extends AuditRecord<?>> childRecords = emptyList();
@@ -123,8 +120,8 @@ public class AuditRecord<E extends EntityType<E>> {
             return this;
         }
 
-        public Builder<E> withMandatoryFieldValues(final Map<? extends EntityField<?, ?>, ?> fieldValues) {
-            this.mandatoryFieldValues = fieldValues == null ? emptyMap() : fieldValues;
+        public Builder<E> withMandatoryFieldValues(final Collection<? extends EntityFieldValue> fieldValues) {
+            this.mandatoryFieldValues = fieldValues == null ? emptyList() : fieldValues;
             return this;
         }
 

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorForCreateTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorForCreateTest.java
@@ -6,7 +6,9 @@ import com.kenshoo.pl.entity.Entity;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.audit.AuditRecord;
 import com.kenshoo.pl.entity.internal.EntityIdExtractor;
+import com.kenshoo.pl.entity.internal.EntityImpl;
 import com.kenshoo.pl.entity.internal.audit.entitytypes.AuditedType;
+import com.kenshoo.pl.entity.internal.audit.entitytypes.NotAuditedAncestorType;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -33,6 +35,8 @@ public class AuditRecordGeneratorForCreateTest {
 
     private static final long ID = 1234;
     private static final String STRING_ID = String.valueOf(ID);
+    private static final String ANCESTOR_NAME = "ancestorName";
+    private static final String ANCESTOR_DESC = "ancestorDesc";
 
     @Mock
     private AuditedFieldSet<AuditedType> completeFieldSet;
@@ -64,7 +68,36 @@ public class AuditRecordGeneratorForCreateTest {
     }
 
     @Test
-    public void generate_WithIdAndOnChangeFieldsOnly_ShouldGenerateMandatoryDataAndFieldRecords() {
+    public void generate_WithMandatoryFieldsOnly_ShouldGenerateBasicDataAndMandatoryFields() {
+        final AuditedCommand cmd = new AuditedCommand(ID, CREATE);
+
+        final EntityImpl entity = new EntityImpl();
+        entity.set(NotAuditedAncestorType.NAME, ANCESTOR_NAME);
+        entity.set(NotAuditedAncestorType.DESC, ANCESTOR_DESC);
+
+        final AuditedFieldSet<AuditedType> expectedIntersectionFieldSet =
+            AuditedFieldSet.builder(AuditedType.ID)
+                           .withMandatoryFields(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC)
+                           .build();
+
+        when(completeFieldSet.intersectWith(eqStreamAsSet(emptySet()))).thenReturn(expectedIntersectionFieldSet);
+        //noinspection ResultOfMethodCallIgnored
+        doReturn(ImmutableSet.of(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC)).when(completeFieldSet).getMandatoryFields();
+        doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, entity);
+
+        final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
+            auditRecordGenerator.generate(cmd, entity, emptyList());
+
+        assertThat(actualOptionalAuditRecord,
+                   isPresentAnd(allOf(hasEntityType(AuditedType.INSTANCE),
+                                      hasEntityId(STRING_ID),
+                                      hasMandatoryFieldValue(NotAuditedAncestorType.NAME, ANCESTOR_NAME),
+                                      hasMandatoryFieldValue(NotAuditedAncestorType.DESC, ANCESTOR_DESC),
+                                      hasOperator(CREATE))));
+    }
+
+    @Test
+    public void generate_WithOnChangeFieldsOnly_ShouldGenerateBasicDataAndFieldRecords() {
         final AuditedCommand cmd = new AuditedCommand(ID, CREATE)
             .with(AuditedType.NAME, "name")
             .with(AuditedType.DESC, "desc");
@@ -92,7 +125,7 @@ public class AuditRecordGeneratorForCreateTest {
     }
 
     @Test
-    public void generate_WithIdAndChildRecordsOnly_ShouldGenerateMandatoryDataAndChildRecords() {
+    public void generate_WithChildRecordsOnly_ShouldGenerateBasicDataAndChildRecords() {
         final AuditedCommand cmd = new AuditedCommand(ID, CREATE);
 
         final Entity entity = Entity.EMPTY;
@@ -116,20 +149,18 @@ public class AuditRecordGeneratorForCreateTest {
     }
 
     @Test
-    public void generate_WithEverything_ShouldGenerateEverything() {
-        final AuditedCommand cmd = new AuditedCommand(ID, CREATE)
-            .with(AuditedType.NAME, "name")
-            .with(AuditedType.DESC, "desc");
-        final Set<? extends EntityField<AuditedType, ?>> cmdChangedFields = cmd.getChangedFields().collect(toSet());
+    public void generate_WithMandatoryFieldsAndChildRecordsOnly_ShouldGenerateMandatoryFieldsAndChildRecords() {
+        final AuditedCommand cmd = new AuditedCommand(ID, CREATE);
 
-        final Entity entity = Entity.EMPTY;
+        final EntityImpl entity = new EntityImpl();
+        entity.set(NotAuditedAncestorType.NAME, ANCESTOR_NAME);
+        entity.set(NotAuditedAncestorType.DESC, ANCESTOR_DESC);
 
-        final AuditedFieldSet<AuditedType> expectedIntersectionFieldSet =
-            AuditedFieldSet.builder(AuditedType.ID)
-                           .withOnChangeFields(ImmutableSet.of(AuditedType.NAME, AuditedType.DESC))
-                           .build();
+        final AuditedFieldSet<AuditedType> expectedIntersectionFieldSet = AuditedFieldSet.builder(AuditedType.ID).build();
 
-        when(completeFieldSet.intersectWith(eqStreamAsSet(cmdChangedFields))).thenReturn(expectedIntersectionFieldSet);
+        when(completeFieldSet.intersectWith(eqStreamAsSet(emptySet()))).thenReturn(expectedIntersectionFieldSet);
+        //noinspection ResultOfMethodCallIgnored
+        doReturn(ImmutableSet.of(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC)).when(completeFieldSet).getMandatoryFields();
         doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, entity);
 
         final List<AuditRecord<?>> childRecords = ImmutableList.of(mockChildRecord(), mockChildRecord());
@@ -139,9 +170,41 @@ public class AuditRecordGeneratorForCreateTest {
 
         //noinspection unchecked
         assertThat(actualOptionalAuditRecord,
-                   isPresentAnd(allOf(hasEntityType(AuditedType.INSTANCE),
-                                      hasEntityId(STRING_ID),
-                                      hasOperator(CREATE),
+                   isPresentAnd(allOf(hasMandatoryFieldValue(NotAuditedAncestorType.NAME, ANCESTOR_NAME),
+                                      hasMandatoryFieldValue(NotAuditedAncestorType.DESC, ANCESTOR_DESC),
+                                      hasSameChildRecord(childRecords.get(0)),
+                                      hasSameChildRecord(childRecords.get(1)))));
+    }
+
+    @Test
+    public void generate_WithEverything_ShouldGenerateEverything() {
+        final AuditedCommand cmd = new AuditedCommand(ID, CREATE)
+            .with(AuditedType.NAME, "name")
+            .with(AuditedType.DESC, "desc");
+        final Set<? extends EntityField<AuditedType, ?>> cmdChangedFields = cmd.getChangedFields().collect(toSet());
+
+        final EntityImpl entity = new EntityImpl();
+        entity.set(NotAuditedAncestorType.NAME, ANCESTOR_NAME);
+        entity.set(NotAuditedAncestorType.DESC, ANCESTOR_DESC);
+
+        final AuditedFieldSet<AuditedType> expectedIntersectionFieldSet =
+            AuditedFieldSet.builder(AuditedType.ID)
+                           .withOnChangeFields(ImmutableSet.of(AuditedType.NAME, AuditedType.DESC))
+                           .build();
+
+        when(completeFieldSet.intersectWith(eqStreamAsSet(cmdChangedFields))).thenReturn(expectedIntersectionFieldSet);
+        //noinspection ResultOfMethodCallIgnored
+        doReturn(ImmutableSet.of(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC)).when(completeFieldSet).getMandatoryFields();
+        doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, entity);
+
+        final List<AuditRecord<?>> childRecords = ImmutableList.of(mockChildRecord(), mockChildRecord());
+
+        final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
+            auditRecordGenerator.generate(cmd, entity, childRecords);
+
+        assertThat(actualOptionalAuditRecord,
+                   isPresentAnd(allOf(hasMandatoryFieldValue(NotAuditedAncestorType.NAME, ANCESTOR_NAME),
+                                      hasMandatoryFieldValue(NotAuditedAncestorType.DESC, ANCESTOR_DESC),
                                       hasCreatedFieldRecord(AuditedType.NAME, "name"),
                                       hasCreatedFieldRecord(AuditedType.DESC, "desc"),
                                       hasSameChildRecord(childRecords.get(0)),

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/entitytypes/NotAuditedAncestorType.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/entitytypes/NotAuditedAncestorType.java
@@ -1,10 +1,12 @@
 package com.kenshoo.pl.entity.internal.audit.entitytypes;
 
+import com.kenshoo.jooq.DataTable;
+import com.kenshoo.pl.entity.AbstractEntityType;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.annotation.Id;
 import com.kenshoo.pl.entity.internal.audit.AncestorTable;
 
-public class NotAuditedAncestorType extends AbstractType<NotAuditedAncestorType> {
+public class NotAuditedAncestorType extends AbstractEntityType<NotAuditedAncestorType> {
 
     public static final NotAuditedAncestorType INSTANCE = new NotAuditedAncestorType();
 
@@ -15,5 +17,10 @@ public class NotAuditedAncestorType extends AbstractType<NotAuditedAncestorType>
 
     private NotAuditedAncestorType() {
         super("NotAuditedAncestor");
+    }
+
+    @Override
+    public DataTable getPrimaryTable() {
+        return AncestorTable.INSTANCE;
     }
 }

--- a/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordMandatoryFieldValueMatcher.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordMandatoryFieldValueMatcher.java
@@ -23,8 +23,8 @@ class AuditRecordMandatoryFieldValueMatcher extends TypeSafeMatcher<AuditRecord<
             return false;
         }
         return actualRecord.getMandatoryFieldValues().stream()
-                           .filter(entry -> expectedField.equals(entry.getKey()))
-                           .anyMatch(entry -> expectedValue.equals(entry.getValue()));
+                           .filter(fieldValue -> expectedField.equals(fieldValue.getField()))
+                           .anyMatch(fieldValue -> expectedValue.equals(fieldValue.getValue()));
     }
 
     @Override

--- a/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordMandatoryFieldValueMatcher.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordMandatoryFieldValueMatcher.java
@@ -1,0 +1,35 @@
+package com.kenshoo.pl.entity.matchers.audit;
+
+import com.kenshoo.pl.entity.EntityField;
+import com.kenshoo.pl.entity.audit.AuditRecord;
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+
+import static java.util.Objects.requireNonNull;
+
+class AuditRecordMandatoryFieldValueMatcher extends TypeSafeMatcher<AuditRecord<?>> {
+
+    private final EntityField<?, ?> expectedField;
+    private final Object expectedValue;
+
+    AuditRecordMandatoryFieldValueMatcher(final EntityField<?, ?> expectedField, final Object expectedValue) {
+        this.expectedField = requireNonNull(expectedField, "expectedField is required");
+        this.expectedValue = requireNonNull(expectedValue, "expectedValue is required");
+    }
+
+    @Override
+    protected boolean matchesSafely(final AuditRecord<?> actualRecord) {
+        if (actualRecord == null) {
+            return false;
+        }
+        return actualRecord.getMandatoryFieldValues().stream()
+                           .filter(entry -> expectedField.equals(entry.getKey()))
+                           .anyMatch(entry -> expectedValue.equals(entry.getValue()));
+    }
+
+    @Override
+    public void describeTo(final Description description) {
+        description.appendValue("an AuditRecord with a mandatory field " + expectedField + " having the value: " + expectedValue);
+    }
+
+}

--- a/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordMatchers.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordMatchers.java
@@ -25,6 +25,10 @@ public class AuditRecordMatchers {
         return new AuditRecordMandatoryFieldValueMatcher(field, value);
     }
 
+    public static Matcher<AuditRecord<?>> hasNoMandatoryFieldValues() {
+        return new AuditRecordNoMandatoryFieldsMatcher();
+    }
+
     public static <E extends EntityType<E>> Matcher<AuditRecord<E>> hasCreatedFieldRecord(final EntityField<E, ?> field, final Object value) {
         return hasFieldRecord(new FieldAuditRecord<>(field, null, value));
     }

--- a/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordMatchers.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordMatchers.java
@@ -21,6 +21,10 @@ public class AuditRecordMatchers {
         return new AuditRecordOperatorMatcher(expectedOperator);
     }
 
+    public static Matcher<AuditRecord<?>> hasMandatoryFieldValue(final EntityField<?, ?> field, final Object value) {
+        return new AuditRecordMandatoryFieldValueMatcher(field, value);
+    }
+
     public static <E extends EntityType<E>> Matcher<AuditRecord<E>> hasCreatedFieldRecord(final EntityField<E, ?> field, final Object value) {
         return hasFieldRecord(new FieldAuditRecord<>(field, null, value));
     }

--- a/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordNoMandatoryFieldsMatcher.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordNoMandatoryFieldsMatcher.java
@@ -1,0 +1,18 @@
+package com.kenshoo.pl.entity.matchers.audit;
+
+import com.kenshoo.pl.entity.audit.AuditRecord;
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+
+public class AuditRecordNoMandatoryFieldsMatcher extends TypeSafeMatcher<AuditRecord<?>> {
+
+    @Override
+    protected boolean matchesSafely(AuditRecord<?> actualAuditRecord) {
+        return actualAuditRecord.getMandatoryFieldValues().isEmpty();
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("an AuditRecord with NO mandatory fields");
+    }
+}


### PR DESCRIPTION
This is the continuation of https://github.com/kenshoo/persistence-layer/pull/129 and https://github.com/kenshoo/persistence-layer/pull/144.
Modifying the `AuditRecordGenerator` to take the mandatory fields from the `AuditedFieldSet` and populate them in the `AuditRecord`.