### PR TITLE
Support in clause

### DIFF
--- a/integration-tests/src/test/java/com/kenshoo/pl/entity/EntitiesFetcherByPLConditionTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/entity/EntitiesFetcherByPLConditionTest.java
@@ -368,7 +368,7 @@ public class EntitiesFetcherByPLConditionTest {
 
         final List<Entity> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
                 ImmutableList.of(uniqueKey.createValue(1, 1), uniqueKey.createValue(2, 1)),
-                PLCondition.TrueCondition,
+                PLCondition.trueCondition(),
                 TestEntityType.TYPE, TestEntityType.FIELD1);
 
         final List<Entity> sortedEntities = entities.stream()
@@ -397,6 +397,70 @@ public class EntitiesFetcherByPLConditionTest {
         assertThat(sortedEntities.size(), is(1));
         assertThat(sortedEntities.get(0),
                 hasFieldValues(fieldValue(TestEntityType.ID, 2), fieldValue(TestEntityType.FIELD1, "Bravo")));
+    }
+
+    @Test
+    public void fetchByInConditionForStringFieldWhereTwoMatchesAndFieldOfConditionRequested() {
+        final List<Entity> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
+                TestEntityType.FIELD1.in("Alpha", "Bravo"),
+                TestEntityType.ID, TestEntityType.FIELD1);
+        assertThat("Incorrect number of entities fetched: ",
+                entities.size(), is(2));
+
+        assertThat(entities.get(0),
+                hasFieldValues(fieldValue(TestEntityType.ID, 1),
+                        fieldValue(TestEntityType.FIELD1, "Alpha")));
+
+        assertThat(entities.get(1),
+                hasFieldValues(fieldValue(TestEntityType.ID, 2),
+                        fieldValue(TestEntityType.FIELD1, "Bravo")));
+    }
+
+    @Test
+    public void fetchByInConditionForIntFieldWhereTwoMatchesAndFieldOfConditionRequested() {
+        final List<Entity> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
+                TestEntityType.TYPE.in(2, 3),
+                TestEntityType.ID, TestEntityType.FIELD1);
+        assertThat("Incorrect number of entities fetched: ",
+                entities.size(), is(2));
+
+        assertThat(entities.get(0),
+                hasFieldValues(fieldValue(TestEntityType.ID, 1),
+                        fieldValue(TestEntityType.FIELD1, "Charlie")));
+
+        assertThat(entities.get(1),
+                hasFieldValues(fieldValue(TestEntityType.ID, 3),
+                        fieldValue(TestEntityType.FIELD1, "Delta")));
+    }
+
+    @Test
+    public void fetchByNotInConditionForIntFieldWhereTwoMatchesAndFieldOfConditionRequested() {
+        final List<Entity> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
+                PLCondition.not(TestEntityType.TYPE.in(2, 3)),
+                TestEntityType.ID, TestEntityType.FIELD1);
+        assertThat("Incorrect number of entities fetched: ",
+                entities.size(), is(2));
+
+        assertThat(entities.get(0),
+                hasFieldValues(fieldValue(TestEntityType.ID, 1),
+                        fieldValue(TestEntityType.FIELD1, "Alpha")));
+
+        assertThat(entities.get(1),
+                hasFieldValues(fieldValue(TestEntityType.ID, 2),
+                        fieldValue(TestEntityType.FIELD1, "Bravo")));
+    }
+
+    @Test
+    public void fetchByInConditionForStringFieldWhereNotAllMatchesAndFieldOfConditionRequested() {
+        final List<Entity> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
+                TestEntityType.FIELD1.in("Alpha", "NotExist"),
+                TestEntityType.ID, TestEntityType.FIELD1);
+        assertThat("Incorrect number of entities fetched: ",
+                entities.size(), is(1));
+
+        assertThat(entities.get(0),
+                hasFieldValues(fieldValue(TestEntityType.ID, 1),
+                        fieldValue(TestEntityType.FIELD1, "Alpha")));
     }
 
     private static class TestTable extends AbstractDataTable<TestTable> {

--- a/integration-tests/src/test/java/com/kenshoo/pl/entity/PLContextSelectTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/entity/PLContextSelectTest.java
@@ -136,7 +136,7 @@ public class PLContextSelectTest {
 
         final List<Entity> entities = plContext.select(TestEntityType.ID, TestEntityType.FIELD1)
                 .from(TestEntityType.INSTANCE)
-                .where(PLCondition.TrueCondition)
+                .where(PLCondition.trueCondition())
                 .fetchByKeys(ImmutableList.of(uniqueKey.createValue(1)));
         assertThat("Incorrect number of entities fetched: ",
                 entities.size(), is(1));
@@ -152,7 +152,7 @@ public class PLContextSelectTest {
 
         final List<Entity> entities = plContext.select(TestEntityType.ID, TestEntityType.FIELD1)
                 .from(TestEntityType.INSTANCE)
-                .where(PLCondition.TrueCondition)
+                .where(PLCondition.trueCondition())
                 .fetchByKeys(ImmutableList.of(uniqueKey.createValue(1)));
         assertThat("Incorrect number of entities fetched: ",
                 entities.size(), is(2));
@@ -165,6 +165,56 @@ public class PLContextSelectTest {
                         fieldValue(TestEntityType.FIELD1, "Bravo")));
     }
 
+    @Test
+    public void selectFromSingleEntityInClause() {
+        final List<Entity> entities = plContext.select(TestEntityType.ID, TestEntityType.FIELD1)
+                .from(TestEntityType.INSTANCE)
+                .where(TestEntityType.FIELD1.in("Alpha", "Bravo"))
+                .fetch();
+        assertThat("Incorrect number of entities fetched: ",
+                entities.size(), is(2));
+
+        assertThat(entities.get(0),
+                hasFieldValues(fieldValue(TestEntityType.ID, 1),
+                        fieldValue(TestEntityType.FIELD1, "Alpha")));
+        assertThat(entities.get(1),
+                hasFieldValues(fieldValue(TestEntityType.ID, 2),
+                        fieldValue(TestEntityType.FIELD1, "Bravo")));
+    }
+
+    @Test
+    public void selectFromSingleEntityInAndEqClause() {
+        final List<Entity> entities = plContext.select(TestEntityType.ID, TestEntityType.FIELD1)
+                .from(TestEntityType.INSTANCE)
+                .where(TestEntityType.FIELD1.in("Alpha", "Bravo").and(TestEntityType.ID.eq(2)))
+                .fetch();
+        assertThat("Incorrect number of entities fetched: ",
+                entities.size(), is(1));
+
+        assertThat(entities.get(0),
+                hasFieldValues(fieldValue(TestEntityType.ID, 2),
+                        fieldValue(TestEntityType.FIELD1, "Bravo")));
+    }
+
+    @Test
+    public void selectFromChildAndParentInClause() {
+        final List<Entity> entities = plContext.select(TestEntityType.ID, TestEntityType.FIELD1, TestParentEntityType.FIELD1)
+                .from(TestEntityType.INSTANCE)
+                .where(TestEntityType.FIELD1.in("Alpha", "Bravo"))
+                .fetch();
+        assertThat("Incorrect number of entities fetched: ",
+                entities.size(), is(2));
+
+        assertThat(entities.get(0),
+                hasFieldValues(fieldValue(TestEntityType.ID, 1),
+                        fieldValue(TestEntityType.FIELD1, "Alpha"),
+                        fieldValue(TestParentEntityType.FIELD1, "ParentAlpha")));
+
+        assertThat(entities.get(1),
+                hasFieldValues(fieldValue(TestEntityType.ID, 2),
+                        fieldValue(TestEntityType.FIELD1, "Bravo"),
+                        fieldValue(TestParentEntityType.FIELD1, "ParentAlpha")));
+    }
 
     @Test(expected = IllegalArgumentException.class)
     public void selectWithoutFieldsShouldThrowException() {

--- a/main/src/main/java/com/kenshoo/pl/entity/EntityField.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/EntityField.java
@@ -3,6 +3,8 @@ package com.kenshoo.pl.entity;
 import org.jooq.Record;
 import org.jooq.TableField;
 
+import java.util.Arrays;
+
 public interface EntityField<E extends EntityType<E>, T> {
 
     EntityFieldDbAdapter<T> getDbAdapter();
@@ -29,5 +31,16 @@ public interface EntityField<E extends EntityType<E>, T> {
         @SuppressWarnings("unchecked")
         final TableField<Record, Object> tableField = (TableField<Record, Object>)getDbAdapter().getFirstTableField();
         return new PLCondition(tableField.eq(tableValue), this);
+    }
+
+    default PLCondition in(T ...values) {
+        if (isVirtual()) {
+            throw new UnsupportedOperationException("The in operation is unsupported for virtual fields");
+        }
+
+        final Object[] tableValues = Arrays.stream(values).map(value -> getDbAdapter().getFirstDbValue(value)).toArray(Object[]::new);
+        @SuppressWarnings("unchecked")
+        final TableField<Record, Object> tableField = (TableField<Record, Object>)getDbAdapter().getFirstTableField();
+        return new PLCondition(tableField.in(tableValues), this);
     }
 }

--- a/main/src/main/java/com/kenshoo/pl/entity/FluentEntitiesFetcher.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/FluentEntitiesFetcher.java
@@ -15,7 +15,7 @@ class FluentEntitiesFetcher implements FetchFromStep, FetchWhereStep, FetchFinal
     private final EntitiesFetcher entitiesFetcher;
     private final EntityField<?, ?>[] fieldsToFetch;
     private EntityType<?> entityType;
-    private PLCondition condition = PLCondition.TrueCondition;
+    private PLCondition condition = PLCondition.trueCondition();
 
 
     FluentEntitiesFetcher(final EntitiesFetcher entitiesFetcher,

--- a/main/src/main/java/com/kenshoo/pl/entity/PLCondition.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/PLCondition.java
@@ -15,8 +15,6 @@ import static java.util.Objects.requireNonNull;
 
 public class PLCondition {
 
-    public static PLCondition TrueCondition = new PLCondition(DSL.trueCondition());
-
     private final Condition jooqCondition;
     private final Set<? extends EntityField<?, ?>> fields;
 
@@ -53,6 +51,10 @@ public class PLCondition {
         requireNonNull(condition, "a condition must be provided");
         return new PLCondition(condition.jooqCondition.not(),
                                condition.fields);
+    }
+
+    public static PLCondition trueCondition() {
+        return  new PLCondition(DSL.trueCondition());
     }
 
     @Override


### PR DESCRIPTION
Support in clause
Example:

        final List<Entity> entities = plContext.select(TestEntityType.ID, TestEntityType.FIELD1)
                .from(TestEntityType.INSTANCE)
                .where(TestEntityType.FIELD1.in("Alpha", "Bravo"))
                .fetch();
