### PR TITLE
Add Triptional (three-state object)

### DIFF
--- a/main/src/main/java/com/kenshoo/pl/entity/TriState.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/TriState.java
@@ -1,0 +1,107 @@
+package com.kenshoo.pl.entity;
+
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static com.kenshoo.pl.entity.TriState.State.*;
+import static java.util.Objects.requireNonNull;
+import static java.util.function.Function.identity;
+
+public class TriState<T> {
+
+    enum State {
+        FILLED,
+        EMPTY,
+        ABSENT
+    }
+
+    private static final TriState<?> EMPTY_INSTANCE = new TriState<>(EMPTY);
+    private static final TriState<?> ABSENT_INSTANCE = new TriState<>(ABSENT);
+
+    private final T value;
+    private final State state;
+
+    private TriState(final State state) {
+        this(null, state);
+    }
+
+    private TriState(final T value) {
+        this(value,
+             value == null ? EMPTY : FILLED);
+    }
+
+    private TriState(final T value, final State state) {
+        this.value = value;
+        this.state = state;
+    }
+
+    public static <T> TriState<T> of(final T value) {
+        return new TriState<>(value);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> TriState<T> empty() {
+        return (TriState<T>)EMPTY_INSTANCE;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> TriState<T> absent() {
+        return (TriState<T>)ABSENT_INSTANCE;
+    }
+
+    public <U> TriState<U> map(final Function<? super T, ? extends U> mapper) {
+        return map(mapper, () -> null);
+    }
+
+    public <U> TriState<U> map(final Function<? super T, ? extends U> filledMapper,
+                               final Supplier<? extends U> emptySupplier) {
+        requireNonNull(filledMapper, "filledMapper is required");
+        requireNonNull(emptySupplier, "emptySupplier is required");
+
+        switch (state) {
+            case FILLED:
+                return of(filledMapper.apply(value));
+            case EMPTY:
+                return of(emptySupplier.get());
+            default:
+                return absent();
+        }
+    }
+
+    public Optional<T> asOptional() {
+        return mapToOptional(identity());
+    }
+
+    public <U> Optional<U> mapToOptional(final Function<? super T, ? extends U> mapper) {
+        return mapToOptional(mapper, () -> null);
+    }
+
+    public <U> Optional<U> mapToOptional(final Function<? super T, ? extends U> filledMapper,
+                                         final Supplier<? extends U> emptySupplier) {
+        switch (state) {
+            case FILLED:
+                return Optional.ofNullable(filledMapper.apply(value));
+            case EMPTY:
+                return Optional.ofNullable(emptySupplier.get());
+            default:
+                return Optional.empty();
+        }
+    }
+
+    public boolean isFilled() {
+        return state == FILLED;
+    }
+
+    public boolean isNotFilled() {
+        return !isFilled();
+    }
+
+    public boolean isEmpty() {
+        return state == EMPTY;
+    }
+
+    public boolean isAbsent() {
+        return state == ABSENT;
+    }
+}

--- a/main/src/main/java/com/kenshoo/pl/entity/Triptional.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/Triptional.java
@@ -4,66 +4,66 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import static com.kenshoo.pl.entity.TriState.State.*;
+import static com.kenshoo.pl.entity.Triptional.State.*;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
 
-public class TriState<T> {
+public class Triptional<T> {
 
     enum State {
         FILLED,
-        EMPTY,
+        NULL,
         ABSENT
     }
 
-    private static final TriState<?> EMPTY_INSTANCE = new TriState<>(EMPTY);
-    private static final TriState<?> ABSENT_INSTANCE = new TriState<>(ABSENT);
+    private static final Triptional<?> NULL_INSTANCE = new Triptional<>(NULL);
+    private static final Triptional<?> ABSENT_INSTANCE = new Triptional<>(ABSENT);
 
     private final T value;
     private final State state;
 
-    private TriState(final State state) {
+    private Triptional(final State state) {
         this(null, state);
     }
 
-    private TriState(final T value) {
+    private Triptional(final T value) {
         this(value,
-             value == null ? EMPTY : FILLED);
+             value == null ? NULL : FILLED);
     }
 
-    private TriState(final T value, final State state) {
+    private Triptional(final T value, final State state) {
         this.value = value;
         this.state = state;
     }
 
-    public static <T> TriState<T> of(final T value) {
-        return new TriState<>(value);
+    public static <T> Triptional<T> of(final T value) {
+        return new Triptional<>(value);
     }
 
     @SuppressWarnings("unchecked")
-    public static <T> TriState<T> empty() {
-        return (TriState<T>)EMPTY_INSTANCE;
+    public static <T> Triptional<T> nul() {
+        return (Triptional<T>) NULL_INSTANCE;
     }
 
     @SuppressWarnings("unchecked")
-    public static <T> TriState<T> absent() {
-        return (TriState<T>)ABSENT_INSTANCE;
+    public static <T> Triptional<T> absent() {
+        return (Triptional<T>)ABSENT_INSTANCE;
     }
 
-    public <U> TriState<U> map(final Function<? super T, ? extends U> mapper) {
+    public <U> Triptional<U> map(final Function<? super T, ? extends U> mapper) {
         return map(mapper, () -> null);
     }
 
-    public <U> TriState<U> map(final Function<? super T, ? extends U> filledMapper,
-                               final Supplier<? extends U> emptySupplier) {
+    public <U> Triptional<U> map(final Function<? super T, ? extends U> filledMapper,
+                                 final Supplier<? extends U> nullReplacer) {
         requireNonNull(filledMapper, "filledMapper is required");
-        requireNonNull(emptySupplier, "emptySupplier is required");
+        requireNonNull(nullReplacer, "nullReplacer is required");
 
         switch (state) {
             case FILLED:
                 return of(filledMapper.apply(value));
-            case EMPTY:
-                return of(emptySupplier.get());
+            case NULL:
+                return of(nullReplacer.get());
             default:
                 return absent();
         }
@@ -78,15 +78,23 @@ public class TriState<T> {
     }
 
     public <U> Optional<U> mapToOptional(final Function<? super T, ? extends U> filledMapper,
-                                         final Supplier<? extends U> emptySupplier) {
+                                         final Supplier<? extends U> nullReplacer) {
         switch (state) {
             case FILLED:
                 return Optional.ofNullable(filledMapper.apply(value));
-            case EMPTY:
-                return Optional.ofNullable(emptySupplier.get());
+            case NULL:
+                return Optional.ofNullable(nullReplacer.get());
             default:
                 return Optional.empty();
         }
+    }
+
+    public boolean isPresent() {
+        return !isAbsent();
+    }
+
+    public boolean isAbsent() {
+        return state == ABSENT;
     }
 
     public boolean isFilled() {
@@ -97,11 +105,7 @@ public class TriState<T> {
         return !isFilled();
     }
 
-    public boolean isEmpty() {
-        return state == EMPTY;
-    }
-
-    public boolean isAbsent() {
-        return state == ABSENT;
+    public boolean isNull() {
+        return state == NULL;
     }
 }

--- a/main/src/main/java/com/kenshoo/pl/entity/Triptional.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/Triptional.java
@@ -1,5 +1,9 @@
 package com.kenshoo.pl.entity;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -46,7 +50,14 @@ public class Triptional<T> {
 
     @SuppressWarnings("unchecked")
     public static <T> Triptional<T> absent() {
-        return (Triptional<T>)ABSENT_INSTANCE;
+        return (Triptional<T>) ABSENT_INSTANCE;
+    }
+
+    public T get() {
+        if (isAbsent()) {
+            throw new NoSuchElementException("No value present");
+        }
+        return value;
     }
 
     public <U> Triptional<U> map(final Function<? super T, ? extends U> mapper) {
@@ -99,5 +110,42 @@ public class Triptional<T> {
 
     public boolean isNull() {
         return state == NULL;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (!(obj instanceof Triptional)) {
+            return false;
+        }
+
+        final Triptional<?> other = (Triptional<?>) obj;
+        return new EqualsBuilder()
+            .append(state, other.state)
+            .append(value, other.value)
+            .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder()
+            .append(state)
+            .append(value)
+            .toHashCode();
+    }
+
+    @Override
+    public String toString() {
+        switch (state) {
+            case FILLED:
+                return String.format("Triptional[%s]", value);
+            case NULL:
+                return "Triptional.null";
+            default:
+                return "Triptional.absent";
+        }
     }
 }

--- a/main/src/main/java/com/kenshoo/pl/entity/Triptional.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/Triptional.java
@@ -6,7 +6,6 @@ import java.util.function.Supplier;
 
 import static com.kenshoo.pl.entity.Triptional.State.*;
 import static java.util.Objects.requireNonNull;
-import static java.util.function.Function.identity;
 
 public class Triptional<T> {
 
@@ -41,7 +40,7 @@ public class Triptional<T> {
     }
 
     @SuppressWarnings("unchecked")
-    public static <T> Triptional<T> nul() {
+    public static <T> Triptional<T> nullInstance() {
         return (Triptional<T>) NULL_INSTANCE;
     }
 
@@ -70,7 +69,7 @@ public class Triptional<T> {
     }
 
     public Optional<T> asOptional() {
-        return mapToOptional(identity());
+        return Optional.ofNullable(value);
     }
 
     public <U> Optional<U> mapToOptional(final Function<? super T, ? extends U> mapper) {
@@ -79,14 +78,7 @@ public class Triptional<T> {
 
     public <U> Optional<U> mapToOptional(final Function<? super T, ? extends U> filledMapper,
                                          final Supplier<? extends U> nullReplacer) {
-        switch (state) {
-            case FILLED:
-                return Optional.ofNullable(filledMapper.apply(value));
-            case NULL:
-                return Optional.ofNullable(nullReplacer.get());
-            default:
-                return Optional.empty();
-        }
+        return map(filledMapper, nullReplacer).asOptional();
     }
 
     public boolean isPresent() {

--- a/main/src/test/java/com/kenshoo/pl/entity/TriptionalTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/TriptionalTest.java
@@ -1,0 +1,255 @@
+package com.kenshoo.pl.entity;
+
+import org.junit.Test;
+
+import java.util.NoSuchElementException;
+
+import static com.github.npathai.hamcrestopt.OptionalMatchers.isEmpty;
+import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresentAndIs;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+public class TriptionalTest {
+
+    @Test
+    public void of_NotNull_ShouldBePresent() {
+        assertThat(Triptional.of(3).isPresent(), is(true));
+    }
+
+    @Test
+    public void of_NotNull_ShouldNotBeAbsent() {
+        assertThat(Triptional.of(3).isAbsent(), is(false));
+    }
+
+    @Test
+    public void of_NotNull_ShouldBeFilled() {
+        assertThat(Triptional.of(3).isFilled(), is(true));
+    }
+
+    @Test
+    public void of_NotNull_ShouldNotBeNotFilled() {
+        assertThat(Triptional.of(3).isNotFilled(), is(false));
+    }
+
+    @Test
+    public void of_NotNull_ShouldNotBeNull() {
+        assertThat(Triptional.of(3).isNull(), is(false));
+    }
+
+    @Test
+    public void of_NotNull_ShouldGetValue() {
+        assertThat(Triptional.of(3).get(), is(3));
+    }
+
+    @Test
+    public void of_Null_ShouldBePresent() {
+        assertThat(Triptional.of(null).isPresent(), is(true));
+    }
+
+    @Test
+    public void of_Null_ShouldNotBeAbsent() {
+        assertThat(Triptional.of(null).isAbsent(), is(false));
+    }
+
+    @Test
+    public void of_Null_ShouldNotBeFilled() {
+        assertThat(Triptional.of(null).isFilled(), is(false));
+    }
+
+    @Test
+    public void of_Null_ShouldBeNotFilled() {
+        assertThat(Triptional.of(null).isNotFilled(), is(true));
+    }
+
+    @Test
+    public void of_Null_ShouldBeNull() {
+        assertThat(Triptional.of(null).isNull(), is(true));
+    }
+
+    @Test
+    public void of_Null_ShouldGetValue() {
+        assertThat(Triptional.of(null).get(), nullValue());
+    }
+
+    @Test
+    public void nullInstance_ShouldBePresent() {
+        assertThat(Triptional.nullInstance().isPresent(), is(true));
+    }
+
+    @Test
+    public void nullInstance_ShouldNotBeAbsent() {
+        assertThat(Triptional.nullInstance().isAbsent(), is(false));
+    }
+
+    @Test
+    public void nullInstance_ShouldNotBeFilled() {
+        assertThat(Triptional.nullInstance().isFilled(), is(false));
+    }
+
+    @Test
+    public void nullInstance_ShouldBeNotFilled() {
+        assertThat(Triptional.nullInstance().isNotFilled(), is(true));
+    }
+
+    @Test
+    public void nullInstance_ShouldBeNull() {
+        assertThat(Triptional.nullInstance().isNull(), is(true));
+    }
+
+    @Test
+    public void nullInstance_ShouldGetValue() {
+        assertThat(Triptional.of(null).get(), nullValue());
+    }
+
+    @Test
+    public void absent_ShouldNotBePresent() {
+        assertThat(Triptional.absent().isPresent(), is(false));
+    }
+
+    @Test
+    public void absent_ShouldBeAbsent() {
+        assertThat(Triptional.absent().isAbsent(), is(true));
+    }
+
+    @Test
+    public void absent_ShouldNotBeFilled() {
+        assertThat(Triptional.absent().isFilled(), is(false));
+    }
+
+    @Test
+    public void absent_ShouldBeNotFilled() {
+        assertThat(Triptional.absent().isNotFilled(), is(true));
+    }
+
+    @Test
+    public void absent_ShouldNotBeNull() {
+        assertThat(Triptional.absent().isNull(), is(false));
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void absent_ShouldThrowExceptionOnGet() {
+        Triptional.absent().get();
+    }
+
+    @Test
+    public void mapOneArg_WhenFilled_ShouldReturnInstanceWithMappedValue() {
+        final Triptional<String> mappedObj = Triptional.of(2).map(String::valueOf);
+        assertThat(mappedObj.get(), is("2"));
+    }
+
+    @Test
+    public void mapOneArg_WhenNull_ShouldReturnNullInstance() {
+        final Triptional<String> mappedObj = Triptional.nullInstance().map(String::valueOf);
+        assertThat(mappedObj.isNull(), is(true));
+    }
+
+    @Test
+    public void mapOneArg_WhenAbsent_ShouldReturnAbsentInstance() {
+        final Triptional<String> mappedObj = Triptional.absent().map(String::valueOf);
+        assertThat(mappedObj.isAbsent(), is(true));
+    }
+
+    @Test
+    public void mapTwoArgs_WhenFilled_ShouldReturnInstanceWithValueFromMapper() {
+        final Triptional<String> mappedObj = Triptional.of(2)
+                                                       .map(String::valueOf, () -> "blabla");
+        assertThat(mappedObj.get(), is("2"));
+    }
+
+    @Test
+    public void mapTwoArgs_WhenNull_ShouldReturnInstanceWithValueFromSupplier() {
+        final Triptional<String> mappedObj = Triptional.nullInstance()
+                                                       .map(String::valueOf, () -> "blabla");
+        assertThat(mappedObj.get(), is("blabla"));
+    }
+
+
+    @Test
+    public void mapTwoArgs_WhenAbsent_ShouldReturnAbsentInstance() {
+        final Triptional<String> mappedObj = Triptional.absent()
+                                                       .map(String::valueOf, () -> "blabla");
+        assertThat(mappedObj.isAbsent(), is(true));
+    }
+
+    @Test
+    public void asOptional_WhenFilled_ShouldReturnPresentWithSameValue() {
+        assertThat(Triptional.of(2).asOptional(), isPresentAndIs(2));
+    }
+
+    @Test
+    public void asOptional_WhenNull_ShouldReturnEmpty() {
+        assertThat(Triptional.nullInstance().asOptional(), isEmpty());
+    }
+
+    @Test
+    public void asOptional_WhenAbsent_ShouldReturnEmpty() {
+        assertThat(Triptional.absent().asOptional(), isEmpty());
+    }
+
+    @Test
+    public void mapToOptionalOneArg_WhenFilled_ShouldReturnPresentWithMappedValue() {
+        assertThat(Triptional.of(2).mapToOptional(String::valueOf), isPresentAndIs("2"));
+    }
+
+    @Test
+    public void mapToOptionalOneArg_WhenNull_ShouldReturnEmpty() {
+        assertThat(Triptional.nullInstance().mapToOptional(String::valueOf), isEmpty());
+    }
+
+    @Test
+    public void mapToOptionalOneArg_WhenAbsent_ShouldReturnEmpty() {
+        assertThat(Triptional.absent().mapToOptional(String::valueOf), isEmpty());
+    }
+
+    @Test
+    public void mapToOptionalTwoArgs_WhenFilled_ShouldReturnPresentWithMappedValue() {
+        assertThat(Triptional.of(2)
+                             .mapToOptional(String::valueOf, () -> "bla"),
+                   isPresentAndIs("2"));
+    }
+
+    @Test
+    public void mapToOptionalTwoArgs_WhenNull_ShouldReturnPresentWithSupplierValue() {
+        assertThat(Triptional.nullInstance()
+                             .mapToOptional(String::valueOf, () -> "bla"),
+                   isPresentAndIs("bla"));
+    }
+
+    @Test
+    public void mapToOptionalTwoArgs_WhenAbsent_ShouldReturnEmpty() {
+        assertThat(Triptional.absent()
+                             .mapToOptional(String::valueOf, () -> "bla"),
+                   isEmpty());
+    }
+
+    @Test
+    public void equals_WhenBothFilledWithSameValue_ShouldReturnTrue() {
+        assertThat(Triptional.of(2).equals(Triptional.of(1 + 1)), is(true));
+    }
+
+    @Test
+    public void equals_WhenBothFilledWithDifferentValues_ShouldReturnFalse() {
+        assertThat(Triptional.of(2).equals(Triptional.of(3)), is(false));
+    }
+
+    @Test
+    public void equals_WhenOneFilledAndOneNull_ShouldReturnFalse() {
+        assertThat(Triptional.of(2).equals(Triptional.nullInstance()), is(false));
+    }
+
+    @Test
+    public void equals_WhenOneFilledAndOneAbsent_ShouldReturnFalse() {
+        assertThat(Triptional.of(2).equals(Triptional.absent()), is(false));
+    }
+
+    @Test
+    public void equals_WhenBothNull_ShouldReturnTrue() {
+        assertThat(Triptional.nullInstance().equals(Triptional.of(null)), is(true));
+    }
+
+    @Test
+    public void equals_WhenOneNullAndOneAbsent_ShouldReturnFalse() {
+        assertThat(Triptional.nullInstance().equals(Triptional.absent()), is(false));
+    }
+}


### PR DESCRIPTION
In the PL we have a notion of a three-state object that can be one of the following:
- Present with non-`null` value
- Present with `null` value
- Absent

This is used when considering a field of an entity in 2 cases:
- in `Entity` after being fetched from the DB, it can be either:
  - Fetched with a non-`null` value
  - Fetched with a `null` value
  - Not fetched

- In `EntityChange` (command) it can be either:
  - Changed in the command to a non-`null` value
  - Changed in the command to a `null` value
  - Not in the command (unchanged)

Currently we represent this by a `containsField()` method together with a `get()` method that can return `null` and that's not quite the approach for functional programming, and in general is not easy to use. 
We could handle this with additional methods or a wrapper "nullable" object for the value but that can be cumbersome. So instead I am adding a three-state object that will represent these cases.

Credit to @galkoren for the name :)