### PR TITLE
PL-84: Replace FieldAuditRecord ctor. with builder

### DIFF
--- a/main/src/main/java/com/kenshoo/pl/entity/audit/FieldAuditRecord.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/audit/FieldAuditRecord.java
@@ -7,6 +7,8 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
+import java.util.Optional;
+
 import static java.util.Objects.requireNonNull;
 
 public class FieldAuditRecord<E extends EntityType<E>> {
@@ -14,10 +16,10 @@ public class FieldAuditRecord<E extends EntityType<E>> {
     private final Object oldValue;
     private final Object newValue;
 
-    public FieldAuditRecord(final EntityField<E, ?> field,
-                            final Object oldValue,
-                            final Object newValue) {
-        this.field = requireNonNull(field, "A field is required");
+    private FieldAuditRecord(final EntityField<E, ?> field,
+                             final Object oldValue,
+                             final Object newValue) {
+        this.field = field;
         this.oldValue = oldValue;
         this.newValue = newValue;
     }
@@ -26,12 +28,16 @@ public class FieldAuditRecord<E extends EntityType<E>> {
         return field;
     }
 
-    public Object getOldValue() {
-        return oldValue;
+    public Optional<?> getOldValue() {
+        return Optional.ofNullable(oldValue);
     }
 
-    public Object getNewValue() {
-        return newValue;
+    public Optional<?> getNewValue() {
+        return Optional.ofNullable(newValue);
+    }
+
+    public static <E extends EntityType<E>> Builder<E> builder(final EntityField<E, ?> field) {
+        return new Builder<>(field);
     }
 
     @Override
@@ -66,5 +72,29 @@ public class FieldAuditRecord<E extends EntityType<E>> {
             .append("oldValue", oldValue)
             .append("newValue", newValue)
             .toString();
+    }
+
+    public static class Builder<E extends EntityType<E>> {
+        private final EntityField<E, ?> field;
+        private Object oldValue;
+        private Object newValue;
+
+        private Builder(final EntityField<E, ?> field) {
+            this.field = requireNonNull(field, "A field is required");
+        }
+
+        public Builder<E> oldValue(Object oldValue) {
+            this.oldValue = oldValue;
+            return this;
+        }
+
+        public Builder<E> newValue(Object newValue) {
+            this.newValue = newValue;
+            return this;
+        }
+
+        public FieldAuditRecord<E> build() {
+            return new FieldAuditRecord<>(field, oldValue, newValue);
+        }
     }
 }

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGenerator.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGenerator.java
@@ -86,16 +86,17 @@ public class AuditRecordGenerator<E extends EntityType<E>> implements CurrentSta
                                                                            final Collection<? extends EntityField<E, ?>> candidateOnChangeFields) {
         return candidateOnChangeFields.stream()
                                       .filter(field -> fieldWasChanged(entityChange, entity, field))
-                                      .map(field -> buildFieldChangeRecord(entityChange, entity, field))
+                                      .map(field -> buildFieldRecord(entityChange, entity, field))
                                       .collect(toList());
     }
 
-    private FieldAuditRecord<E> buildFieldChangeRecord(final EntityChange<E> entityChange,
-                                                       final Entity entity,
-                                                       final EntityField<E, ?> field) {
-        return new FieldAuditRecord<>(field,
-                                      entity.getOptional(field).orElse(null),
-                                      entityChange.get(field));
+    private FieldAuditRecord<E> buildFieldRecord(final EntityChange<E> entityChange,
+                                                 final Entity entity,
+                                                 final EntityField<E, ?> field) {
+        final FieldAuditRecord.Builder<E> fieldRecordBuilder = FieldAuditRecord.builder(field);
+        entity.getOptional(field).ifPresent(fieldRecordBuilder::oldValue);
+        return fieldRecordBuilder.newValue(entityChange.get(field))
+                                 .build();
     }
 
     private String extractEntityId(final EntityChange<E> entityChange,

--- a/main/src/test/java/com/kenshoo/pl/entity/AuditRecordTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/AuditRecordTest.java
@@ -19,7 +19,9 @@ public class AuditRecordTest {
     private static final String ENTITY_ID_2 = "456";
 
     private static final FieldAuditRecord<AuditedType> NAME_FIELD_RECORD =
-        new FieldAuditRecord<>(AuditedType.NAME, null, "name");
+        FieldAuditRecord.builder(AuditedType.NAME)
+                        .newValue("name")
+                        .build();
 
     @Mock
     private AuditRecord<?> childRecord;

--- a/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordMatchers.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordMatchers.java
@@ -31,17 +31,24 @@ public class AuditRecordMatchers {
     }
 
     public static <E extends EntityType<E>> Matcher<AuditRecord<E>> hasCreatedFieldRecord(final EntityField<E, ?> field, final Object value) {
-        return hasFieldRecord(new FieldAuditRecord<>(field, null, value));
+        return hasFieldRecord(FieldAuditRecord.builder(field)
+                                              .newValue(value)
+                                              .build());
     }
 
     public static <E extends EntityType<E>> Matcher<AuditRecord<E>> hasChangedFieldRecord(final EntityField<E, ?> field,
                                                                                           final String oldValue,
                                                                                           final String newValue) {
-        return hasFieldRecord(new FieldAuditRecord<>(field, oldValue, newValue));
+        return hasFieldRecord(FieldAuditRecord.builder(field)
+                                              .oldValue(oldValue)
+                                              .newValue(newValue)
+                                              .build());
     }
 
     public static <E extends EntityType<E>> Matcher<AuditRecord<E>> hasDeletedFieldRecord(final EntityField<E, ?> field, final Object value) {
-        return hasFieldRecord(new FieldAuditRecord<>(field, value, null));
+        return hasFieldRecord(FieldAuditRecord.builder(field)
+                                              .oldValue(value)
+                                              .build());
     }
 
     public static <E extends EntityType<E>> Matcher<AuditRecord<E>> hasFieldRecordFor(final EntityField<E, ?> expectedField) {


### PR DESCRIPTION
Replacing ctor. with builder so that only one of the values can be passed and we don't need to pass any `null`s