### PR TITLE
PL-87: Extract Triptionals.firstFilled() from EntityIdExtractor

### DIFF
--- a/main/src/main/java/com/kenshoo/pl/entity/internal/EntityIdExtractor.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/EntityIdExtractor.java
@@ -1,11 +1,10 @@
 package com.kenshoo.pl.entity.internal;
 
 import com.kenshoo.pl.entity.*;
-import org.jooq.lambda.Seq;
 
 import java.util.Optional;
-import java.util.function.Supplier;
 
+import static com.kenshoo.pl.entity.internal.Triptionals.firstFilled;
 import static java.util.Objects.requireNonNull;
 
 public class EntityIdExtractor {
@@ -22,20 +21,18 @@ public class EntityIdExtractor {
                            .flatMap(idField -> extract(entityChange, entity, idField));
     }
 
-    private <E extends EntityType<E>> Optional<String> extract(final EntityChange<E> entityChange,
-                                                               final Entity entity,
-                                                               final EntityField<E, ?> idField) {
+    private <E extends EntityType<E>, T> Optional<String> extract(final EntityChange<E> entityChange,
+                                                                  final Entity entity,
+                                                                  final EntityField<E, T> idField) {
 
-        return Seq.<Supplier<Triptional<?>>>of(() -> entityChange.safeGet(idField),
-                                               () -> extractFromIdentifier(entityChange, idField),
-                                               () -> entity.safeGet(idField))
-            .map(Supplier::get)
-            .findFirst(Triptional::isFilled)
-            .flatMap(triptionalId -> triptionalId.mapToOptional(String::valueOf));
+        return firstFilled(() -> entityChange.safeGet(idField),
+                           () -> extractFromIdentifier(entityChange, idField),
+                           () -> entity.safeGet(idField))
+            .mapToOptional(String::valueOf);
     }
 
-    private <E extends EntityType<E>> Triptional<?> extractFromIdentifier(final EntityChange<E> entityChange,
-                                                                          final EntityField<E, ?> idField) {
+    private <E extends EntityType<E>, T> Triptional<T> extractFromIdentifier(final EntityChange<E> entityChange,
+                                                                             final EntityField<E, T> idField) {
         return Triptional.of(entityChange.getIdentifier())
                          .flatMap(identifier -> identifier.safeGet(idField));
     }

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/Triptionals.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/Triptionals.java
@@ -1,0 +1,23 @@
+package com.kenshoo.pl.entity.internal;
+
+import com.kenshoo.pl.entity.Triptional;
+
+import java.util.Arrays;
+import java.util.function.Supplier;
+
+import static org.jooq.lambda.Seq.seq;
+
+public final class Triptionals {
+
+    @SafeVarargs
+    public static <T> Triptional<T> firstFilled(final Supplier<Triptional<T>>... suppliers) {
+        return seq(Arrays.stream(suppliers))
+                     .map(Supplier::get)
+                     .findFirst(Triptional::isFilled)
+                     .orElse(Triptional.absent());
+    }
+
+    private Triptionals() {
+        // singleton
+    }
+}

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/TriptionalsTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/TriptionalsTest.java
@@ -1,0 +1,116 @@
+package com.kenshoo.pl.entity.internal;
+
+import com.kenshoo.pl.entity.Triptional;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.function.Supplier;
+
+import static com.kenshoo.pl.entity.internal.Triptionals.firstFilled;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TriptionalsTest {
+
+    @Spy
+    private StubTriptionalSupplier stubTriptionalSupplier;
+
+    @Test
+    public void firstFilled_WhenOneSupplierOfFilled_ShouldReturnIt() {
+        assertThat(firstFilled(() -> Triptional.of(2)), is(Triptional.of(2)));
+    }
+
+    @Test
+    public void firstFilled_WhenOneSupplierOfNull_ShouldReturnAbsent() {
+        assertThat(firstFilled(Triptional::nullInstance), is(Triptional.absent()));
+    }
+
+    @Test
+    public void firstFilled_WhenOneSupplierOfAbsent_ShouldReturnAbsent() {
+        assertThat(firstFilled(Triptional::absent), is(Triptional.absent()));
+    }
+
+    @Test
+    public void firstFilled_WhenTwoSuppliersOfFilled_ShouldReturnFirstValue() {
+        assertThat(firstFilled(() -> Triptional.of(2),
+                               () -> Triptional.of(3)),
+                   is(Triptional.of(2)));
+    }
+
+    @Test
+    public void firstFilled_WhenTwoSuppliersOfFilled_ShouldNotCalculateSecondValue() {
+        firstFilled(() -> Triptional.of(2),
+                    stubTriptionalSupplier);
+
+        verify(stubTriptionalSupplier, never()).get();
+    }
+
+    @Test
+    public void firstFilled_WhenFirstSupplierOfFilled_SecondOfNull_ShouldReturnFirstValue() {
+        assertThat(firstFilled(() -> Triptional.of(2),
+                               Triptional::nullInstance),
+                   is(Triptional.of(2)));
+    }
+
+    @Test
+    public void firstFilled_WhenFirstSupplierOfFilled_SecondOfAbsent_ShouldReturnFirstValue() {
+        assertThat(firstFilled(() -> Triptional.of(2),
+                               Triptional::absent),
+                   is(Triptional.of(2)));
+    }
+
+    @Test
+    public void firstFilled_WhenFirstSupplierOfNull_SecondOfFilled_ShouldReturnSecondValue() {
+        assertThat(firstFilled(Triptional::absent,
+                               () -> Triptional.of(2)),
+                   is(Triptional.of(2)));
+    }
+
+    @Test
+    public void firstFilled_WhenTwoSuppliersOfNull_ShouldReturnAbsent() {
+        assertThat(firstFilled(Triptional::nullInstance,
+                               Triptional::nullInstance),
+                   is(Triptional.absent()));
+    }
+
+    @Test
+    public void firstFilled_WhenFirstSupplierOfNull_SecondOfAbsent_ShouldReturnAbsent() {
+        assertThat(firstFilled(Triptional::nullInstance,
+                               Triptional::absent),
+                   is(Triptional.absent()));
+    }
+
+    @Test
+    public void firstFilled_WhenFirstSupplierOfAbsent_SecondOfFilled_ShouldReturnSecondValue() {
+        assertThat(firstFilled(Triptional::absent,
+                               () -> Triptional.of(2)),
+                   is(Triptional.of(2)));
+    }
+
+    @Test
+    public void firstFilled_WhenFirstSupplierOfAbsent_SecondOfNull_ShouldReturnAbsent() {
+        assertThat(firstFilled(Triptional::absent,
+                               Triptional::nullInstance),
+                   is(Triptional.absent()));
+    }
+
+    @Test
+    public void firstFilled_WhenTwoSuppliersOfAbsent_ShouldReturnAbsent() {
+        assertThat(firstFilled(Triptional::absent,
+                               Triptional::absent),
+                   is(Triptional.absent()));
+    }
+
+    private static class StubTriptionalSupplier implements Supplier<Triptional<Integer>> {
+
+        @Override
+        public Triptional<Integer> get() {
+            return Triptional.of(9999);
+        }
+    }
+}


### PR DESCRIPTION
Following @galkoren -s suggestion: Extracting a static method from `EntityIdExtractor`, for finding the first 'filled' value from a sequence of `Triptional` suppliers. 
This method will be reused in the next PR where I will generalize `EntityIdExtractor` to support any field.
And then _finally_  I will be able to complete the task of supporting self-mandatory audited fields.

**General note:** Both `Triptional` and also the generalized extractor of the next PR - can be used elsewhere in the code to simplify it and avoid potential bugs.