### PR TITLE
PL-80: Add FieldsValueMap.safeGet() returning Triptional

### DIFF
--- a/main/src/main/java/com/kenshoo/pl/entity/FieldsValueMap.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/FieldsValueMap.java
@@ -19,4 +19,16 @@ public interface FieldsValueMap<E extends EntityType<E>> {
      * @throws RuntimeException if the field is not present in the map
      */
     <T> T get(EntityField<E, T> field);
+
+    /**
+     * @param field field whose value should be fetched
+     * @param <T> the type of the value in the field
+     * @return the field value if not-<code>null</code>; or <code>Triptional.nullInstance()</code> if <code>null</code>; or <code>Triptional.absent()</code> if the field doesn't exist
+     */
+    default <T> Triptional<T> safeGet(final EntityField<E, T> field) {
+        if (containsField(field)) {
+            return Triptional.of(get(field));
+        }
+        return Triptional.absent();
+    }
 }

--- a/main/src/main/java/com/kenshoo/pl/entity/Triptional.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/Triptional.java
@@ -85,6 +85,25 @@ public class Triptional<T> {
         }
     }
 
+    public <U> Triptional<U> flatMap(final Function<? super T, Triptional<U>> mapper) {
+        return flatMap(mapper, Triptional::nullInstance);
+    }
+
+    public <U> Triptional<U> flatMap(final Function<? super T, Triptional<U>> filledMapper,
+                                     final Supplier<Triptional<U>> nullReplacer) {
+        requireNonNull(filledMapper, "filledMapper is required");
+        requireNonNull(nullReplacer, "nullReplacer is required");
+
+        switch (state) {
+            case FILLED:
+                return requireNonNull(filledMapper.apply(value));
+            case NULL:
+                return requireNonNull(nullReplacer.get());
+            default:
+                return absent();
+        }
+    }
+
     public Optional<T> asOptional() {
         return Optional.ofNullable(value);
     }

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGenerator.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGenerator.java
@@ -95,8 +95,8 @@ public class AuditRecordGenerator<E extends EntityType<E>> implements CurrentSta
                                                  final EntityField<E, ?> field) {
         final FieldAuditRecord.Builder<E> fieldRecordBuilder = FieldAuditRecord.builder(field);
         entity.safeGet(field).ifFilled(fieldRecordBuilder::oldValue);
-        return fieldRecordBuilder.newValue(entityChange.get(field))
-                                 .build();
+        entityChange.safeGet(field).ifFilled(fieldRecordBuilder::newValue);
+        return fieldRecordBuilder.build();
     }
 
     private String extractEntityId(final EntityChange<E> entityChange,

--- a/main/src/test/java/com/kenshoo/pl/entity/FieldsValueMapTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/FieldsValueMapTest.java
@@ -1,0 +1,62 @@
+package com.kenshoo.pl.entity;
+
+import org.junit.Test;
+import org.mockito.Mock;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class FieldsValueMapTest {
+
+    private static final String DUMMY_VALUE = "abc";
+
+    @SuppressWarnings("unchecked")
+    @Mock
+    final EntityField<TestEntity, String> mockField = mock(EntityField.class);
+
+    @Test
+    public void safeGet_WhenNotNull_ShouldReturnIt() {
+
+        assertThat(new StubFieldsValueMap<TestEntity>(true, DUMMY_VALUE).safeGet(mockField),
+                   is(Triptional.of(DUMMY_VALUE)));
+    }
+
+    @Test
+    public void safeGet_WhenPresentAndNull_ShouldReturnNull() {
+        assertThat(new StubFieldsValueMap<TestEntity>(true).safeGet(mockField),
+                   is(Triptional.nullInstance()));
+    }
+
+    @Test
+    public void safeGet_WhenDoesntExist_ShouldReturnAbsent() {
+        assertThat(new StubFieldsValueMap<TestEntity>(false).safeGet(mockField),
+                   is(Triptional.absent()));
+    }
+
+    private static final class StubFieldsValueMap<E extends EntityType<E>> implements FieldsValueMap<E> {
+
+        private final boolean fieldPresent;
+        private final Object value;
+
+        private StubFieldsValueMap(final boolean fieldPresent) {
+            this(fieldPresent, null);
+        }
+
+        private StubFieldsValueMap(final boolean fieldPresent, final Object value) {
+            this.fieldPresent = fieldPresent;
+            this.value = value;
+        }
+
+        @Override
+        public <T> boolean containsField(final EntityField<E, T> field) {
+            return fieldPresent;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public <T> T get(final EntityField<E, T> field) {
+            return (T)value;
+        }
+    }
+}

--- a/main/src/test/java/com/kenshoo/pl/entity/FieldsValueMapTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/FieldsValueMapTest.java
@@ -10,6 +10,8 @@ import static org.mockito.Mockito.mock;
 public class FieldsValueMapTest {
 
     private static final String DUMMY_VALUE = "abc";
+    private static final boolean PRESENT = true;
+    private static final boolean ABSENT = false;
 
     @SuppressWarnings("unchecked")
     @Mock
@@ -18,19 +20,19 @@ public class FieldsValueMapTest {
     @Test
     public void safeGet_WhenNotNull_ShouldReturnIt() {
 
-        assertThat(new StubFieldsValueMap<TestEntity>(true, DUMMY_VALUE).safeGet(mockField),
+        assertThat(new StubFieldsValueMap<TestEntity>(PRESENT, DUMMY_VALUE).safeGet(mockField),
                    is(Triptional.of(DUMMY_VALUE)));
     }
 
     @Test
     public void safeGet_WhenPresentAndNull_ShouldReturnNull() {
-        assertThat(new StubFieldsValueMap<TestEntity>(true).safeGet(mockField),
+        assertThat(new StubFieldsValueMap<TestEntity>(PRESENT).safeGet(mockField),
                    is(Triptional.nullInstance()));
     }
 
     @Test
     public void safeGet_WhenDoesntExist_ShouldReturnAbsent() {
-        assertThat(new StubFieldsValueMap<TestEntity>(false).safeGet(mockField),
+        assertThat(new StubFieldsValueMap<TestEntity>(ABSENT).safeGet(mockField),
                    is(Triptional.absent()));
     }
 

--- a/main/src/test/java/com/kenshoo/pl/entity/TriptionalTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/TriptionalTest.java
@@ -183,7 +183,7 @@ public class TriptionalTest {
     }
 
     @Test
-    public void mapTwoArgs_WhenNull_ShouldReturnInstanceWithValueFromSupplier() {
+    public void mapTwoArgs_WhenNull_ShouldReturnInstanceWithReplacingValue() {
         final Triptional<String> mappedObj = Triptional.nullInstance()
                                                        .map(String::valueOf, () -> "blabla");
         assertThat(mappedObj.get(), is("blabla"));
@@ -194,6 +194,85 @@ public class TriptionalTest {
     public void mapTwoArgs_WhenAbsent_ShouldReturnAbsentInstance() {
         final Triptional<String> mappedObj = Triptional.absent()
                                                        .map(String::valueOf, () -> "blabla");
+        assertThat(mappedObj.isAbsent(), is(true));
+    }
+
+    @Test
+    public void flatMapOneArg_WhenFilled_AndMappedToFilled_ShouldReturnFilledWithNewValue() {
+        final Triptional<String> mappedObj = Triptional.of(2).flatMap(this::toTriptionalString);
+        assertThat(mappedObj.get(), is("2"));
+    }
+
+    @Test
+    public void flatMapOneArg_WhenFilled_AndMappedToNullInstance_ShouldReturnNullInstance() {
+        final Triptional<String> mappedObj = Triptional.of(2).flatMap(any -> Triptional.nullInstance());
+        assertThat(mappedObj.isNull(), is(true));
+    }
+
+    @Test
+    public void flatMapOneArg_WhenFilled_AndMappedToAbsent_ShouldReturnAbsent() {
+        final Triptional<String> mappedObj = Triptional.of(2).flatMap(any -> Triptional.absent());
+        assertThat(mappedObj.isAbsent(), is(true));
+    }
+
+    @Test
+    public void flatMapOneArg_WhenNull_ShouldReturnNullInstance() {
+        final Triptional<String> mappedObj = Triptional.nullInstance().flatMap(this::toTriptionalString);
+        assertThat(mappedObj.isNull(), is(true));
+    }
+
+    @Test
+    public void flatMapOneArg_WhenAbsent_ShouldReturnAbsentInstance() {
+        final Triptional<String> mappedObj = Triptional.absent().flatMap(this::toTriptionalString);
+        assertThat(mappedObj.isAbsent(), is(true));
+    }
+
+    @Test
+    public void flatMapTwoArgs_WhenFilled_AndMappedToFilled_ShouldReturnFilledWithMappedValue() {
+        final Triptional<String> mappedObj = Triptional.of(2).flatMap(this::toTriptionalString,
+                                                                      () -> Triptional.of("blabla"));
+        assertThat(mappedObj.get(), is("2"));
+    }
+
+    @Test
+    public void flatMapTwoArgs_WhenFilled_AndMappedToNullInstance_ShouldReturnNullInstance() {
+        final Triptional<String> mappedObj = Triptional.of(2).flatMap(any -> Triptional.nullInstance(),
+                                                                      () -> Triptional.of("blabla"));
+        assertThat(mappedObj.isNull(), is(true));
+    }
+
+    @Test
+    public void flatMapTwoArgs_WhenFilled_AndMappedToAbsent_ShouldReturnAbsent() {
+        final Triptional<String> mappedObj = Triptional.of(2).flatMap(any -> Triptional.absent(),
+                                                                      () -> Triptional.of("blabla"));
+        assertThat(mappedObj.isAbsent(), is(true));
+    }
+
+    @Test
+    public void flatMapTwoArgs_WhenNull_AndReplacerReturnsFilled_ShouldReturnReplacingInstance() {
+        final Triptional<String> mappedObj = Triptional.nullInstance().flatMap(this::toTriptionalString,
+                                                                               () -> Triptional.of("blabla"));
+        assertThat(mappedObj.get(), is("blabla"));
+    }
+
+    @Test
+    public void flatMapTwoArgs_WhenNull_AndReplacerReturnsNull_ShouldReturnNullInstance() {
+        final Triptional<String> mappedObj = Triptional.nullInstance().flatMap(this::toTriptionalString,
+                                                                               Triptional::nullInstance);
+        assertThat(mappedObj.isNull(), is(true));
+    }
+
+    @Test
+    public void flatMapTwoArgs_WhenNull_AndReplacerReturnsAbsent_ShouldReturnAbsent() {
+        final Triptional<String> mappedObj = Triptional.nullInstance().flatMap(this::toTriptionalString,
+                                                                               Triptional::absent);
+        assertThat(mappedObj.isAbsent(), is(true));
+    }
+
+    @Test
+    public void flatMapTwoArgs_WhenAbsent_ShouldReturnAbsent() {
+        final Triptional<String> mappedObj = Triptional.absent().flatMap(this::toTriptionalString,
+                                                                         () -> Triptional.of("blabla"));
         assertThat(mappedObj.isAbsent(), is(true));
     }
 
@@ -235,7 +314,7 @@ public class TriptionalTest {
     }
 
     @Test
-    public void mapToOptionalTwoArgs_WhenNull_ShouldReturnPresentWithSupplierValue() {
+    public void mapToOptionalTwoArgs_WhenNull_ShouldReturnPresentWithReplacingValue() {
         assertThat(Triptional.nullInstance()
                              .mapToOptional(String::valueOf, () -> "bla"),
                    isPresentAndIs("bla"));
@@ -276,5 +355,9 @@ public class TriptionalTest {
     @Test
     public void equals_WhenOneNullAndOneAbsent_ShouldReturnFalse() {
         assertThat(Triptional.nullInstance().equals(Triptional.absent()), is(false));
+    }
+
+    private Triptional<String> toTriptionalString(final Object val) {
+        return Triptional.of(String.valueOf(val));
     }
 }


### PR DESCRIPTION
See #154 - the same here, applied to `FieldsValueMap`.
Using it to simplify code in `EntityIdExtractor` (especially) and also `AuditRecordGenerator`