### PR TITLE
Rename EntityImpl -> CurrentEntityState

### DIFF
--- a/integration-tests/src/test/java/com.kenshoo.pl/entity/EntityFetcherByIdTest.java
+++ b/integration-tests/src/test/java/com.kenshoo.pl/entity/EntityFetcherByIdTest.java
@@ -120,7 +120,7 @@ public class EntityFetcherByIdTest {
 
         final Identifier<ParentEntity> parentId = new ParentEntity.Key(1);
 
-        final Map<Identifier<ParentEntity>, Entity> idEntityMap = entitiesFetcher.fetchEntitiesByIds(ImmutableList.of(parentId),
+        final Map<Identifier<ParentEntity>, CurrentEntityState> idEntityMap = entitiesFetcher.fetchEntitiesByIds(ImmutableList.of(parentId),
                 ID, FIELD_1);
 
         final List<FieldsValueMap<ChildEntity>> manyValues = idEntityMap.get(parentId).getMany(ChildEntity.INSTANCE);
@@ -152,7 +152,7 @@ public class EntityFetcherByIdTest {
 
         final Identifier<GrandChildEntity> grandChildId = new GrandChildEntity.Color("color1");
 
-        final Map<Identifier<GrandChildEntity>, Entity> idEntityMap = entitiesFetcher.fetchEntitiesByIds(ImmutableList.of(grandChildId),
+        final Map<Identifier<GrandChildEntity>, CurrentEntityState> idEntityMap = entitiesFetcher.fetchEntitiesByIds(ImmutableList.of(grandChildId),
                 OtherChildEntity.ID, OtherChildEntity.NAME);
 
         final List<FieldsValueMap<OtherChildEntity>> manyValues = idEntityMap.get(grandChildId).getMany(OtherChildEntity.INSTANCE);
@@ -183,9 +183,9 @@ public class EntityFetcherByIdTest {
     public void dont_fetch_as_a_secondary_table_of_your_parent_if_you_can_fetch_it_directly_from_another_parent() {
 
         final Identifier<OtherGrandChildEntity> grandChildId = new OtherGrandChildEntity.ChildIdAndName(1, "otherGrandChild1");
-        final Map<Identifier<OtherGrandChildEntity>, Entity> idEntityMap = entitiesFetcher.fetchEntitiesByIds(ImmutableList.of(grandChildId), ChildEntity.ID);
+        final Map<Identifier<OtherGrandChildEntity>, CurrentEntityState> idEntityMap = entitiesFetcher.fetchEntitiesByIds(ImmutableList.of(grandChildId), ChildEntity.ID);
 
-        final Entity entity = idEntityMap.get(grandChildId);
+        final CurrentEntityState entity = idEntityMap.get(grandChildId);
 
         assertThat(entity.get(ChildEntity.ID), Is.is(1));
         assertThat(entity.getMany(ChildEntity.INSTANCE), empty());

--- a/integration-tests/src/test/java/com/kenshoo/matcher/EntityHasFieldValuesMatcher.java
+++ b/integration-tests/src/test/java/com/kenshoo/matcher/EntityHasFieldValuesMatcher.java
@@ -1,7 +1,7 @@
 package com.kenshoo.matcher;
 
 import com.google.common.collect.ImmutableSet;
-import com.kenshoo.pl.entity.Entity;
+import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.EntityFieldValue;
 import org.apache.commons.lang3.StringUtils;
@@ -13,7 +13,7 @@ import java.util.Objects;
 
 import static java.util.stream.Collectors.joining;
 
-public class EntityHasFieldValuesMatcher extends TypeSafeMatcher<Entity> {
+public class EntityHasFieldValuesMatcher extends TypeSafeMatcher<CurrentEntityState> {
 
     private final Collection<EntityFieldValue> expectedFieldValues;
     private String mismatchesMessage;
@@ -24,7 +24,7 @@ public class EntityHasFieldValuesMatcher extends TypeSafeMatcher<Entity> {
     }
 
     @Override
-    protected boolean matchesSafely(final Entity actualEntity) {
+    protected boolean matchesSafely(final CurrentEntityState actualEntity) {
         mismatchesMessage = expectedFieldValues.stream()
                                                .map(fieldValue -> validateField(actualEntity, fieldValue))
                                                .collect(joining("\n"));
@@ -38,11 +38,11 @@ public class EntityHasFieldValuesMatcher extends TypeSafeMatcher<Entity> {
     }
 
     @Override
-    protected void describeMismatchSafely(Entity item, Description mismatchDescription) {
+    protected void describeMismatchSafely(CurrentEntityState item, Description mismatchDescription) {
         mismatchDescription.appendText("the following mismatches occurred:\n" + mismatchesMessage);
     }
 
-    private String validateField(final Entity actualEntity, final EntityFieldValue fieldValue) {
+    private String validateField(final CurrentEntityState actualEntity, final EntityFieldValue fieldValue) {
         if (!actualEntity.containsField(fieldValue.getField())) {
             return "\t\tMissing expected field '" + fieldValue.getFieldName() + "'";
         }

--- a/integration-tests/src/test/java/com/kenshoo/matcher/EntityHasFieldValuesMatcher.java
+++ b/integration-tests/src/test/java/com/kenshoo/matcher/EntityHasFieldValuesMatcher.java
@@ -2,6 +2,7 @@ package com.kenshoo.matcher;
 
 import com.google.common.collect.ImmutableSet;
 import com.kenshoo.pl.entity.CurrentEntityState;
+import com.kenshoo.pl.entity.Entity;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.EntityFieldValue;
 import org.apache.commons.lang3.StringUtils;
@@ -13,7 +14,7 @@ import java.util.Objects;
 
 import static java.util.stream.Collectors.joining;
 
-public class EntityHasFieldValuesMatcher extends TypeSafeMatcher<CurrentEntityState> {
+public class EntityHasFieldValuesMatcher extends TypeSafeMatcher<Entity> {
 
     private final Collection<EntityFieldValue> expectedFieldValues;
     private String mismatchesMessage;
@@ -24,7 +25,7 @@ public class EntityHasFieldValuesMatcher extends TypeSafeMatcher<CurrentEntitySt
     }
 
     @Override
-    protected boolean matchesSafely(final CurrentEntityState actualEntity) {
+    protected boolean matchesSafely(final Entity actualEntity) {
         mismatchesMessage = expectedFieldValues.stream()
                                                .map(fieldValue -> validateField(actualEntity, fieldValue))
                                                .collect(joining("\n"));
@@ -38,11 +39,11 @@ public class EntityHasFieldValuesMatcher extends TypeSafeMatcher<CurrentEntitySt
     }
 
     @Override
-    protected void describeMismatchSafely(CurrentEntityState item, Description mismatchDescription) {
+    protected void describeMismatchSafely(Entity item, Description mismatchDescription) {
         mismatchDescription.appendText("the following mismatches occurred:\n" + mismatchesMessage);
     }
 
-    private String validateField(final CurrentEntityState actualEntity, final EntityFieldValue fieldValue) {
+    private String validateField(final Entity actualEntity, final EntityFieldValue fieldValue) {
         if (!actualEntity.containsField(fieldValue.getField())) {
             return "\t\tMissing expected field '" + fieldValue.getFieldName() + "'";
         }

--- a/integration-tests/src/test/java/com/kenshoo/pl/entity/EntitiesFetcherByIdTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/entity/EntitiesFetcherByIdTest.java
@@ -105,7 +105,7 @@ public class EntitiesFetcherByIdTest {
 
         Identifier<ParentEntity> parentId = new ParentEntity.Key(1);
 
-        Map<Identifier<ParentEntity>, Entity> idEntityMap = entitiesFetcher.fetchEntitiesByIds(ImmutableList.of(parentId),
+        Map<Identifier<ParentEntity>, CurrentEntityState> idEntityMap = entitiesFetcher.fetchEntitiesByIds(ImmutableList.of(parentId),
                 ID, FIELD_1);
 
         List<FieldsValueMap<ChildEntity>> manyValues = idEntityMap.get(parentId).getMany(INSTANCE);
@@ -137,7 +137,7 @@ public class EntitiesFetcherByIdTest {
 
         Identifier<GrandChildEntity> grandChildId = new GrandChildEntity.Color("color1");
 
-        Map<Identifier<GrandChildEntity>, Entity> idEntityMap = entitiesFetcher.fetchEntitiesByIds(ImmutableList.of(grandChildId),
+        Map<Identifier<GrandChildEntity>, CurrentEntityState> idEntityMap = entitiesFetcher.fetchEntitiesByIds(ImmutableList.of(grandChildId),
                 OtherChildEntity.ID, OtherChildEntity.NAME);
 
         List<FieldsValueMap<OtherChildEntity>> manyValues = idEntityMap.get(grandChildId).getMany(OtherChildEntity.INSTANCE);

--- a/integration-tests/src/test/java/com/kenshoo/pl/entity/EntitiesFetcherByPLConditionTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/entity/EntitiesFetcherByPLConditionTest.java
@@ -89,7 +89,7 @@ public class EntitiesFetcherByPLConditionTest {
 
     @Test
     public void fetchByEqualsConditionWhereOneMatchesAndFieldOfConditionRequested() {
-        final List<Entity> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
+        final List<CurrentEntityState> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
                                                             TestEntityType.FIELD1.eq("Alpha"),
                                                             TestEntityType.ID, TestEntityType.FIELD1);
         assertThat("Incorrect number of entities fetched: ",
@@ -102,7 +102,7 @@ public class EntitiesFetcherByPLConditionTest {
 
     @Test
     public void fetchByEqualsConditionWhereOneMatchesAndFieldOfConditionNotRequested() {
-        final List<Entity> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
+        final List<CurrentEntityState> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
                                                             TestEntityType.FIELD1.eq("Alpha"),
                                                             TestEntityType.ID, TestEntityType.TYPE);
         assertThat("Incorrect number of entities fetched: ",
@@ -115,13 +115,13 @@ public class EntitiesFetcherByPLConditionTest {
 
     @Test
     public void fetchByEqualsConditionWhereTwoMatch() {
-        final List<Entity> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
+        final List<CurrentEntityState> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
                                                             TestEntityType.TYPE.eq(1),
                                                             TestEntityType.ID, TestEntityType.FIELD1);
         assertThat("Incorrect number of entities fetched: ",
                    entities.size(), is(2));
 
-        final List<Entity> sortedEntities = entities.stream()
+        final List<CurrentEntityState> sortedEntities = entities.stream()
                                                     .sorted(comparing(entity -> entity.get(TestEntityType.ID)))
                                                     .collect(toList());
 
@@ -135,7 +135,7 @@ public class EntitiesFetcherByPLConditionTest {
 
     @Test
     public void fetchByEqualsConditionWhereNoneMatch() {
-        final List<Entity> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
+        final List<CurrentEntityState> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
                                                             TestEntityType.TYPE.eq(999),
                                                             TestEntityType.ID, TestEntityType.FIELD1);
         assertThat("Should not find entities for given condition: ",
@@ -150,7 +150,7 @@ public class EntitiesFetcherByPLConditionTest {
 
     @Test
     public void fetchByEqualsConditionWhereConditionOnChildAndParentRequested() {
-        final List<Entity> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
+        final List<CurrentEntityState> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
                                                             TestEntityType.FIELD1.eq("Alpha"),
                                                             TestParentEntityType.FIELD1);
         assertThat("Incorrect number of entities fetched: ",
@@ -162,7 +162,7 @@ public class EntitiesFetcherByPLConditionTest {
 
     @Test
     public void fetchByEqualsConditionWhereConditionOnChildAndParentSecondaryRequested() {
-        final List<Entity> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
+        final List<CurrentEntityState> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
                                                             TestEntityType.FIELD1.eq("Alpha"),
                                                             TestParentEntityType.SECONDARY_FIELD1);
         assertThat("Incorrect number of entities fetched: ",
@@ -174,7 +174,7 @@ public class EntitiesFetcherByPLConditionTest {
 
     @Test
     public void fetchByEqualsConditionWhereConditionOnChildAndBothParentAndSecondaryRequested() {
-        final List<Entity> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
+        final List<CurrentEntityState> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
                                                             TestEntityType.FIELD1.eq("Charlie"),
                                                             TestParentEntityType.FIELD1, TestParentEntityType.SECONDARY_FIELD1);
         assertThat("Incorrect number of entities fetched: ",
@@ -187,7 +187,7 @@ public class EntitiesFetcherByPLConditionTest {
 
     @Test
     public void fetchByEqualsConditionWhereConditionOnParentAndChildRequested() {
-        final List<Entity> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
+        final List<CurrentEntityState> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
                                                             TestParentEntityType.FIELD2.eq("ParentBravo2"),
                                                             TestEntityType.FIELD1);
         assertThat("Incorrect number of entities fetched: ",
@@ -199,7 +199,7 @@ public class EntitiesFetcherByPLConditionTest {
 
     @Test
     public void fetchByEqualsConditionWhereConditionOnParentAndParentRequested() {
-        final List<Entity> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
+        final List<CurrentEntityState> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
                                                             TestParentEntityType.FIELD2.eq("ParentBravo2"),
                                                             TestParentEntityType.FIELD1);
         assertThat("Incorrect number of entities fetched: ",
@@ -211,7 +211,7 @@ public class EntitiesFetcherByPLConditionTest {
 
     @Test
     public void fetchByEqualsConditionWhereConditionOnParentAndParentSecondaryRequested() {
-        final List<Entity> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
+        final List<CurrentEntityState> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
                                                             TestParentEntityType.FIELD2.eq("ParentBravo2"),
                                                             TestParentEntityType.SECONDARY_FIELD1);
         assertThat("Incorrect number of entities fetched: ",
@@ -223,7 +223,7 @@ public class EntitiesFetcherByPLConditionTest {
 
     @Test
     public void fetchByEqualsConditionWhereConditionOnParentAndBothChildAndParentSecondaryRequested() {
-        final List<Entity> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
+        final List<CurrentEntityState> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
                                                             TestParentEntityType.FIELD2.eq("ParentBravo2"),
                                                             TestEntityType.FIELD1, TestParentEntityType.SECONDARY_FIELD1);
         assertThat("Incorrect number of entities fetched: ",
@@ -236,7 +236,7 @@ public class EntitiesFetcherByPLConditionTest {
 
     @Test
     public void fetchByEqualsConditionWhereConditionOnParentSecondaryAndChildRequested() {
-        final List<Entity> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
+        final List<CurrentEntityState> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
                                                             TestParentEntityType.SECONDARY_FIELD2.eq("ParentSecondaryBravo2"),
                                                             TestEntityType.FIELD1);
         assertThat("Incorrect number of entities fetched: ",
@@ -248,7 +248,7 @@ public class EntitiesFetcherByPLConditionTest {
 
     @Test
     public void fetchByEqualsConditionWhereConditionOnParentSecondaryAndParentRequested() {
-        final List<Entity> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
+        final List<CurrentEntityState> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
                                                             TestParentEntityType.SECONDARY_FIELD2.eq("ParentSecondaryBravo2"),
                                                             TestParentEntityType.FIELD1);
         assertThat("Incorrect number of entities fetched: ",
@@ -260,7 +260,7 @@ public class EntitiesFetcherByPLConditionTest {
 
     @Test
     public void fetchByEqualsConditionWhereConditionOnParentSecondaryAndParentSecondaryRequested() {
-        final List<Entity> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
+        final List<CurrentEntityState> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
                                                             TestParentEntityType.SECONDARY_FIELD2.eq("ParentSecondaryBravo2"),
                                                             TestParentEntityType.SECONDARY_FIELD1);
         assertThat("Incorrect number of entities fetched: ",
@@ -272,7 +272,7 @@ public class EntitiesFetcherByPLConditionTest {
 
     @Test
     public void fetchByEqualsConditionWhereConditionOnParentSecondaryAndBothChildAndParentRequested() {
-        final List<Entity> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
+        final List<CurrentEntityState> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
                                                             TestParentEntityType.SECONDARY_FIELD2.eq("ParentSecondaryBravo2"),
                                                             TestEntityType.FIELD1, TestParentEntityType.FIELD1);
         assertThat("Incorrect number of entities fetched: ",
@@ -285,7 +285,7 @@ public class EntitiesFetcherByPLConditionTest {
 
     @Test
     public void fetchByAndConditionWhereOneMatches() {
-        final List<Entity> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
+        final List<CurrentEntityState> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
                                                             TestEntityType.ID.eq(1).and(TestEntityType.TYPE.eq(1)),
                                                             TestEntityType.FIELD1);
         assertThat("Incorrect number of entities fetched: ",
@@ -297,7 +297,7 @@ public class EntitiesFetcherByPLConditionTest {
 
     @Test
     public void fetchByAndConditionWhereNoneMatch() {
-        final List<Entity> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
+        final List<CurrentEntityState> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
                                                             TestEntityType.ID.eq(1).and(TestEntityType.TYPE.eq(99)),
                                                             TestEntityType.FIELD1);
         assertThat("Should not find entities for given condition: ",
@@ -306,7 +306,7 @@ public class EntitiesFetcherByPLConditionTest {
 
     @Test
     public void fetchByOrConditionWhereOneMatches() {
-        final List<Entity> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
+        final List<CurrentEntityState> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
                                                             TestEntityType.ID.eq(2).or(TestEntityType.TYPE.eq(99)),
                                                             TestEntityType.FIELD1);
         assertThat("Incorrect number of entities fetched: ",
@@ -318,14 +318,14 @@ public class EntitiesFetcherByPLConditionTest {
 
     @Test
     public void fetchByOrConditionWhereTwoMatch() {
-        final List<Entity> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
+        final List<CurrentEntityState> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
                                                             TestEntityType.ID.eq(2).or(TestEntityType.TYPE.eq(3)),
                                                             TestEntityType.TYPE, TestEntityType.FIELD1);
 
         assertThat("Incorrect number of entities fetched: ",
                    entities.size(), is(2));
 
-        final List<Entity> sortedEntities = entities.stream()
+        final List<CurrentEntityState> sortedEntities = entities.stream()
                                                     .sorted(comparing(entity -> entity.get(TestEntityType.TYPE)))
                                                     .collect(toList());
 
@@ -337,7 +337,7 @@ public class EntitiesFetcherByPLConditionTest {
 
     @Test
     public void fetchByOrConditionWhereNoneMatch() {
-        final List<Entity> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
+        final List<CurrentEntityState> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
                                                             TestEntityType.ID.eq(999).or(TestEntityType.TYPE.eq(999)),
                                                             TestEntityType.TYPE, TestEntityType.FIELD1);
 
@@ -347,11 +347,11 @@ public class EntitiesFetcherByPLConditionTest {
 
     @Test
     public void fetchByNotEqualsConditionWhereTwoMatch() {
-        final List<Entity> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
+        final List<CurrentEntityState> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
                                                             not(TestEntityType.ID.eq(1)),
                                                             TestEntityType.TYPE, TestEntityType.FIELD1);
 
-        final List<Entity> sortedEntities = entities.stream()
+        final List<CurrentEntityState> sortedEntities = entities.stream()
                                                     .sorted(comparing(entity -> entity.get(TestEntityType.TYPE)))
                                                     .collect(toList());
 
@@ -366,12 +366,12 @@ public class EntitiesFetcherByPLConditionTest {
     public void fetchByUniqueKeys() {
         final PairUniqueKey<TestEntityType, Integer, Integer> uniqueKey= new PairUniqueKey<>(TestEntityType.ID, TestEntityType.TYPE);
 
-        final List<Entity> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
+        final List<CurrentEntityState> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
                 ImmutableList.of(uniqueKey.createValue(1, 1), uniqueKey.createValue(2, 1)),
                 PLCondition.trueCondition(),
                 TestEntityType.TYPE, TestEntityType.FIELD1);
 
-        final List<Entity> sortedEntities = entities.stream()
+        final List<CurrentEntityState> sortedEntities = entities.stream()
                 .sorted(comparing(entity -> entity.get(TestEntityType.TYPE)))
                 .collect(toList());
 
@@ -385,12 +385,12 @@ public class EntitiesFetcherByPLConditionTest {
     public void fetchByUniqueKeysAndCondition() {
         final PairUniqueKey<TestEntityType, Integer, Integer> uniqueKey= new PairUniqueKey<>(TestEntityType.ID, TestEntityType.TYPE);
 
-        final List<Entity> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
+        final List<CurrentEntityState> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
                 ImmutableList.of(uniqueKey.createValue(1, 1), uniqueKey.createValue(2, 1)),
                 not(TestEntityType.ID.eq(1)),
                 TestEntityType.ID, TestEntityType.TYPE, TestEntityType.FIELD1);
 
-        final List<Entity> sortedEntities = entities.stream()
+        final List<CurrentEntityState> sortedEntities = entities.stream()
                 .sorted(comparing(entity -> entity.get(TestEntityType.TYPE)))
                 .collect(toList());
 
@@ -401,7 +401,7 @@ public class EntitiesFetcherByPLConditionTest {
 
     @Test
     public void fetchByInConditionForStringFieldWhereTwoMatchesAndFieldOfConditionRequested() {
-        final List<Entity> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
+        final List<CurrentEntityState> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
                 TestEntityType.FIELD1.in("Alpha", "Bravo"),
                 TestEntityType.ID, TestEntityType.FIELD1);
         assertThat("Incorrect number of entities fetched: ",
@@ -418,7 +418,7 @@ public class EntitiesFetcherByPLConditionTest {
 
     @Test
     public void fetchByInConditionForIntFieldWhereTwoMatchesAndFieldOfConditionRequested() {
-        final List<Entity> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
+        final List<CurrentEntityState> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
                 TestEntityType.TYPE.in(2, 3),
                 TestEntityType.ID, TestEntityType.FIELD1);
         assertThat("Incorrect number of entities fetched: ",
@@ -435,7 +435,7 @@ public class EntitiesFetcherByPLConditionTest {
 
     @Test
     public void fetchByNotInConditionForIntFieldWhereTwoMatchesAndFieldOfConditionRequested() {
-        final List<Entity> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
+        final List<CurrentEntityState> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
                 PLCondition.not(TestEntityType.TYPE.in(2, 3)),
                 TestEntityType.ID, TestEntityType.FIELD1);
         assertThat("Incorrect number of entities fetched: ",
@@ -452,7 +452,7 @@ public class EntitiesFetcherByPLConditionTest {
 
     @Test
     public void fetchByInConditionForStringFieldWhereNotAllMatchesAndFieldOfConditionRequested() {
-        final List<Entity> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
+        final List<CurrentEntityState> entities = entitiesFetcher.fetch(TestEntityType.INSTANCE,
                 TestEntityType.FIELD1.in("Alpha", "NotExist"),
                 TestEntityType.ID, TestEntityType.FIELD1);
         assertThat("Incorrect number of entities fetched: ",

--- a/integration-tests/src/test/java/com/kenshoo/pl/entity/EntitiesFetcherByPLConditionWithVirtualPartitionTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/entity/EntitiesFetcherByPLConditionWithVirtualPartitionTest.java
@@ -72,7 +72,7 @@ public class EntitiesFetcherByPLConditionWithVirtualPartitionTest {
 
     @Test
     public void fetchByEqualsConditionWhereInsidePartitionShouldReturnAll() {
-        final List<Entity> entities = entitiesFetcher.fetch(ENTITY_TYPE,
+        final List<CurrentEntityState> entities = entitiesFetcher.fetch(ENTITY_TYPE,
                                                             FIELD1.eq("1-1-1"),
                                                             FIELD1);
 
@@ -83,7 +83,7 @@ public class EntitiesFetcherByPLConditionWithVirtualPartitionTest {
 
     @Test
     public void fetchByEqualsConditionWhereOutsidePartitionShouldReturnEmpty() {
-        final List<Entity> entities = entitiesFetcher.fetch(ENTITY_TYPE,
+        final List<CurrentEntityState> entities = entitiesFetcher.fetch(ENTITY_TYPE,
                                                             ID2.eq(2),
                                                             FIELD1);
 
@@ -92,13 +92,13 @@ public class EntitiesFetcherByPLConditionWithVirtualPartitionTest {
 
     @Test
     public void fetchByEqualsConditionWherePartiallyIntersectsPartitionShouldReturnIntersection() {
-        final List<Entity> entities = entitiesFetcher.fetch(ENTITY_TYPE,
+        final List<CurrentEntityState> entities = entitiesFetcher.fetch(ENTITY_TYPE,
                                                             ID1.eq(1),
                                                             FIELD1);
         assertThat("Incorrect number of entities fetched: ",
                    entities.size(), is(2));
 
-        final List<Entity> sortedEntities = sortByField1(entities);
+        final List<CurrentEntityState> sortedEntities = sortByField1(entities);
 
         assertThat(sortedEntities.get(0), hasFieldValues(fieldValue(FIELD1, "1-1-1")));
         assertThat(sortedEntities.get(1), hasFieldValues(fieldValue(FIELD1, "1-1-2")));
@@ -106,13 +106,13 @@ public class EntitiesFetcherByPLConditionWithVirtualPartitionTest {
 
     @Test
     public void fetchByAndConditionWhereInsidePartitionShouldReturnAll() {
-        final List<Entity> entities = entitiesFetcher.fetch(ENTITY_TYPE,
+        final List<CurrentEntityState> entities = entitiesFetcher.fetch(ENTITY_TYPE,
                                                             ID1.eq(1).and(ID2.eq(1)),
                                                             FIELD1);
         assertThat("Incorrect number of entities fetched: ",
                    entities.size(), is(2));
 
-        final List<Entity> sortedEntities = sortByField1(entities);
+        final List<CurrentEntityState> sortedEntities = sortByField1(entities);
 
         assertThat(sortedEntities.get(0), hasFieldValues(fieldValue(FIELD1, "1-1-1")));
         assertThat(sortedEntities.get(1), hasFieldValues(fieldValue(FIELD1, "1-1-2")));
@@ -120,7 +120,7 @@ public class EntitiesFetcherByPLConditionWithVirtualPartitionTest {
 
     @Test
     public void fetchByAndConditionWhereOutsidePartitionShouldReturnEmpty() {
-        final List<Entity> entities = entitiesFetcher.fetch(ENTITY_TYPE,
+        final List<CurrentEntityState> entities = entitiesFetcher.fetch(ENTITY_TYPE,
                                                             ID1.eq(2).and(ID2.eq(1)),
                                                             FIELD1);
         assertThat(entities, is(empty()));
@@ -128,7 +128,7 @@ public class EntitiesFetcherByPLConditionWithVirtualPartitionTest {
 
     @Test
     public void fetchByAndConditionWherePartiallyIntersectsPartitionShouldReturnIntersection() {
-        final List<Entity> entities = entitiesFetcher.fetch(ENTITY_TYPE,
+        final List<CurrentEntityState> entities = entitiesFetcher.fetch(ENTITY_TYPE,
                                                             ID2.eq(1).and(ID3.eq(1)),
                                                             FIELD1);
         assertThat("Incorrect number of entities fetched: ",
@@ -138,14 +138,14 @@ public class EntitiesFetcherByPLConditionWithVirtualPartitionTest {
 
     @Test
     public void fetchByOrConditionWherePartiallyIntersectsPartitionShouldReturnIntersection() {
-        final List<Entity> entities = entitiesFetcher.fetch(ENTITY_TYPE,
+        final List<CurrentEntityState> entities = entitiesFetcher.fetch(ENTITY_TYPE,
                                                             ID1.eq(1).or(ID3.eq(1)),
                                                             FIELD1);
 
         assertThat("Incorrect number of entities fetched: ",
                    entities.size(), is(2));
 
-        final List<Entity> sortedEntities = sortByField1(entities);
+        final List<CurrentEntityState> sortedEntities = sortByField1(entities);
 
         assertThat(sortedEntities.get(0), hasFieldValues(fieldValue(FIELD1, "1-1-1")));
         assertThat(sortedEntities.get(1), hasFieldValues(fieldValue(FIELD1, "1-1-2")));
@@ -153,7 +153,7 @@ public class EntitiesFetcherByPLConditionWithVirtualPartitionTest {
 
     @Test
     public void fetchByOrConditionWhereOutsidePartitionShouldReturnEmpty() {
-        final List<Entity> entities = entitiesFetcher.fetch(ENTITY_TYPE,
+        final List<CurrentEntityState> entities = entitiesFetcher.fetch(ENTITY_TYPE,
                                                             ID1.eq(2).or(FIELD1.eq("1-2-1")),
                                                             FIELD1);
 
@@ -162,7 +162,7 @@ public class EntitiesFetcherByPLConditionWithVirtualPartitionTest {
 
     @Test
     public void fetchByNotEqualsConditionWherePartiallyIntersectsPartitionShouldReturnIntersection() {
-        final List<Entity> entities = entitiesFetcher.fetch(ENTITY_TYPE,
+        final List<CurrentEntityState> entities = entitiesFetcher.fetch(ENTITY_TYPE,
                                                             not(FIELD1.eq("1-1-1")),
                                                             FIELD1);
 
@@ -171,7 +171,7 @@ public class EntitiesFetcherByPLConditionWithVirtualPartitionTest {
         assertThat(entities.get(0), hasFieldValues(fieldValue(FIELD1, "1-1-2")));
     }
 
-    private List<Entity> sortByField1(List<Entity> entities) {
+    private List<CurrentEntityState> sortByField1(List<CurrentEntityState> entities) {
         return entities.stream()
                        .sorted(comparing(entity -> entity.get(FIELD1)))
                        .collect(toList());

--- a/integration-tests/src/test/java/com/kenshoo/pl/entity/PLContextSelectTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/entity/PLContextSelectTest.java
@@ -21,7 +21,6 @@ import java.util.Set;
 
 import static com.kenshoo.matcher.EntityHasFieldValuesMatcher.fieldValue;
 import static com.kenshoo.matcher.EntityHasFieldValuesMatcher.hasFieldValues;
-import static com.kenshoo.pl.entity.PLCondition.not;
 import static com.kenshoo.pl.entity.annotation.RequiredFieldType.RELATION;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -85,7 +84,7 @@ public class PLContextSelectTest {
 
     @Test
     public void selectFromSingleEntity() {
-        final List<Entity> entities = plContext.select(TestEntityType.ID, TestEntityType.FIELD1)
+        final List<CurrentEntityState> entities = plContext.select(TestEntityType.ID, TestEntityType.FIELD1)
                                                .from(TestEntityType.INSTANCE)
                                                .where(TestEntityType.FIELD1.eq("Alpha"))
                                                .fetch();
@@ -99,7 +98,7 @@ public class PLContextSelectTest {
 
     @Test
     public void selectIsNull() {
-        final List<Entity> entities = plContext.select(TestParentEntityType.FIELD1)
+        final List<CurrentEntityState> entities = plContext.select(TestParentEntityType.FIELD1)
                 .from(TestParentEntityType.INSTANCE)
                 .where(TestParentEntityType.FIELD2.isNull())
                 .fetch();
@@ -110,7 +109,7 @@ public class PLContextSelectTest {
 
     @Test
     public void selectFromChildAndParent() {
-        final List<Entity> entities = plContext.select(TestEntityType.ID, TestEntityType.FIELD1, TestParentEntityType.FIELD1)
+        final List<CurrentEntityState> entities = plContext.select(TestEntityType.ID, TestEntityType.FIELD1, TestParentEntityType.FIELD1)
                                                .from(TestEntityType.INSTANCE)
                                                .where(TestEntityType.FIELD1.eq("Alpha"))
                                                .fetch();
@@ -125,7 +124,7 @@ public class PLContextSelectTest {
 
     @Test
     public void selectFromChildAndParentAndParentSecondary() {
-        final List<Entity> entities = plContext.select(TestEntityType.ID,
+        final List<CurrentEntityState> entities = plContext.select(TestEntityType.ID,
                                                        TestEntityType.FIELD1,
                                                        TestParentEntityType.FIELD1,
                                                        TestParentEntityType.SECONDARY_FIELD1)
@@ -146,7 +145,7 @@ public class PLContextSelectTest {
     public void selectFromSingleEntityByKeys() {
         final SingleUniqueKey<TestEntityType, Integer> uniqueKey = new SingleUniqueKey<>(TestEntityType.ID);
 
-        final List<Entity> entities = plContext.select(TestEntityType.ID, TestEntityType.FIELD1)
+        final List<CurrentEntityState> entities = plContext.select(TestEntityType.ID, TestEntityType.FIELD1)
                 .from(TestEntityType.INSTANCE)
                 .where(PLCondition.trueCondition())
                 .fetchByKeys(ImmutableList.of(uniqueKey.createValue(1)));
@@ -162,7 +161,7 @@ public class PLContextSelectTest {
     public void selectFromSingleEntityByParentKeys() {
         final SingleUniqueKey<TestParentEntityType, Integer> uniqueKey = new SingleUniqueKey<>(TestParentEntityType.ID);
 
-        final List<Entity> entities = plContext.select(TestEntityType.ID, TestEntityType.FIELD1)
+        final List<CurrentEntityState> entities = plContext.select(TestEntityType.ID, TestEntityType.FIELD1)
                 .from(TestEntityType.INSTANCE)
                 .where(PLCondition.trueCondition())
                 .fetchByKeys(ImmutableList.of(uniqueKey.createValue(1)));
@@ -179,7 +178,7 @@ public class PLContextSelectTest {
 
     @Test
     public void selectFromSingleEntityInClause() {
-        final List<Entity> entities = plContext.select(TestEntityType.ID, TestEntityType.FIELD1)
+        final List<CurrentEntityState> entities = plContext.select(TestEntityType.ID, TestEntityType.FIELD1)
                 .from(TestEntityType.INSTANCE)
                 .where(TestEntityType.FIELD1.in("Alpha", "Bravo"))
                 .fetch();
@@ -196,7 +195,7 @@ public class PLContextSelectTest {
 
     @Test
     public void selectFromSingleEntityInAndEqClause() {
-        final List<Entity> entities = plContext.select(TestEntityType.ID, TestEntityType.FIELD1)
+        final List<CurrentEntityState> entities = plContext.select(TestEntityType.ID, TestEntityType.FIELD1)
                 .from(TestEntityType.INSTANCE)
                 .where(TestEntityType.FIELD1.in("Alpha", "Bravo").and(TestEntityType.ID.eq(2)))
                 .fetch();
@@ -210,7 +209,7 @@ public class PLContextSelectTest {
 
     @Test
     public void selectFromChildAndParentInClause() {
-        final List<Entity> entities = plContext.select(TestEntityType.ID, TestEntityType.FIELD1, TestParentEntityType.FIELD1)
+        final List<CurrentEntityState> entities = plContext.select(TestEntityType.ID, TestEntityType.FIELD1, TestParentEntityType.FIELD1)
                 .from(TestEntityType.INSTANCE)
                 .where(TestEntityType.FIELD1.in("Alpha", "Bravo"))
                 .fetch();

--- a/integration-tests/src/test/java/com/kenshoo/pl/entity/PersistenceLayerTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/entity/PersistenceLayerTest.java
@@ -446,7 +446,7 @@ public class PersistenceLayerTest {
         // because it is not nullable.
         UpdateTestCommand cmd = new UpdateTestCommand(ID_1).with(URL, GOOGLE_URL).with(URL_PARAM, "abc");
         persistenceLayer.update(asList(cmd), changeFlowConfig().build());
-        Entity fromDB = plContext.select(URL_PARAM).from(INSTANCE).where(ID.eq(ID_1)).fetch().get(0);
+        CurrentEntityState fromDB = plContext.select(URL_PARAM).from(INSTANCE).where(ID.eq(ID_1)).fetch().get(0);
         assertThat(fromDB.get(URL_PARAM), is("abc"));
     }
 
@@ -532,7 +532,7 @@ public class PersistenceLayerTest {
             public void enrich(Collection<? extends ChangeEntityCommand<EntityForTest>> changeEntityCommands, ChangeOperation changeOperation, ChangeContext changeContext) {
                 ChangeEntityCommand<EntityForTest> command = Iterables.getFirst(changeEntityCommands, null);
                 assertNotNull(command);
-                Entity entity = changeContext.getEntity(command);
+                CurrentEntityState entity = changeContext.getEntity(command);
                 command.set(EntityForTest.FIELD2, Integer.parseInt(entity.get(EntityForTestComplexKeyParent.FIELD1)));
             }
 
@@ -653,7 +653,7 @@ public class PersistenceLayerTest {
         Instant expectedCreationDate = Instant.now();
         CreateResult<EntityForTest, EntityForTest.Key> results = persistenceLayer.create(ImmutableList.of(command), changeFlowConfig().build(), EntityForTest.Key.DEFINITION);
         assertThat(results.hasErrors(), is(false));
-        Map<Identifier<EntityForTest>, Entity> entityMap = entitiesFetcher.fetchEntitiesByIds(ImmutableList.of(new EntityForTest.Key(newId)),
+        Map<Identifier<EntityForTest>, CurrentEntityState> entityMap = entitiesFetcher.fetchEntitiesByIds(ImmutableList.of(new EntityForTest.Key(newId)),
                                                                                               EntityForTest.CREATION_DATE);
         assertThat(entityMap.size(), is(1));
         Instant actualCreationDate = entityMap.values().iterator().next().get(EntityForTest.CREATION_DATE);
@@ -671,7 +671,7 @@ public class PersistenceLayerTest {
         Instant expectedCreationDate = Instant.now();
         CreateResult<EntityForTest, EntityForTest.Key> results = persistenceLayer.create(ImmutableList.of(command), changeFlowConfig().build(), EntityForTest.Key.DEFINITION);
         assertThat(results.hasErrors(), is(false));
-        Map<Identifier<EntityForTest>, Entity> entityMap = entitiesFetcher.fetchEntitiesByIds(singleton(new EntityForTest.Key(newId)),
+        Map<Identifier<EntityForTest>, CurrentEntityState> entityMap = entitiesFetcher.fetchEntitiesByIds(singleton(new EntityForTest.Key(newId)),
                                                                                                singleton(EntityForTest.CREATION_DATE));
         assertThat(entityMap.size(), is(1));
         Instant actualCreationDate = entityMap.values().iterator().next().get(EntityForTest.CREATION_DATE);
@@ -789,7 +789,7 @@ public class PersistenceLayerTest {
         UpdateTestCommand command = new UpdateTestCommand(NON_EXISTING_ID);
         command.set(EntityForTest.FIELD2, new FieldValueSupplier<Integer>() {
             @Override
-            public Integer supply(Entity entity) {
+            public Integer supply(CurrentEntityState entity) {
                 return entity.get(EntityForTest.FIELD2) + 20;
             }
 
@@ -1338,7 +1338,7 @@ public class PersistenceLayerTest {
         }
 
         @Override
-        public FieldsValueMap<EntityForTest> supply(Entity entity) throws ValidationException {
+        public FieldsValueMap<EntityForTest> supply(CurrentEntityState entity) throws ValidationException {
             if (validationError.isPresent()) {
                 throw new ValidationException(validationError.get());
             }
@@ -1365,7 +1365,7 @@ public class PersistenceLayerTest {
         }
 
         @Override
-        public FieldsValueMap<EntityForTest> supply(Entity entity) throws ValidationException {
+        public FieldsValueMap<EntityForTest> supply(CurrentEntityState entity) throws ValidationException {
 
             FieldsValueMapImpl<EntityForTest> entityFieldsSupplier = new FieldsValueMapImpl<>();
             for (EntityField<EntityForTest, ?> fieldToNull : fieldsToNull) {
@@ -1384,7 +1384,7 @@ public class PersistenceLayerTest {
     private static class TestField1MultiFieldSupplier implements MultiFieldValueSupplier<EntityForTest> {
 
         @Override
-        public FieldsValueMap<EntityForTest> supply(Entity entity) throws ValidationException {
+        public FieldsValueMap<EntityForTest> supply(CurrentEntityState entity) throws ValidationException {
             FieldsValueMapImpl<EntityForTest> entityFieldsSupplier = new FieldsValueMapImpl<>();
             entityFieldsSupplier.set(EntityForTest.FIELD1, FIELD1_VALID_VALUE);
             return entityFieldsSupplier;

--- a/integration-tests/src/test/java/com/kenshoo/pl/one2many/PersistenceLayerOneToManyTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/one2many/PersistenceLayerOneToManyTest.java
@@ -699,7 +699,7 @@ public class PersistenceLayerOneToManyTest {
             }
 
             @Override
-            public ValidationError validate(String fieldValue, Entity entity) {
+            public ValidationError validate(String fieldValue, CurrentEntityState entity) {
                 return entity.get(ParentEntity.NAME).equals(parentName)
                         ? new ValidationError("this is invalid")
                         : null;
@@ -865,7 +865,7 @@ public class PersistenceLayerOneToManyTest {
     private <E extends EntityType<E>> FieldValueSupplier<String> supplyFromField(EntityField<E, String> field, Function<String, String> mapping) {
         return new FieldValueSupplier<String>() {
             @Override
-            public String supply(Entity entity) throws ValidationException, NotSuppliedException {
+            public String supply(CurrentEntityState entity) throws ValidationException, NotSuppliedException {
                 return mapping.apply(entity.get(field));
             }
 

--- a/integration-tests/src/test/java/com/kenshoo/pl/secondaryOfParent/FourLevelsWith3rdLevelBackReferencing2ndLevelNoSecondaryTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/secondaryOfParent/FourLevelsWith3rdLevelBackReferencing2ndLevelNoSecondaryTest.java
@@ -130,7 +130,7 @@ public class FourLevelsWith3rdLevelBackReferencing2ndLevelNoSecondaryTest {
 
         final EntityType0.Key keyToFetch = new EntityType0.Key(ENTITY_0_ID);
 
-        final Map<Identifier<EntityType0>, Entity> fetchedKeyToEntity =
+        final Map<Identifier<EntityType0>, CurrentEntityState> fetchedKeyToEntity =
             entitiesFetcher.fetchEntitiesByIds(singleton(keyToFetch), EntityType2.NAME, EntityType3.NAME);
 
         assertThat(fetchedKeyToEntity.get(keyToFetch),

--- a/integration-tests/src/test/java/com/kenshoo/pl/secondaryOfParent/ParentWithSecondaryTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/secondaryOfParent/ParentWithSecondaryTest.java
@@ -102,7 +102,7 @@ public class ParentWithSecondaryTest {
 
         final ChildEntityType.Key keyToFetch = new ChildEntityType.Key(CHILD_ID);
 
-        final Map<Identifier<ChildEntityType>, Entity> fetchedKeyToEntity =
+        final Map<Identifier<ChildEntityType>, CurrentEntityState> fetchedKeyToEntity =
             entitiesFetcher.fetchEntitiesByIds(singleton(keyToFetch),
                                                ParentEntityType.SEC_FIELD_1, ParentEntityType.SEC_FIELD_2);
 
@@ -116,7 +116,7 @@ public class ParentWithSecondaryTest {
 
         final ChildEntityType.Key keyToFetch = new ChildEntityType.Key(CHILD_ID);
 
-        final Map<Identifier<ChildEntityType>, Entity> fetchedKeyToEntity =
+        final Map<Identifier<ChildEntityType>, CurrentEntityState> fetchedKeyToEntity =
             entitiesFetcher.fetchEntitiesByIds(singleton(keyToFetch),
                                                ParentEntityType.FIELD_1, ParentEntityType.SEC_FIELD_1, ParentEntityType.SEC_FIELD_2);
 

--- a/integration-tests/src/test/java/com/kenshoo/pl/secondaryOfParent/ParentWithTwoSecondariesTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/secondaryOfParent/ParentWithTwoSecondariesTest.java
@@ -114,7 +114,7 @@ public class ParentWithTwoSecondariesTest {
 
         final ChildEntityType.Key keyToFetch = new ChildEntityType.Key(CHILD_ID);
 
-        final Map<Identifier<ChildEntityType>, Entity> fetchedKeyToEntity =
+        final Map<Identifier<ChildEntityType>, CurrentEntityState> fetchedKeyToEntity =
             entitiesFetcher.fetchEntitiesByIds(singleton(keyToFetch),
                                                ParentEntityType.SEC_1_FIELD_1,
                                                ParentEntityType.SEC_1_FIELD_2,

--- a/integration-tests/src/test/java/com/kenshoo/pl/secondaryOfParent/ThreeLevelsWithSecondaryForEachOfTop2Test.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/secondaryOfParent/ThreeLevelsWithSecondaryForEachOfTop2Test.java
@@ -116,7 +116,7 @@ public class ThreeLevelsWithSecondaryForEachOfTop2Test {
 
         final EntityType0.Key keyToFetch = new EntityType0.Key(ENTITY_0_ID);
 
-        final Map<Identifier<EntityType0>, Entity> fetchedKeyToEntity =
+        final Map<Identifier<EntityType0>, CurrentEntityState> fetchedKeyToEntity =
             entitiesFetcher.fetchEntitiesByIds(singleton(keyToFetch),
                                                EntityType1.ENTITY_1_SEC_FIELD_1, EntityType2.ENTITY_2_SEC_FIELD_1);
 
@@ -130,7 +130,7 @@ public class ThreeLevelsWithSecondaryForEachOfTop2Test {
 
         final EntityType0.Key keyToFetch = new EntityType0.Key(ENTITY_0_ID);
 
-        final Map<Identifier<EntityType0>, Entity> fetchedKeyToEntity =
+        final Map<Identifier<EntityType0>, CurrentEntityState> fetchedKeyToEntity =
             entitiesFetcher.fetchEntitiesByIds(singleton(keyToFetch),
                                                EntityType1.ENTITY_1_SEC_FIELD_1, EntityType2.FIELD_1, EntityType2.ENTITY_2_SEC_FIELD_1);
 

--- a/main/src/main/java/com/kenshoo/pl/entity/ChangeContext.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/ChangeContext.java
@@ -8,9 +8,9 @@ public interface ChangeContext {
 
     boolean isEnabled(Feature feature);
 
-    Entity getEntity(EntityChange entityChange);
+    CurrentEntityState getEntity(EntityChange entityChange);
 
-    void addEntity(EntityChange change, Entity currentState);
+    void addEntity(EntityChange change, CurrentEntityState currentState);
 
     void addValidationError(EntityChange<? extends EntityType<?>> entityChange, ValidationError error);
 

--- a/main/src/main/java/com/kenshoo/pl/entity/ChangeContextImpl.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/ChangeContextImpl.java
@@ -16,7 +16,7 @@ import static org.jooq.lambda.Seq.seq;
 public class ChangeContextImpl implements ChangeContext {
 
     private final Multimap<EntityChange, ValidationError> validationErrors = HashMultimap.create();
-    private final Map<EntityChange, Entity> entities = new IdentityHashMap<>();
+    private final Map<EntityChange, CurrentEntityState> entities = new IdentityHashMap<>();
     private final PersistentLayerStats stats = new PersistentLayerStats();
     private final Set<FieldFetchRequest> fieldsToFetchRequests = Sets.newHashSet();
     private final Hierarchy hierarchy;
@@ -33,12 +33,12 @@ public class ChangeContextImpl implements ChangeContext {
     }
 
     @Override
-    public Entity getEntity(EntityChange entityChange) {
+    public CurrentEntityState getEntity(EntityChange entityChange) {
         return entities.get(entityChange);
     }
 
     @Override
-    public void addEntity(EntityChange change, Entity currentState) {
+    public void addEntity(EntityChange change, CurrentEntityState currentState) {
         this.entities.put(change, currentState);
     }
 

--- a/main/src/main/java/com/kenshoo/pl/entity/ChangeEntityCommand.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/ChangeEntityCommand.java
@@ -81,7 +81,7 @@ abstract public class ChangeEntityCommand<E extends EntityType<E>> implements Mu
             }
 
             @Override
-            public T supply(Entity currentState) throws ValidationException {
+            public T supply(CurrentEntityState currentState) throws ValidationException {
                 FieldsValueMap<E> result = delegatingSupplier.supply(currentState);
                 if (result.containsField(entityField)) {
                     return result.get(entityField);
@@ -149,7 +149,7 @@ abstract public class ChangeEntityCommand<E extends EntityType<E>> implements Mu
         values.remove(field);
     }
 
-    void resolveSuppliers(Entity currentState) throws ValidationException {
+    void resolveSuppliers(CurrentEntityState currentState) throws ValidationException {
         // HashMap creates keySet/entrySet on demand so if the map is empty, calling these method implicitly increases its
         // memory consumption. Since in many cases the suppliers HashMap is empty, we can short-circuit this.
         if (suppliers.isEmpty()) {

--- a/main/src/main/java/com/kenshoo/pl/entity/CurrentEntityMutableState.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/CurrentEntityMutableState.java
@@ -1,0 +1,46 @@
+package com.kenshoo.pl.entity;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.emptyList;
+
+
+public class CurrentEntityMutableState implements CurrentEntityState {
+
+    private final Map<EntityField<?, ?>, Object> fields = new HashMap<>();
+    private Map<EntityType, List<FieldsValueMap>> manyByType;
+
+    public boolean containsField(EntityField<?, ?> field) {
+        return fields.containsKey(field);
+    }
+
+    @Override
+    public <T> T get(EntityField<?, T> field) {
+        //noinspection unchecked
+        T value = (T) fields.get(field);
+        if (value == null && !fields.containsKey(field)) {
+            throw new IllegalArgumentException("Field " + field + " of entity \"" + field.getEntityType().getName() + "\" is not fetched");
+        }
+        return value;
+    }
+
+    @Override
+    public <E extends EntityType<E>> List<FieldsValueMap<E>> getMany(E type) {
+        return manyByType == null ? emptyList() : (List) manyByType.get(type);
+    }
+
+    public <T> void set(EntityField<?, T> field, T value) {
+        fields.put(field, value);
+    }
+
+    synchronized
+    public <E extends EntityType<E>> void add(E entityType, List<FieldsValueMap<E>> fieldsValueMaps) {
+        if (manyByType == null) {
+            manyByType = new HashMap<>();
+        }
+        manyByType.put(entityType, (List) fieldsValueMaps);
+    }
+
+}

--- a/main/src/main/java/com/kenshoo/pl/entity/CurrentEntityState.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/CurrentEntityState.java
@@ -1,4 +1,4 @@
-package com.kenshoo.pl.entity.internal;
+package com.kenshoo.pl.entity;
 
 import com.kenshoo.pl.entity.Entity;
 import com.kenshoo.pl.entity.EntityField;
@@ -11,7 +11,19 @@ import java.util.Map;
 import static java.util.Collections.emptyList;
 
 
-public class EntityImpl implements Entity {
+public class CurrentEntityState implements Entity {
+
+    public final  static CurrentEntityState EMPTY = new CurrentEntityState() {
+        @Override
+        public boolean containsField(EntityField<?, ?> field) {
+            return false;
+        }
+
+        @Override
+        public <T> T get(EntityField<?, T> field) {
+            return null;
+        }
+    };
 
     private final Map<EntityField<?, ?>, Object> fields = new HashMap<>();
     private Map<EntityType, List<FieldsValueMap>> manyByType;

--- a/main/src/main/java/com/kenshoo/pl/entity/CurrentEntityState.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/CurrentEntityState.java
@@ -1,19 +1,8 @@
 package com.kenshoo.pl.entity;
 
-import com.kenshoo.pl.entity.Entity;
-import com.kenshoo.pl.entity.EntityField;
-import com.kenshoo.pl.entity.EntityType;
-import com.kenshoo.pl.entity.FieldsValueMap;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+public interface CurrentEntityState extends Entity {
 
-import static java.util.Collections.emptyList;
-
-
-public class CurrentEntityState implements Entity {
-
-    public final  static CurrentEntityState EMPTY = new CurrentEntityState() {
+    CurrentEntityState EMPTY = new CurrentEntityState() {
         @Override
         public boolean containsField(EntityField<?, ?> field) {
             return false;
@@ -24,39 +13,5 @@ public class CurrentEntityState implements Entity {
             return null;
         }
     };
-
-    private final Map<EntityField<?, ?>, Object> fields = new HashMap<>();
-    private Map<EntityType, List<FieldsValueMap>> manyByType;
-
-    public boolean containsField(EntityField<?, ?> field) {
-        return fields.containsKey(field);
-    }
-
-    @Override
-    public <T> T get(EntityField<?, T> field) {
-        //noinspection unchecked
-        T value = (T) fields.get(field);
-        if (value == null && !fields.containsKey(field)) {
-            throw new IllegalArgumentException("Field " + field + " of entity \"" + field.getEntityType().getName() + "\" is not fetched");
-        }
-        return value;
-    }
-
-    @Override
-    public <E extends EntityType<E>> List<FieldsValueMap<E>> getMany(E type) {
-        return manyByType == null ? emptyList() : (List) manyByType.get(type);
-    }
-
-    public <T> void set(EntityField<?, T> field, T value) {
-        fields.put(field, value);
-    }
-
-    synchronized
-    public <E extends EntityType<E>> void add(E entityType, List<FieldsValueMap<E>> fieldsValueMaps) {
-        if (manyByType == null) {
-            manyByType = new HashMap<>();
-        }
-        manyByType.put(entityType, (List) fieldsValueMaps);
-    }
 
 }

--- a/main/src/main/java/com/kenshoo/pl/entity/Entity.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/Entity.java
@@ -6,18 +6,6 @@ import static java.util.Collections.emptyList;
 
 public interface Entity {
 
-    Entity EMPTY = new Entity() {
-        @Override
-        public boolean containsField(EntityField<?, ?> field) {
-            return false;
-        }
-
-        @Override
-        public <T> T get(EntityField<?, T> field) {
-            return null;
-        }
-    };
-
     boolean containsField(EntityField<?, ?> field);
 
     <T> T get(EntityField<?, T> field);
@@ -35,10 +23,6 @@ public interface Entity {
     }
 
     default <E extends EntityType<E>> List<FieldsValueMap<E>> getMany(E type) {
-        return emptyList();
-    }
-
-    default <E extends EntityType<E>> List<FieldsValueMap<E>> finalChildrenState(EntityChange<E> entityChange, E type) {
         return emptyList();
     }
 

--- a/main/src/main/java/com/kenshoo/pl/entity/EntityPersistence.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/EntityPersistence.java
@@ -33,7 +33,7 @@ public interface EntityPersistence<E extends EntityType<E>, PK extends Identifie
 
     <ID extends Identifier<E>> InsertOnDuplicateUpdateResult<E, ID> customInsertOnDuplicateUpdate(List<? extends InsertOnDuplicateUpdateCommand<E, ID>> commands, Function<ChangeFlowConfig.Builder<E>, ChangeFlowConfig.Builder<E>> flowConfigModifier);
 
-    <UKV extends UniqueKeyValue<E>> Map<UKV, Entity> fetchEntities(Collection<UKV> keys, Collection<EntityField<?, ?>> fieldsToFetch);
+    <UKV extends UniqueKeyValue<E>> Map<UKV, CurrentEntityState> fetchEntities(Collection<UKV> keys, Collection<EntityField<?, ?>> fieldsToFetch);
 
     <UKV extends UniqueKeyValue<E>, PE extends PartialEntity> Map<UKV, PE> fetchByKeys(Collection<UKV> keys, final Class<PE> entityIface);
 

--- a/main/src/main/java/com/kenshoo/pl/entity/FetchFinalStep.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/FetchFinalStep.java
@@ -10,12 +10,12 @@ public interface FetchFinalStep {
      *
      * @return the result entities
      */
-    List<Entity> fetch();
+    List<CurrentEntityState> fetch();
 
     /**
      * Finish building the query and fetch the results from the DB
      * @param keys the keys to fetch
      * @return the result entities
      */
-    List<Entity> fetchByKeys(Collection<? extends Identifier<?>> keys);
+    List<CurrentEntityState> fetchByKeys(Collection<? extends Identifier<?>> keys);
 }

--- a/main/src/main/java/com/kenshoo/pl/entity/FluentEntitiesFetcher.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/FluentEntitiesFetcher.java
@@ -2,11 +2,8 @@ package com.kenshoo.pl.entity;
 
 import com.kenshoo.pl.entity.internal.EntitiesFetcher;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
 
@@ -34,11 +31,11 @@ class FluentEntitiesFetcher implements FetchFromStep, FetchWhereStep, FetchFinal
         return this;
     }
 
-    public List<Entity> fetch() {
+    public List<CurrentEntityState> fetch() {
         return entitiesFetcher.fetch(entityType, condition, fieldsToFetch);
     }
 
-    public List<Entity> fetchByKeys(Collection<? extends Identifier<?>> keys) {
+    public List<CurrentEntityState> fetchByKeys(Collection<? extends Identifier<?>> keys) {
         return entitiesFetcher.fetch(entityType, keys, condition, fieldsToFetch);
     }
 }

--- a/main/src/main/java/com/kenshoo/pl/entity/OverridingContext.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/OverridingContext.java
@@ -10,7 +10,7 @@ import static java.util.Optional.ofNullable;
 public class OverridingContext implements ChangeContext {
 
     private final ChangeContext original;
-    private final Map<EntityChange, Entity> overrides = new IdentityHashMap<>();
+    private final Map<EntityChange, CurrentEntityState> overrides = new IdentityHashMap<>();
 
     public OverridingContext(ChangeContext original) {
         this.original = original;
@@ -22,13 +22,13 @@ public class OverridingContext implements ChangeContext {
     }
 
     @Override
-    public Entity getEntity(EntityChange entityChange) {
+    public CurrentEntityState getEntity(EntityChange entityChange) {
         return ofNullable(overrides.get(entityChange))
                 .orElseGet(() -> original.getEntity(entityChange));
     }
 
     @Override
-    public void addEntity(EntityChange change, Entity currentState) {
+    public void addEntity(EntityChange change, CurrentEntityState currentState) {
         overrides.put(change, new OverridingEntity(currentState, original.getEntity(change)));
     }
 
@@ -72,13 +72,13 @@ public class OverridingContext implements ChangeContext {
         return original.getHierarchy();
     }
 
-    private static class OverridingEntity implements Entity {
+    private static class OverridingEntity extends CurrentEntityState {
 
-        private final Entity overriding;
-        private final Entity original;
+        private final CurrentEntityState overriding;
+        private final CurrentEntityState original;
 
 
-        private OverridingEntity(Entity overriding, Entity original) {
+        private OverridingEntity(CurrentEntityState overriding, CurrentEntityState original) {
             this.overriding = overriding;
             this.original = original;
         }

--- a/main/src/main/java/com/kenshoo/pl/entity/OverridingContext.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/OverridingContext.java
@@ -72,7 +72,7 @@ public class OverridingContext implements ChangeContext {
         return original.getHierarchy();
     }
 
-    private static class OverridingEntity extends CurrentEntityState {
+    private static class OverridingEntity implements CurrentEntityState {
 
         private final CurrentEntityState overriding;
         private final CurrentEntityState original;

--- a/main/src/main/java/com/kenshoo/pl/entity/PersistenceLayer.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/PersistenceLayer.java
@@ -170,7 +170,7 @@ public class PersistenceLayer<ROOT extends EntityType<ROOT>> {
     }
 
     private boolean isMissing(ChangeEntityCommand<?> cmd, ChangeContext context) {
-        return context.getEntity(cmd) == Entity.EMPTY;
+        return context.getEntity(cmd) == CurrentEntityState.EMPTY;
     }
 
     private <E extends EntityType<E>> Collection<EntityChange<E>> prepareOneLayer(Collection<? extends ChangeEntityCommand<E>> commands, ChangeOperation changeOperation, ChangeContext changeContext, ChangeFlowConfig<E> flowConfig) {
@@ -209,7 +209,7 @@ public class PersistenceLayer<ROOT extends EntityType<ROOT>> {
         List<C> validCommands = Lists.newArrayListWithCapacity(commands.size());
 
         for (C command : commands) {
-            Entity currentState = changeContext.getEntity(command);
+            CurrentEntityState currentState = changeContext.getEntity(command);
             try {
                 command.resolveSuppliers(currentState);
                 validCommands.add(command);
@@ -278,7 +278,7 @@ public class PersistenceLayer<ROOT extends EntityType<ROOT>> {
     }
 
     private void populateIdentityField(final ChangeEntityCommand<ROOT> cmd, final ChangeContext changeContext, final EntityField<ROOT, Object> idField) {
-        final Entity currentState = Optional.ofNullable(changeContext.getEntity(cmd))
+        final CurrentEntityState currentState = Optional.ofNullable(changeContext.getEntity(cmd))
                                       .orElseThrow(() -> new IllegalStateException("Could not find entity of command in the change context"));
         cmd.set(idField,  currentState.get(idField));
     }

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/EntitiesFetcher.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/EntitiesFetcher.java
@@ -126,7 +126,7 @@ public class EntitiesFetcher {
             Map<Identifier<E>, List<FieldsValueMap<SUB>>> multiValuesMap = fetchMultiValuesMap(queryExtender.getQuery(), aliasedKey, plan.getFields());
             multiValuesMap.forEach((Identifier<E> id, List<FieldsValueMap<SUB>> multiValues) -> {
                 final SUB subEntityType = entityTypeOf(plan.getFields());
-                ((CurrentEntityState) entities.get(id)).add(subEntityType, multiValues);
+                ((CurrentEntityMutableState) entities.get(id)).add(subEntityType, multiValues);
             });
         }
     }

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/EntitiesFetcher.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/EntitiesFetcher.java
@@ -36,13 +36,13 @@ public class EntitiesFetcher {
         this.oldEntityFetcher = new OldEntityFetcher(dslContext);
     }
 
-    public <E extends EntityType<E>> Map<Identifier<E>, Entity> fetchEntitiesByIds(final Collection<? extends Identifier<E>> ids,
-                                                                                   final EntityField<?, ?>... fieldsToFetchArgs) {
+    public <E extends EntityType<E>> Map<Identifier<E>, CurrentEntityState> fetchEntitiesByIds(final Collection<? extends Identifier<E>> ids,
+                                                                                               final EntityField<?, ?>... fieldsToFetchArgs) {
         return fetchEntitiesByIds(ids, ImmutableList.copyOf(fieldsToFetchArgs));
     }
 
-    public <E extends EntityType<E>> Map<Identifier<E>, Entity> fetchEntitiesByIds(final Collection<? extends Identifier<E>> ids,
-                                                                                   final Collection<? extends EntityField<?, ?>> fieldsToFetch) {
+    public <E extends EntityType<E>> Map<Identifier<E>, CurrentEntityState> fetchEntitiesByIds(final Collection<? extends Identifier<E>> ids,
+                                                                                               final Collection<? extends EntityField<?, ?>> fieldsToFetch) {
         if (!features.isEnabled(FetchMany)) {
             return oldEntityFetcher.fetchEntitiesByIds(ids, fieldsToFetch);
         }
@@ -57,20 +57,20 @@ public class EntitiesFetcher {
         return fetchEntities(uniqueKey.getEntityType().getPrimaryTable(), aliasedKey, fieldsToFetch, query -> query.whereIdsIn(ids));
     }
 
-    public List<Entity> fetch(final EntityType<?> entityType,
-                              final PLCondition plCondition,
-                              final EntityField<?, ?>... fieldsToFetch) {
+    public List<CurrentEntityState> fetch(final EntityType<?> entityType,
+                                          final PLCondition plCondition,
+                                          final EntityField<?, ?>... fieldsToFetch) {
         return oldEntityFetcher.fetch(entityType, plCondition, fieldsToFetch);
     }
 
-    public List<Entity> fetch(final EntityType<?> entityType,
-                              final Collection<? extends Identifier<?>> ids,
-                              final PLCondition plCondition,
-                              final EntityField<?, ?>... fieldsToFetch) {
+    public List<CurrentEntityState> fetch(final EntityType<?> entityType,
+                                          final Collection<? extends Identifier<?>> ids,
+                                          final PLCondition plCondition,
+                                          final EntityField<?, ?>... fieldsToFetch) {
         return oldEntityFetcher.fetch(entityType, ids, plCondition, fieldsToFetch);
     }
 
-    public <E extends EntityType<E>> Map<Identifier<E>, Entity> fetchEntitiesByForeignKeys(E entityType, UniqueKey<E> foreignUniqueKey, Collection<? extends Identifier<E>> keys, Collection<EntityField<?, ?>> fieldsToFetch) {
+    public <E extends EntityType<E>> Map<Identifier<E>, CurrentEntityState> fetchEntitiesByForeignKeys(E entityType, UniqueKey<E> foreignUniqueKey, Collection<? extends Identifier<E>> keys, Collection<EntityField<?, ?>> fieldsToFetch) {
         if (!features.isEnabled(FetchMany)) {
             return oldEntityFetcher.fetchEntitiesByForeignKeys(entityType, foreignUniqueKey, keys, fieldsToFetch);
         }
@@ -84,7 +84,7 @@ public class EntitiesFetcher {
         }
     }
 
-    private <E extends EntityType<E>> Map<Identifier<E>, Entity> fetchEntities(
+    private <E extends EntityType<E>> Map<Identifier<E>, CurrentEntityState> fetchEntities(
             final DataTable startingTable,
             final AliasedKey<E> aliasedKey,
             final Collection<? extends EntityField<?, ?>> fieldsToFetch,
@@ -99,7 +99,7 @@ public class EntitiesFetcher {
                 .leftJoin(oneToOnePlan.getSecondaryTableRelations());
         queryModifier.accept(mainQueryBuilder);
 
-        final Map<Identifier<E>, Entity> entities = fetchMainEntities(aliasedKey, oneToOnePlan, mainQueryBuilder);
+        final Map<Identifier<E>, CurrentEntityState> entities = fetchMainEntities(aliasedKey, oneToOnePlan, mainQueryBuilder);
 
         executionPlan.getManyToOnePlans().forEach(plan -> {
             final QueryBuilder<E> subQueryBuilder = new QueryBuilder<E>(dslContext).selecting(selectFieldsOf(plan.getFields(), aliasedKey))
@@ -121,23 +121,23 @@ public class EntitiesFetcher {
         return oldEntityFetcher.fetchByCondition(entityType, condition, entityIface);
     }
 
-    private <E extends EntityType<E>, SUB extends EntityType<SUB>> void fetchAndPopulateSubEntities(AliasedKey<E> aliasedKey, Map<Identifier<E>, Entity> entities, ExecutionPlan.ManyToOnePlan<SUB> plan, QueryBuilder<E> queryBuilder) {
+    private <E extends EntityType<E>, SUB extends EntityType<SUB>> void fetchAndPopulateSubEntities(AliasedKey<E> aliasedKey, Map<Identifier<E>, CurrentEntityState> entities, ExecutionPlan.ManyToOnePlan<SUB> plan, QueryBuilder<E> queryBuilder) {
         try (QueryExtension<SelectJoinStep<Record>> queryExtender = queryBuilder.build()) {
             Map<Identifier<E>, List<FieldsValueMap<SUB>>> multiValuesMap = fetchMultiValuesMap(queryExtender.getQuery(), aliasedKey, plan.getFields());
             multiValuesMap.forEach((Identifier<E> id, List<FieldsValueMap<SUB>> multiValues) -> {
                 final SUB subEntityType = entityTypeOf(plan.getFields());
-                ((EntityImpl) entities.get(id)).add(subEntityType, multiValues);
+                ((CurrentEntityState) entities.get(id)).add(subEntityType, multiValues);
             });
         }
     }
 
-    private <E extends EntityType<E>> Map<Identifier<E>, Entity> fetchMainEntities(AliasedKey<E> aliasedKey, ExecutionPlan.OneToOnePlan oneToOnePlan, QueryBuilder<E> queryBuilder) {
+    private <E extends EntityType<E>> Map<Identifier<E>, CurrentEntityState> fetchMainEntities(AliasedKey<E> aliasedKey, ExecutionPlan.OneToOnePlan oneToOnePlan, QueryBuilder<E> queryBuilder) {
         try (QueryExtension<SelectJoinStep<Record>> queryExtender = queryBuilder.build()) {
             return fetchEntitiesMap(queryExtender.getQuery(), aliasedKey, oneToOnePlan.getFields());
         }
     }
 
-    private <E extends EntityType<E>> Map<Identifier<E>, Entity> fetchEntitiesMap(ResultQuery<Record> query, AliasedKey<E> aliasedKey, List<? extends EntityField<?, ?>> fields) {
+    private <E extends EntityType<E>> Map<Identifier<E>, CurrentEntityState> fetchEntitiesMap(ResultQuery<Record> query, AliasedKey<E> aliasedKey, List<? extends EntityField<?, ?>> fields) {
         return query.fetchMap(record -> RecordReader.createKey(record, aliasedKey), record -> RecordReader.createEntity(record, fields));
     }
 

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/EntitiesToContextFetcher.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/EntitiesToContextFetcher.java
@@ -62,7 +62,7 @@ public class EntitiesToContextFetcher {
             ChangeEntityCommand<E> cmd) {
 
         final ChangeEntityCommand ancestor = getAncestor(cmd, parentLevel);
-        final CurrentEntityState currentState = (CurrentEntityState)context.getEntity(cmd);
+        final CurrentEntityMutableState currentState = (CurrentEntityMutableState)context.getEntity(cmd);
         seq(parentFields).forEach(field ->  currentState.set(field, getValue(context, ancestor, field)));
     }
 
@@ -106,7 +106,7 @@ public class EntitiesToContextFetcher {
         E entityType = flowConfig.getEntityType();
         Collection<EntityField<E, ?>> foreignKeys = entityType.determineForeignKeys(flowConfig.getRequiredRelationFields()).filter(not(new IsFieldReferringToParent<>(context.getHierarchy(), entityType))).collect(toList());
         if (foreignKeys.isEmpty()) {
-            CurrentEntityState sharedEntity = new CurrentEntityState();
+            CurrentEntityState sharedEntity = new CurrentEntityMutableState();
             commands.forEach(cmd -> context.addEntity(cmd, sharedEntity));
         } else {
             final UniqueKey<E> foreignUniqueKey = new ForeignUniqueKey<>(foreignKeys);

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/EntitiesToContextFetcher.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/EntitiesToContextFetcher.java
@@ -24,7 +24,7 @@ public class EntitiesToContextFetcher {
 
     public <E extends EntityType<E>> void fetchEntities(Collection<? extends ChangeEntityCommand<E>> commands, ChangeOperation changeOperation, ChangeContext context, ChangeFlowConfig<E> flow) {
 
-        commands.forEach(c -> context.addEntity(c, Entity.EMPTY));
+        commands.forEach(c -> context.addEntity(c, CurrentEntityState.EMPTY));
 
         final Set<EntityField<?, ?>> fieldsToFetch = context.getFetchRequests().stream().
                 filter( r -> r.getWhereToQuery().equals(flow.getEntityType()) && r.supports(changeOperation)).
@@ -62,7 +62,7 @@ public class EntitiesToContextFetcher {
             ChangeEntityCommand<E> cmd) {
 
         final ChangeEntityCommand ancestor = getAncestor(cmd, parentLevel);
-        final EntityImpl currentState = (EntityImpl)context.getEntity(cmd);
+        final CurrentEntityState currentState = (CurrentEntityState)context.getEntity(cmd);
         seq(parentFields).forEach(field ->  currentState.set(field, getValue(context, ancestor, field)));
     }
 
@@ -98,7 +98,7 @@ public class EntitiesToContextFetcher {
                 cmd -> concat(cmd.getIdentifier(), cmd.getKeysToParent())));
         //noinspection ConstantConditions
         UniqueKey<E> uniqueKey = keysByCommand.values().iterator().next().getUniqueKey();
-        Map<Identifier<E>, Entity> fetchedEntities = entitiesFetcher.fetchEntitiesByIds(keysByCommand.values(), fieldsToFetch);
+        Map<Identifier<E>, CurrentEntityState> fetchedEntities = entitiesFetcher.fetchEntitiesByIds(keysByCommand.values(), fieldsToFetch);
         addFetchedEntitiesToChangeContext(fetchedEntities, changeContext, keysByCommand);
     }
 
@@ -106,21 +106,21 @@ public class EntitiesToContextFetcher {
         E entityType = flowConfig.getEntityType();
         Collection<EntityField<E, ?>> foreignKeys = entityType.determineForeignKeys(flowConfig.getRequiredRelationFields()).filter(not(new IsFieldReferringToParent<>(context.getHierarchy(), entityType))).collect(toList());
         if (foreignKeys.isEmpty()) {
-            EntityImpl sharedEntity = new EntityImpl();
+            CurrentEntityState sharedEntity = new CurrentEntityState();
             commands.forEach(cmd -> context.addEntity(cmd, sharedEntity));
         } else {
             final UniqueKey<E> foreignUniqueKey = new ForeignUniqueKey<>(foreignKeys);
             Map<? extends ChangeEntityCommand<E>, Identifier<E>> keysByCommand = commands.stream().collect(toMap(identity(), foreignUniqueKey::createValue));
-            Map<Identifier<E>, Entity> fetchedEntities = entitiesFetcher.fetchEntitiesByForeignKeys(entityType, foreignUniqueKey, Sets.newHashSet(keysByCommand.values()), fieldsToFetch);
+            Map<Identifier<E>, CurrentEntityState> fetchedEntities = entitiesFetcher.fetchEntitiesByForeignKeys(entityType, foreignUniqueKey, Sets.newHashSet(keysByCommand.values()), fieldsToFetch);
             addFetchedEntitiesToChangeContext(fetchedEntities, context, keysByCommand);
         }
     }
 
-    private <E extends EntityType<E>> void addFetchedEntitiesToChangeContext(Map<Identifier<E>, Entity> fetchedEntities, ChangeContext changeContext, Map<? extends ChangeEntityCommand<E>, Identifier<E>> keysByCommand) {
+    private <E extends EntityType<E>> void addFetchedEntitiesToChangeContext(Map<Identifier<E>, CurrentEntityState> fetchedEntities, ChangeContext changeContext, Map<? extends ChangeEntityCommand<E>, Identifier<E>> keysByCommand) {
         for (Map.Entry<? extends ChangeEntityCommand<E>, Identifier<E>> entry : keysByCommand.entrySet()) {
             ChangeEntityCommand<E> command = entry.getKey();
             Identifier<E> identifier = entry.getValue();
-            Entity currentState = fetchedEntities.get(identifier);
+            CurrentEntityState currentState = fetchedEntities.get(identifier);
             if (currentState != null) {
                 changeContext.addEntity(command, currentState);
             }
@@ -128,6 +128,6 @@ public class EntitiesToContextFetcher {
     }
 
     private <E extends EntityType<E>> Predicate<ChangeEntityCommand<E>> notMissing(ChangeContext context) {
-        return cmd -> context.getEntity(cmd) != Entity.EMPTY;
+        return cmd -> context.getEntity(cmd) != CurrentEntityState.EMPTY;
     }
 }

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/EntityDbUtil.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/EntityDbUtil.java
@@ -1,7 +1,7 @@
 package com.kenshoo.pl.entity.internal;
 
 import com.kenshoo.pl.data.DatabaseId;
-import com.kenshoo.pl.entity.Entity;
+import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.EntityFieldDbAdapter;
 import com.kenshoo.pl.entity.EntityType;
@@ -45,8 +45,8 @@ public class EntityDbUtil {
         return getFieldValuesInner(fields, field -> getDbValues(fieldsValueMap, field, FieldsValueMap::get));
     }
 
-    public static <E extends EntityType<E>> Object[] getFieldValues(Collection<EntityField<E, ?>> fields, Entity currentState) {
-        return getFieldValuesInner(fields, field -> getDbValues(currentState, field, Entity::get));
+    public static <E extends EntityType<E>> Object[] getFieldValues(Collection<EntityField<E, ?>> fields, CurrentEntityState currentState) {
+        return getFieldValuesInner(fields, field -> getDbValues(currentState, field, CurrentEntityState::get));
     }
 
     private static <E extends EntityType<E>> Object[] getFieldValuesInner(Collection<EntityField<E, ?>> fields, Function<EntityField<E, ?>, Stream<?>> mapper) {

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/EntityIdExtractor.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/EntityIdExtractor.java
@@ -12,7 +12,7 @@ public class EntityIdExtractor {
     public static final EntityIdExtractor INSTANCE = new EntityIdExtractor();
 
     public <E extends EntityType<E>> Optional<String> extract(final EntityChange<E> entityChange,
-                                                              final Entity currentState) {
+                                                              final CurrentEntityState currentState) {
         requireNonNull(entityChange, "entityChange is required");
         requireNonNull(currentState, "entity is required");
 
@@ -22,7 +22,7 @@ public class EntityIdExtractor {
     }
 
     private <E extends EntityType<E>, T> Optional<String> extract(final EntityChange<E> entityChange,
-                                                                  final Entity currentState,
+                                                                  final CurrentEntityState currentState,
                                                                   final EntityField<E, T> idField) {
 
         return firstFilled(() -> entityChange.safeGet(idField),

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/EntityIdExtractor.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/EntityIdExtractor.java
@@ -14,7 +14,7 @@ public class EntityIdExtractor {
     public <E extends EntityType<E>> Optional<String> extract(final EntityChange<E> entityChange,
                                                               final CurrentEntityState currentState) {
         requireNonNull(entityChange, "entityChange is required");
-        requireNonNull(currentState, "entity is required");
+        requireNonNull(currentState, "currentState is required");
 
         return entityChange.getEntityType()
                            .getIdField()

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/EntityWithGeneratedId.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/EntityWithGeneratedId.java
@@ -3,7 +3,7 @@ package com.kenshoo.pl.entity.internal;
 import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.EntityField;
 
-public class EntityWithGeneratedId extends CurrentEntityState {
+public class EntityWithGeneratedId implements CurrentEntityState {
 
     private final EntityField<?, Object> idField;
     private final Object idValue;

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/EntityWithGeneratedId.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/EntityWithGeneratedId.java
@@ -1,9 +1,9 @@
 package com.kenshoo.pl.entity.internal;
 
-import com.kenshoo.pl.entity.Entity;
+import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.EntityField;
 
-public class EntityWithGeneratedId implements Entity {
+public class EntityWithGeneratedId extends CurrentEntityState {
 
     private final EntityField<?, Object> idField;
     private final Object idValue;

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/FalseUpdatesPurger.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/FalseUpdatesPurger.java
@@ -4,7 +4,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.kenshoo.pl.entity.ChangeContext;
 import com.kenshoo.pl.entity.ChangeEntityCommand;
 import com.kenshoo.pl.entity.ChangeOperation;
-import com.kenshoo.pl.entity.Entity;
+import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.EntityType;
 import com.kenshoo.pl.entity.FieldChange;
@@ -45,7 +45,7 @@ public class FalseUpdatesPurger<E extends EntityType<E>> implements PostFetchCom
     @Override
     public void enrich(Collection<? extends ChangeEntityCommand<E>> commands, ChangeOperation changeOperation, ChangeContext changeContext) {
         commands.forEach(command -> {
-            Entity currentState = changeContext.getEntity(command);
+            CurrentEntityState currentState = changeContext.getEntity(command);
             // Collect the fields first to avoid modification of command's inner collection while traversing
             List<FieldChange<E, ?>> unchangedFields = command.getChanges()
                     .filter(fieldChange -> areEqual(currentState, fieldChange))
@@ -69,7 +69,7 @@ public class FalseUpdatesPurger<E extends EntityType<E>> implements PostFetchCom
         return SupportedChangeOperation.UPDATE;
     }
 
-    private <T> boolean areEqual(Entity currentState, FieldChange<E, T> fieldChange) {
+    private <T> boolean areEqual(CurrentEntityState currentState, FieldChange<E, T> fieldChange) {
         if (!currentState.containsField(fieldChange.getField())) {
             return false;
         }

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/LazyDelegatingMultiSupplier.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/LazyDelegatingMultiSupplier.java
@@ -1,7 +1,7 @@
 package com.kenshoo.pl.entity.internal;
 
 import com.kenshoo.pl.entity.ChangeOperation;
-import com.kenshoo.pl.entity.Entity;
+import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.EntityType;
 import com.kenshoo.pl.entity.FieldsValueMap;
@@ -23,7 +23,7 @@ public class LazyDelegatingMultiSupplier<E extends EntityType<E>> implements Mul
     }
 
     @Override
-    public FieldsValueMap<E> supply(Entity currentState) throws ValidationException {
+    public FieldsValueMap<E> supply(CurrentEntityState currentState) throws ValidationException {
         if (suppliedMap == null) {
             suppliedMap = multiSupplier.supply(currentState);
         }

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/MissingEntitiesFilter.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/MissingEntitiesFilter.java
@@ -4,7 +4,7 @@ import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableMap;
 import com.kenshoo.pl.entity.ChangeContext;
 import com.kenshoo.pl.entity.ChangeOperation;
-import com.kenshoo.pl.entity.Entity;
+import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.EntityChange;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.EntityType;
@@ -25,8 +25,8 @@ public class MissingEntitiesFilter<E extends EntityType<E>> implements ChangesFi
     @Override
     public <T extends EntityChange<E>> Collection<T> filter(Collection<T> changes, ChangeOperation changeOperation, ChangeContext changeContext) {
         return Collections2.filter(changes, command -> {
-                    Entity currentState = changeContext.getEntity(command);
-                    if (currentState == Entity.EMPTY) {
+                    CurrentEntityState currentState = changeContext.getEntity(command);
+                    if (currentState == CurrentEntityState.EMPTY) {
                         if(!command.allowMissingEntity()) {
                             changeContext.addValidationError(command, new ValidationError(Errors.ENTITY_NOT_FOUND, ImmutableMap.of("id", command.getIdentifier().toString())));
                         }

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/MissingParentEntitiesFilter.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/MissingParentEntitiesFilter.java
@@ -3,7 +3,7 @@ package com.kenshoo.pl.entity.internal;
 import com.google.common.collect.Collections2;
 import com.kenshoo.pl.entity.ChangeContext;
 import com.kenshoo.pl.entity.ChangeOperation;
-import com.kenshoo.pl.entity.Entity;
+import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.EntityChange;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.EntityType;
@@ -27,8 +27,8 @@ public class MissingParentEntitiesFilter<E extends EntityType<E>> implements Cha
             return changes;
         }
         return Collections2.filter(changes, command -> {
-                    Entity currentState = changeContext.getEntity(command);
-                    if (currentState == Entity.EMPTY) {
+                    CurrentEntityState currentState = changeContext.getEntity(command);
+                    if (currentState == CurrentEntityState.EMPTY) {
                         changeContext.addValidationError(command, new ValidationError(Errors.PARENT_ENTITY_NOT_FOUND));
                         return false;
                     }

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/OverrideFieldsCombination.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/OverrideFieldsCombination.java
@@ -1,6 +1,6 @@
 package com.kenshoo.pl.entity.internal;
 
-import com.kenshoo.pl.entity.Entity;
+import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.EntityType;
 import com.kenshoo.pl.entity.FieldsValueMap;
@@ -12,9 +12,9 @@ public class OverrideFieldsCombination<E extends EntityType<E>> implements Field
 
     private final FieldsValueMap<E> fieldsValueMap;
     private final Map<EntityField<E,?>, FieldsCombinationValidator.Substitution<E, ?>> overrideFieldValueFunctions;
-    private final Entity currentState;
+    private final CurrentEntityState currentState;
 
-    public OverrideFieldsCombination(Entity currentState, FieldsValueMap<E> fieldsValueMap, Map<EntityField<E, ?>, FieldsCombinationValidator.Substitution<E, ?>> overrideFieldValueFunctions) {
+    public OverrideFieldsCombination(CurrentEntityState currentState, FieldsValueMap<E> fieldsValueMap, Map<EntityField<E, ?>, FieldsCombinationValidator.Substitution<E, ?>> overrideFieldValueFunctions) {
         this.currentState = currentState;
         this.fieldsValueMap = fieldsValueMap;
         this.overrideFieldValueFunctions = overrideFieldValueFunctions;

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/PartialEntityInvocationHandler.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/PartialEntityInvocationHandler.java
@@ -1,6 +1,6 @@
 package com.kenshoo.pl.entity.internal;
 
-import com.kenshoo.pl.entity.Entity;
+import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.EntityType;
 
@@ -11,9 +11,9 @@ import java.util.Map;
 public class PartialEntityInvocationHandler<E extends EntityType<E>> implements InvocationHandler {
 
     private final Map<Method, EntityField<E, ?>> methodsMap;
-    private final Entity currentState;
+    private final CurrentEntityState currentState;
 
-    public PartialEntityInvocationHandler(Map<Method, EntityField<E, ?>> methodsMap, Entity currentState) {
+    public PartialEntityInvocationHandler(Map<Method, EntityField<E, ?>> methodsMap, CurrentEntityState currentState) {
         this.methodsMap = methodsMap;
         this.currentState = currentState;
     }

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/ResultingFieldsCombination.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/ResultingFieldsCombination.java
@@ -1,7 +1,7 @@
 package com.kenshoo.pl.entity.internal;
 
 import com.kenshoo.pl.entity.ChangeOperation;
-import com.kenshoo.pl.entity.Entity;
+import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.EntityChange;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.EntityType;
@@ -14,11 +14,11 @@ import static java.util.stream.Collectors.toSet;
 
 public class ResultingFieldsCombination<E extends EntityType<E>> implements FieldsValueMap<E> {
     private final EntityChange<E> entityChange;
-    private final Entity currentState;
+    private final CurrentEntityState currentState;
     private final Collection<EntityField<E, ?>> fields;
     private final ChangeOperation changeOperation;
 
-    public ResultingFieldsCombination(EntityChange<E> entityChange, Entity currentState, Stream<EntityField<E, ?>> fields, ChangeOperation changeOperation) {
+    public ResultingFieldsCombination(EntityChange<E> entityChange, CurrentEntityState currentState, Stream<EntityField<E, ?>> fields, ChangeOperation changeOperation) {
         this.entityChange = entityChange;
         this.currentState = currentState;
         this.fields = fields.collect(toSet());

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/SingleFieldEnricher.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/SingleFieldEnricher.java
@@ -31,13 +31,13 @@ abstract public class SingleFieldEnricher<E extends EntityType<E>, T> implements
 
     abstract protected EntityField<E, T> enrichedField();
 
-    abstract protected T enrichedValue(EntityChange<E> entityChange, Entity currentState);
+    abstract protected T enrichedValue(EntityChange<E> entityChange, CurrentEntityState currentState);
 
     protected Predicate<EntityChange<E>> additionalCommandFilter() {
         return entityChange -> true;
     }
 
-    protected BiPredicate<EntityChange<E>, Entity> additionalPostFetchCommandFilter() {
+    protected BiPredicate<EntityChange<E>, CurrentEntityState> additionalPostFetchCommandFilter() {
         return (entityChange, currentState) -> true;
     }
 

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGenerator.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGenerator.java
@@ -58,7 +58,7 @@ public class AuditRecordGenerator<E extends EntityType<E>> implements CurrentSta
                                          final CurrentEntityState currentState,
                                          final Collection<? extends AuditRecord<?>> childRecords) {
         requireNonNull(entityChange, "entityChange is required");
-        requireNonNull(currentState, "entity is required");
+        requireNonNull(currentState, "currentState is required");
 
         final String entityId = extractEntityId(entityChange, currentState);
 
@@ -103,7 +103,7 @@ public class AuditRecordGenerator<E extends EntityType<E>> implements CurrentSta
                                    final CurrentEntityState currentState) {
         return entityIdExtractor.extract(entityChange, currentState)
                                 .orElseThrow(() -> new IllegalStateException("Could not extract the entity id for entity type '" + entityChange.getEntityType() + "' " +
-                                                                                 "from either the EntityChange or the Entity, so the audit record cannot be generated."));
+                                                                                 "from either the EntityChange or the CurrentEntityState, so the audit record cannot be generated."));
     }
 
     private Collection<? extends EntityFieldValue> generateMandatoryFieldValues(final CurrentEntityState currentState) {

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGenerator.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGenerator.java
@@ -42,7 +42,7 @@ public class AuditRecordGenerator<E extends EntityType<E>> implements CurrentSta
     }
 
     public Optional<? extends AuditRecord<E>> generate(final EntityChange<E> entityChange,
-                                                       final Entity currentState,
+                                                       final CurrentEntityState currentState,
                                                        final Collection<? extends AuditRecord<?>> childRecords) {
         final AuditRecord<E> auditRecord = generateInner(entityChange,
                                                          currentState,
@@ -55,7 +55,7 @@ public class AuditRecordGenerator<E extends EntityType<E>> implements CurrentSta
     }
 
     private AuditRecord<E> generateInner(final EntityChange<E> entityChange,
-                                         final Entity currentState,
+                                         final CurrentEntityState currentState,
                                          final Collection<? extends AuditRecord<?>> childRecords) {
         requireNonNull(entityChange, "entityChange is required");
         requireNonNull(currentState, "entity is required");
@@ -82,7 +82,7 @@ public class AuditRecordGenerator<E extends EntityType<E>> implements CurrentSta
     }
 
     private Collection<? extends FieldAuditRecord<E>> generateFieldRecords(final EntityChange<E> entityChange,
-                                                                           final Entity currentState,
+                                                                           final CurrentEntityState currentState,
                                                                            final Collection<? extends EntityField<E, ?>> candidateOnChangeFields) {
         return candidateOnChangeFields.stream()
                                       .filter(field -> fieldWasChanged(entityChange, currentState, field))
@@ -91,7 +91,7 @@ public class AuditRecordGenerator<E extends EntityType<E>> implements CurrentSta
     }
 
     private FieldAuditRecord<E> buildFieldRecord(final EntityChange<E> entityChange,
-                                                 final Entity currentState,
+                                                 final CurrentEntityState currentState,
                                                  final EntityField<E, ?> field) {
         final FieldAuditRecord.Builder<E> fieldRecordBuilder = FieldAuditRecord.builder(field);
          currentState.safeGet(field).ifFilled(fieldRecordBuilder::oldValue);
@@ -100,13 +100,13 @@ public class AuditRecordGenerator<E extends EntityType<E>> implements CurrentSta
     }
 
     private String extractEntityId(final EntityChange<E> entityChange,
-                                   final Entity currentState) {
+                                   final CurrentEntityState currentState) {
         return entityIdExtractor.extract(entityChange, currentState)
                                 .orElseThrow(() -> new IllegalStateException("Could not extract the entity id for entity type '" + entityChange.getEntityType() + "' " +
                                                                                  "from either the EntityChange or the Entity, so the audit record cannot be generated."));
     }
 
-    private Collection<? extends EntityFieldValue> generateMandatoryFieldValues(final Entity currentState) {
+    private Collection<? extends EntityFieldValue> generateMandatoryFieldValues(final CurrentEntityState currentState) {
         return auditedFieldSet.getExternalMandatoryFields().stream()
                               .map(field -> ImmutablePair.of(field,  currentState.safeGet(field)))
                               .filter(pair -> pair.getValue().isFilled())
@@ -115,19 +115,19 @@ public class AuditRecordGenerator<E extends EntityType<E>> implements CurrentSta
     }
 
     private boolean fieldWasChanged(final EntityChange<E> entityChange,
-                                    final Entity currentState,
+                                    final CurrentEntityState currentState,
                                     final EntityField<E, ?> field) {
         return !fieldStayedTheSame(entityChange, currentState, field);
     }
 
     private boolean fieldStayedTheSame(final EntityChange<E> entityChange,
-                                       final Entity currentState,
+                                       final CurrentEntityState currentState,
                                        final EntityField<E, ?> field) {
         return  currentState.containsField(field) && fieldValuesEqual(entityChange, currentState, field);
     }
 
     private <T> boolean fieldValuesEqual(final EntityChange<E> entityChange,
-                                         final Entity currentState,
+                                         final CurrentEntityState currentState,
                                          final EntityField<E, T> field) {
         return field.valuesEqual(entityChange.get(field),  currentState.get(field));
     }

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/fetch/OldEntityFetcher.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/fetch/OldEntityFetcher.java
@@ -134,7 +134,7 @@ public class OldEntityFetcher {
             condition = condition.and(fieldAndValue.getField().eq(fieldAndValue.getValue()));
         }
         List<CurrentEntityState> entities = query.where(condition).fetch(record -> {
-            CurrentEntityState currentState = new CurrentEntityState();
+            CurrentEntityMutableState currentState = new CurrentEntityMutableState();
             Iterator<Object> valuesIterator = record.intoList().iterator();
             for (EntityField<E, ?> field : fieldsToFetch) {
                 fieldFromRecordToEntity(currentState, field, valuesIterator);
@@ -227,7 +227,7 @@ public class OldEntityFetcher {
         );
     }
 
-    private <T> void fieldFromRecordToEntity(CurrentEntityState currentState, EntityField<?, T> field, Iterator<Object> valuesIterator) {
+    private <T> void fieldFromRecordToEntity(CurrentEntityMutableState currentState, EntityField<?, T> field, Iterator<Object> valuesIterator) {
          currentState.set(field, field.getDbAdapter().getFromRecord(valuesIterator));
     }
 
@@ -247,7 +247,7 @@ public class OldEntityFetcher {
     }
 
     private CurrentEntityState mapRecordToEntity(final Record record, final Collection<EntityField<?, ?>> fieldsToFetch) {
-        final CurrentEntityState currentState = new CurrentEntityState();
+        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
         final Iterator<Object> valuesIterator = record.intoList().iterator();
         fieldsToFetch.forEach( field -> fieldFromRecordToEntity(currentState, field, valuesIterator));
         return currentState;

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/fetch/OldEntityFetcher.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/fetch/OldEntityFetcher.java
@@ -7,7 +7,7 @@ import com.kenshoo.jooq.*;
 import com.kenshoo.pl.data.ImpersonatorTable;
 import com.kenshoo.pl.entity.UniqueKey;
 import com.kenshoo.pl.entity.*;
-import com.kenshoo.pl.entity.internal.EntityImpl;
+import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.internal.EntityTypeReflectionUtil;
 import com.kenshoo.pl.entity.internal.PartialEntityInvocationHandler;
 import org.jooq.*;
@@ -37,13 +37,13 @@ public class OldEntityFetcher {
     }
 
 
-    public <E extends EntityType<E>> Map<Identifier<E>, Entity> fetchEntitiesByIds(final Collection<? extends Identifier<E>> ids,
-                                                                                   final EntityField<?, ?>... fieldsToFetchArgs) {
+    public <E extends EntityType<E>> Map<Identifier<E>, CurrentEntityState> fetchEntitiesByIds(final Collection<? extends Identifier<E>> ids,
+                                                                                               final EntityField<?, ?>... fieldsToFetchArgs) {
         return fetchEntitiesByIds(ids, ImmutableList.copyOf(fieldsToFetchArgs));
     }
 
-    public <E extends EntityType<E>> Map<Identifier<E>, Entity> fetchEntitiesByIds(final Collection<? extends Identifier<E>> ids,
-                                                                                   final Collection<? extends EntityField<?, ?>> fieldsToFetch) {
+    public <E extends EntityType<E>> Map<Identifier<E>, CurrentEntityState> fetchEntitiesByIds(final Collection<? extends Identifier<E>> ids,
+                                                                                               final Collection<? extends EntityField<?, ?>> fieldsToFetch) {
         if (ids.isEmpty()) {
             return Collections.emptyMap();
         }
@@ -57,9 +57,9 @@ public class OldEntityFetcher {
         }
     }
 
-    public List<Entity> fetch(final EntityType<?> entityType,
-                              final PLCondition plCondition,
-                              final EntityField<?, ?>... fieldsToFetch) {
+    public List<CurrentEntityState> fetch(final EntityType<?> entityType,
+                                          final PLCondition plCondition,
+                                          final EntityField<?, ?>... fieldsToFetch) {
         requireNonNull(entityType, "An entity type must be provided");
         requireNonNull(plCondition, "A condition must be provided");
         notEmpty(fieldsToFetch, "There must be at least one field to fetch");
@@ -74,10 +74,10 @@ public class OldEntityFetcher {
                 .fetch(record -> mapRecordToEntity(record, requestedFieldsToFetch));
     }
 
-    public List<Entity> fetch(final EntityType<?> entityType,
-                              final Collection<? extends Identifier<?>> ids,
-                              final PLCondition plCondition,
-                              final EntityField<?, ?>... fieldsToFetch) {
+    public List<CurrentEntityState> fetch(final EntityType<?> entityType,
+                                          final Collection<? extends Identifier<?>> ids,
+                                          final PLCondition plCondition,
+                                          final EntityField<?, ?>... fieldsToFetch) {
         notEmpty(fieldsToFetch, "There must be at least one field to fetch");
         requireNonNull(plCondition, "A condition must be provided");
 
@@ -102,7 +102,7 @@ public class OldEntityFetcher {
     }
 
 
-    public <E extends EntityType<E>> Map<Identifier<E>, Entity> fetchEntitiesByForeignKeys(E entityType, UniqueKey<E> foreignUniqueKey, Collection<? extends Identifier<E>> keys, Collection<EntityField<?, ?>> fieldsToFetch) {
+    public <E extends EntityType<E>> Map<Identifier<E>, CurrentEntityState> fetchEntitiesByForeignKeys(E entityType, UniqueKey<E> foreignUniqueKey, Collection<? extends Identifier<E>> keys, Collection<EntityField<?, ?>> fieldsToFetch) {
         try (final TempTableResource<ImpersonatorTable> foreignKeysTable = createForeignKeysTable(entityType.getPrimaryTable(), foreignUniqueKey, keys)) {
             final AliasedKey<E> aliasedKey = new AliasedKey<>(foreignUniqueKey, foreignKeysTable);
             final SelectJoinStep<Record> query = buildFetchQuery(foreignKeysTable.getTable(), aliasedKey.aliasedFields(), fieldsToFetch);
@@ -117,7 +117,7 @@ public class OldEntityFetcher {
         }
         UniqueKey<E> uniqueKey = keys.iterator().next().getUniqueKey();
         final Map<Method, EntityField<E, ?>> entityMethodsMap = EntityTypeReflectionUtil.getMethodsMap(entityType, entityIface);
-        Map<Identifier<E>, Entity> entityMap = fetchEntitiesByIds(keys, entityMethodsMap.values());
+        Map<Identifier<E>, CurrentEntityState> entityMap = fetchEntitiesByIds(keys, entityMethodsMap.values());
         ClassLoader classLoader = entityIface.getClassLoader();
         Class<?>[] interfaces = {entityIface};
         //noinspection unchecked
@@ -133,8 +133,8 @@ public class OldEntityFetcher {
             //noinspection unchecked
             condition = condition.and(fieldAndValue.getField().eq(fieldAndValue.getValue()));
         }
-        List<Entity> entities = query.where(condition).fetch(record -> {
-            EntityImpl currentState = new EntityImpl();
+        List<CurrentEntityState> entities = query.where(condition).fetch(record -> {
+            CurrentEntityState currentState = new CurrentEntityState();
             Iterator<Object> valuesIterator = record.intoList().iterator();
             for (EntityField<E, ?> field : fieldsToFetch) {
                 fieldFromRecordToEntity(currentState, field, valuesIterator);
@@ -206,7 +206,7 @@ public class OldEntityFetcher {
         return seq(edge.target.table.getReferences()).map(new ToEdgesOf(edge.target));
     }
 
-    private <E extends EntityType<E>> Map<Identifier<E>, Entity> fetchEntitiesMap(ResultQuery<Record> query, AliasedKey<E> aliasedKey, Collection<? extends EntityField<?, ?>> fields) {
+    private <E extends EntityType<E>> Map<Identifier<E>, CurrentEntityState> fetchEntitiesMap(ResultQuery<Record> query, AliasedKey<E> aliasedKey, Collection<? extends EntityField<?, ?>> fields) {
         return query.fetchMap(record -> RecordReader.createKey(record, aliasedKey), record -> RecordReader.createEntity(record, fields));
     }
 
@@ -227,7 +227,7 @@ public class OldEntityFetcher {
         );
     }
 
-    private <T> void fieldFromRecordToEntity(EntityImpl currentState, EntityField<?, T> field, Iterator<Object> valuesIterator) {
+    private <T> void fieldFromRecordToEntity(CurrentEntityState currentState, EntityField<?, T> field, Iterator<Object> valuesIterator) {
          currentState.set(field, field.getDbAdapter().getFromRecord(valuesIterator));
     }
 
@@ -246,8 +246,8 @@ public class OldEntityFetcher {
                          .reduce(inputJooqCondition, Condition::and);
     }
 
-    private Entity mapRecordToEntity(final Record record, final Collection<EntityField<?, ?>> fieldsToFetch) {
-        final EntityImpl currentState = new EntityImpl();
+    private CurrentEntityState mapRecordToEntity(final Record record, final Collection<EntityField<?, ?>> fieldsToFetch) {
+        final CurrentEntityState currentState = new CurrentEntityState();
         final Iterator<Object> valuesIterator = record.intoList().iterator();
         fieldsToFetch.forEach( field -> fieldFromRecordToEntity(currentState, field, valuesIterator));
         return currentState;

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/fetch/RecordReader.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/fetch/RecordReader.java
@@ -2,7 +2,7 @@ package com.kenshoo.pl.entity.internal.fetch;
 
 import com.google.common.collect.Iterators;
 import com.kenshoo.pl.entity.*;
-import com.kenshoo.pl.entity.internal.EntityImpl;
+import com.kenshoo.pl.entity.CurrentEntityState;
 import org.jooq.Record;
 
 import java.util.Collection;
@@ -19,8 +19,8 @@ public class RecordReader {
         return new UniqueKey<>(aliasedKey.unAliasedFields()).createValue(fieldsValueMap);
     }
 
-    public static EntityImpl createEntity(Record record, Collection<? extends EntityField<?, ?>> fields) {
-        EntityImpl currentState = new EntityImpl();
+    public static CurrentEntityState createEntity(Record record, Collection<? extends EntityField<?, ?>> fields) {
+        CurrentEntityState currentState = new CurrentEntityState();
         Iterator<Object> valuesIterator = record.intoList().iterator();
         fields.forEach(field -> populateEntity(field, valuesIterator, currentState));
         return currentState;
@@ -38,7 +38,7 @@ public class RecordReader {
         fieldsValueMap.set(field, value);
     }
 
-    private static <E extends EntityType<E>, T> void populateEntity(EntityField<E, T> entityField, Iterator<Object> valuesIterator, EntityImpl currentState) {
+    private static <E extends EntityType<E>, T> void populateEntity(EntityField<E, T> entityField, Iterator<Object> valuesIterator, CurrentEntityState currentState) {
          currentState.set(entityField, entityField.getDbAdapter().getFromRecord(valuesIterator));
     }
 

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/fetch/RecordReader.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/fetch/RecordReader.java
@@ -20,7 +20,7 @@ public class RecordReader {
     }
 
     public static CurrentEntityState createEntity(Record record, Collection<? extends EntityField<?, ?>> fields) {
-        CurrentEntityState currentState = new CurrentEntityState();
+        CurrentEntityMutableState currentState = new CurrentEntityMutableState();
         Iterator<Object> valuesIterator = record.intoList().iterator();
         fields.forEach(field -> populateEntity(field, valuesIterator, currentState));
         return currentState;
@@ -38,7 +38,7 @@ public class RecordReader {
         fieldsValueMap.set(field, value);
     }
 
-    private static <E extends EntityType<E>, T> void populateEntity(EntityField<E, T> entityField, Iterator<Object> valuesIterator, CurrentEntityState currentState) {
+    private static <E extends EntityType<E>, T> void populateEntity(EntityField<E, T> entityField, Iterator<Object> valuesIterator, CurrentEntityMutableState currentState) {
          currentState.set(entityField, entityField.getDbAdapter().getFromRecord(valuesIterator));
     }
 

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/validators/EntityChangeValidator.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/validators/EntityChangeValidator.java
@@ -1,6 +1,6 @@
 package com.kenshoo.pl.entity.internal.validators;
 
-import com.kenshoo.pl.entity.Entity;
+import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.EntityChange;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.EntityType;
@@ -40,6 +40,6 @@ public interface EntityChangeValidator<E extends EntityType<E>> {
      *
      * @return a validation error if any, <code>null</code> if none
      */
-    ValidationError validate(EntityChange<E> entityChange, Entity currentState);
+    ValidationError validate(EntityChange<E> entityChange, CurrentEntityState currentState);
 
 }

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/validators/FieldComplexValidationAdapter.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/validators/FieldComplexValidationAdapter.java
@@ -1,6 +1,6 @@
 package com.kenshoo.pl.entity.internal.validators;
 
-import com.kenshoo.pl.entity.Entity;
+import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.EntityChange;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.EntityType;
@@ -34,7 +34,7 @@ public class FieldComplexValidationAdapter<E extends EntityType<E>, T> implement
     }
 
     @Override
-    public ValidationError validate(EntityChange<E> entityChange, Entity currentState) {
+    public ValidationError validate(EntityChange<E> entityChange, CurrentEntityState currentState) {
         if (entityChange.isFieldChanged(validator.validatedField())) {
             return validator.validate(entityChange.get(validator.validatedField()), currentState);
         } else {

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/validators/FieldValidationAdapter.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/validators/FieldValidationAdapter.java
@@ -1,6 +1,6 @@
 package com.kenshoo.pl.entity.internal.validators;
 
-import com.kenshoo.pl.entity.Entity;
+import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.EntityChange;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.EntityType;
@@ -34,7 +34,7 @@ public class FieldValidationAdapter<E extends EntityType<E>, T> implements Entit
     }
 
     @Override
-    public ValidationError validate(EntityChange<E> entityChange, Entity currentState) {
+    public ValidationError validate(EntityChange<E> entityChange, CurrentEntityState currentState) {
         if (entityChange.isFieldChanged(validator.validatedField())) {
             return validator.validate(entityChange.get(validator.validatedField()));
         } else {

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/validators/FieldsCombinationValidationAdapter.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/validators/FieldsCombinationValidationAdapter.java
@@ -1,6 +1,6 @@
 package com.kenshoo.pl.entity.internal.validators;
 
-import com.kenshoo.pl.entity.Entity;
+import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.EntityChange;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.EntityType;
@@ -39,7 +39,7 @@ public class FieldsCombinationValidationAdapter<E extends EntityType<E>> impleme
     }
 
     @Override
-    public ValidationError validate(EntityChange<E> entityChange, Entity currentState) {
+    public ValidationError validate(EntityChange<E> entityChange, CurrentEntityState currentState) {
         if(validator.validateWhen().test(currentState)) {
             ResultingFieldsCombination<E> resultingFieldsCombination = new ResultingFieldsCombination<>(entityChange, currentState, validator.validatedFields(), entityChange.getChangeOperation());
             if (hasSubstitutions()) {

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/validators/ImmutableFieldValidationAdapter.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/validators/ImmutableFieldValidationAdapter.java
@@ -1,7 +1,7 @@
 package com.kenshoo.pl.entity.internal.validators;
 
 import com.google.common.collect.ImmutableMap;
-import com.kenshoo.pl.entity.Entity;
+import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.EntityChange;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.EntityType;
@@ -40,7 +40,7 @@ public class ImmutableFieldValidationAdapter<E extends EntityType<E>, T> impleme
     }
 
     @Override
-    public ValidationError validate(EntityChange<E> entityChange, Entity currentState) {
+    public ValidationError validate(EntityChange<E> entityChange, CurrentEntityState currentState) {
         if (entityChange.isFieldChanged(validator.immutableField()) && validator.immutableWhen().test(currentState)) {
             return new ValidationError(validator.getErrorCode(), validator.immutableField(), ImmutableMap.of("field", validator.immutableField().toString()));
         }

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/validators/PrototypeFieldComplexValidationAdapter.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/validators/PrototypeFieldComplexValidationAdapter.java
@@ -1,6 +1,6 @@
 package com.kenshoo.pl.entity.internal.validators;
 
-import com.kenshoo.pl.entity.Entity;
+import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.EntityChange;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.EntityType;
@@ -36,7 +36,7 @@ public class PrototypeFieldComplexValidationAdapter<E extends EntityType<E>, T> 
     }
 
     @Override
-    public ValidationError validate(EntityChange<E> entityChange, Entity currentState) {
+    public ValidationError validate(EntityChange<E> entityChange, CurrentEntityState currentState) {
         if (entityChange.isFieldChanged(validatedField)) {
             return prototypeFieldValidator.validate(entityChange.get(validatedField), currentState);
         } else {

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/validators/PrototypeFieldValidationAdapter.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/validators/PrototypeFieldValidationAdapter.java
@@ -1,6 +1,6 @@
 package com.kenshoo.pl.entity.internal.validators;
 
-import com.kenshoo.pl.entity.Entity;
+import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.EntityChange;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.EntityType;
@@ -36,7 +36,7 @@ public class PrototypeFieldValidationAdapter<E extends EntityType<E>, T> impleme
     }
 
     @Override
-    public ValidationError validate(EntityChange<E> entityChange, Entity currentState) {
+    public ValidationError validate(EntityChange<E> entityChange, CurrentEntityState currentState) {
         if (entityChange.isFieldChanged(validatedField)) {
             ValidationError error = prototypeFieldValidator.validate(entityChange.get(validatedField));
             return error != null ? new ValidationError(error.getErrorCode(), validatedField, error.getParameters()) : null;

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/validators/PrototypeFieldsCombinationValidationAdapter.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/validators/PrototypeFieldsCombinationValidationAdapter.java
@@ -1,6 +1,6 @@
 package com.kenshoo.pl.entity.internal.validators;
 
-import com.kenshoo.pl.entity.Entity;
+import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.EntityChange;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.EntityFieldPrototype;
@@ -41,7 +41,7 @@ public class PrototypeFieldsCombinationValidationAdapter<E extends EntityType<E>
     }
 
     @Override
-    public ValidationError validate(EntityChange<E> entityChange, Entity currentState) {
+    public ValidationError validate(EntityChange<E> entityChange, CurrentEntityState currentState) {
         FieldsValueMap<E> fieldsValueMap = new ResultingFieldsCombination<>(entityChange, currentState, fieldsMapping.values().stream(), entityChange.getChangeOperation());
         PrototypeFieldsCombination<E> prototypeFieldsCombination = new PrototypeFieldsCombination<>(fieldsMapping, fieldsValueMap);
         return prototypeFieldsCombinationValidator.validate(prototypeFieldsCombination);

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/validators/RequiredFieldValidationAdapter.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/validators/RequiredFieldValidationAdapter.java
@@ -1,7 +1,7 @@
 package com.kenshoo.pl.entity.internal.validators;
 
 import com.google.common.collect.ImmutableMap;
-import com.kenshoo.pl.entity.Entity;
+import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.EntityChange;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.EntityType;
@@ -35,7 +35,7 @@ public class RequiredFieldValidationAdapter<E extends EntityType<E>, T> implemen
     }
 
     @Override
-    public ValidationError validate(EntityChange<E> entityChange, Entity currentState) {
+    public ValidationError validate(EntityChange<E> entityChange, CurrentEntityState currentState) {
         if (entityChange.get(validator.requiredField()) == null && validator.requireWhen().test(currentState)) {
             return new ValidationError(validator.getErrorCode(), validator.requiredField(), ImmutableMap.of("field", validator.requiredField().toString()));
         }

--- a/main/src/main/java/com/kenshoo/pl/entity/spi/FieldComplexValidator.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/spi/FieldComplexValidator.java
@@ -1,6 +1,6 @@
 package com.kenshoo.pl.entity.spi;
 
-import com.kenshoo.pl.entity.Entity;
+import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.EntityType;
 import com.kenshoo.pl.entity.ValidationError;
@@ -30,7 +30,7 @@ public interface FieldComplexValidator<E extends EntityType<E>, T> extends Chang
      *
      * @return a validation error if any, <code>null</code> if none
      */
-    ValidationError validate(T fieldValue, Entity currentState);
+    ValidationError validate(T fieldValue, CurrentEntityState currentState);
 
     /**
      * @return a list of fields to fetch. Can contain only parent entities fields.

--- a/main/src/main/java/com/kenshoo/pl/entity/spi/FieldValueSupplier.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/spi/FieldValueSupplier.java
@@ -1,9 +1,8 @@
 package com.kenshoo.pl.entity.spi;
 
 import com.kenshoo.pl.entity.ChangeOperation;
-import com.kenshoo.pl.entity.Entity;
+import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.EntityField;
-import com.kenshoo.pl.entity.EntityType;
 
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -11,7 +10,7 @@ import java.util.stream.Stream;
 
 /**
  * A "delayed" supplier of the new value for a field that decides on the value given the current state. For example,
- * a logic to increment the current value by 10% can be implemented by implementing this interface. The {@link #supply(Entity)}
+ * a logic to increment the current value by 10% can be implemented by implementing this interface. The {@link #supply(CurrentEntityState)}
  * method is going to be called after the current state has been fetched from the database.
  *
  * @param <T> type of the field whose value is being supplied
@@ -27,12 +26,12 @@ public interface FieldValueSupplier<T> extends FetchEntityFields {
      * @throws ValidationException if the supposed change is invalid
      * @throws NotSuppliedException if the supplier doesn't want to change the current value
      */
-    T supply(Entity currentState) throws ValidationException, NotSuppliedException;
+    T supply(CurrentEntityState currentState) throws ValidationException, NotSuppliedException;
 
     static <OLD_VAL, NEW_VAL> FieldValueSupplier<NEW_VAL> fromOldValue(EntityField<?, OLD_VAL> field, Function<OLD_VAL, NEW_VAL> func) {
         return new FieldValueSupplier<NEW_VAL>() {
             @Override
-            public NEW_VAL supply(Entity oldState) throws ValidationException, NotSuppliedException {
+            public NEW_VAL supply(CurrentEntityState oldState) throws ValidationException, NotSuppliedException {
                 return func.apply(oldState.get(field));
             }
             @Override
@@ -45,7 +44,7 @@ public interface FieldValueSupplier<T> extends FetchEntityFields {
     static <T1, T2, RES> FieldValueSupplier<RES> fromValues(EntityField<?, T1> field1, EntityField<?, T2> field2, BiFunction<T1, T2, RES> func) {
         return new FieldValueSupplier<RES>() {
             @Override
-            public RES supply(Entity oldState) throws ValidationException, NotSuppliedException {
+            public RES supply(CurrentEntityState oldState) throws ValidationException, NotSuppliedException {
                 return func.apply(oldState.get(field1), oldState.get(field2));
             }
             @Override

--- a/main/src/main/java/com/kenshoo/pl/entity/spi/FieldsCombinationValidator.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/spi/FieldsCombinationValidator.java
@@ -1,6 +1,6 @@
 package com.kenshoo.pl.entity.spi;
 
-import com.kenshoo.pl.entity.Entity;
+import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.EntityType;
 import com.kenshoo.pl.entity.FieldsValueMap;
@@ -42,7 +42,7 @@ public interface FieldsCombinationValidator<E extends EntityType<E>> extends Cha
     /**
      * @return Predicate when should validate fields.
      */
-    default Predicate<Entity> validateWhen() {
+    default Predicate<CurrentEntityState> validateWhen() {
         return e -> true;
     }
 
@@ -67,6 +67,6 @@ public interface FieldsCombinationValidator<E extends EntityType<E>> extends Cha
         /**
          * @return the field substitution function
          */
-        Function<Entity, T> overrideHow();
+        Function<CurrentEntityState, T> overrideHow();
     }
 }

--- a/main/src/main/java/com/kenshoo/pl/entity/spi/ImmutableFieldValidator.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/spi/ImmutableFieldValidator.java
@@ -1,6 +1,6 @@
 package com.kenshoo.pl.entity.spi;
 
-import com.kenshoo.pl.entity.Entity;
+import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.EntityType;
 
@@ -35,7 +35,7 @@ public interface ImmutableFieldValidator<E extends EntityType<E>, T> extends Cha
     /**
      * @return Predicate when should validate field.
      */
-    default Predicate<Entity> immutableWhen() {
+    default Predicate<CurrentEntityState> immutableWhen() {
         return e -> true;
     }
 

--- a/main/src/main/java/com/kenshoo/pl/entity/spi/MultiFieldValueSupplier.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/spi/MultiFieldValueSupplier.java
@@ -1,6 +1,6 @@
 package com.kenshoo.pl.entity.spi;
 
-import com.kenshoo.pl.entity.Entity;
+import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.EntityType;
 import com.kenshoo.pl.entity.FieldsValueMap;
 
@@ -20,6 +20,6 @@ public interface MultiFieldValueSupplier<E extends EntityType<E>> extends  Fetch
      * @param currentState entity before the change
      * @return new values
      */
-    FieldsValueMap<E> supply(Entity currentState) throws ValidationException;
+    FieldsValueMap<E> supply(CurrentEntityState currentState) throws ValidationException;
 
 }

--- a/main/src/main/java/com/kenshoo/pl/entity/spi/PrototypeFieldComplexValidator.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/spi/PrototypeFieldComplexValidator.java
@@ -1,6 +1,6 @@
 package com.kenshoo.pl.entity.spi;
 
-import com.kenshoo.pl.entity.Entity;
+import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.EntityFieldPrototype;
 import com.kenshoo.pl.entity.ValidationError;
@@ -27,7 +27,7 @@ public interface PrototypeFieldComplexValidator<T> extends ChangeValidator {
      *
      * @return a validation error if any, <code>null</code> if none
      */
-    ValidationError validate(T fieldValue, Entity currentState);
+    ValidationError validate(T fieldValue, CurrentEntityState currentState);
 
     /**
      * @return a list of fields to fetch. Can contain only parent entities fields.

--- a/main/src/main/java/com/kenshoo/pl/entity/spi/RequiredFieldValidator.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/spi/RequiredFieldValidator.java
@@ -1,6 +1,6 @@
 package com.kenshoo.pl.entity.spi;
 
-import com.kenshoo.pl.entity.Entity;
+import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.EntityType;
 
@@ -28,7 +28,7 @@ public interface RequiredFieldValidator<E extends EntityType<E>, T> extends Chan
     /**
      * @return Predicate when should validate field.
      */
-    default Predicate<Entity> requireWhen() {
+    default Predicate<CurrentEntityState> requireWhen() {
         return e -> true;
     }
 

--- a/main/src/main/java/com/kenshoo/pl/entity/spi/helpers/ChangeResultInspector.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/spi/helpers/ChangeResultInspector.java
@@ -3,7 +3,7 @@ package com.kenshoo.pl.entity.spi.helpers;
 import com.google.common.collect.Sets;
 import com.kenshoo.pl.entity.ChangeEntityCommand;
 import com.kenshoo.pl.entity.ChangeResult;
-import com.kenshoo.pl.entity.Entity;
+import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.EntityChangeResult;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.EntityType;
@@ -36,7 +36,7 @@ public class ChangeResultInspector<E extends EntityType<E>> {
         this.inspectedFlow = inspectedFlow;
     }
 
-    public void inspect(Map<? extends Identifier<E>, Entity> originalState, ChangeResult<E, ?, ?> results, List<ObservedResult<E>> observedResults) {
+    public void inspect(Map<? extends Identifier<E>, CurrentEntityState> originalState, ChangeResult<E, ?, ?> results, List<ObservedResult<E>> observedResults) {
         Iterator<? extends EntityChangeResult<E, ?, ?>> resultIterator = results.iterator();
         Iterator<ObservedResult<E>> observedResultIterator = observedResults.iterator();
         while(resultIterator.hasNext() && observedResultIterator.hasNext()) {
@@ -59,7 +59,7 @@ public class ChangeResultInspector<E extends EntityType<E>> {
         logger.warn("Change result inspector can't inspect keyword changes for flow " + inspectedFlow, t);
     }
 
-    private void inspectResult(Entity originalEntity, EntityChangeResult<E, ?, ?> result, ObservedResult<E> observedResult) {
+    private void inspectResult(CurrentEntityState originalEntity, EntityChangeResult<E, ?, ?> result, ObservedResult<E> observedResult) {
         ChangeEntityCommand<E> command = result.getCommand();
         inspectedFields.forEach(field -> {
             boolean fieldChanged = command.isFieldChanged(field);
@@ -87,7 +87,7 @@ public class ChangeResultInspector<E extends EntityType<E>> {
     }
 
 
-    private <T> Object getValue(Entity fieldsValueMap, EntityField<E, T> field) {
+    private <T> Object getValue(CurrentEntityState fieldsValueMap, EntityField<E, T> field) {
         return field.getDbAdapter().getDbValues(fieldsValueMap.get(field)).collect(Collectors.toList()).get(0);
     }
 

--- a/main/src/main/java/com/kenshoo/pl/entity/spi/helpers/CopyFieldsOnCreateEnricher.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/spi/helpers/CopyFieldsOnCreateEnricher.java
@@ -67,7 +67,7 @@ public class CopyFieldsOnCreateEnricher<E extends EntityType<E>> implements Post
     @Override
     public void enrich(Collection<? extends ChangeEntityCommand<E>> commands, ChangeOperation changeOperation, ChangeContext changeContext) {
         for (ChangeEntityCommand<E> command : commands) {
-            Entity currentState = changeContext.getEntity(command);
+            CurrentEntityState currentState = changeContext.getEntity(command);
             for (Field2Copy<E, ?> field2Copy : fields2Copy) {
                 copyField(field2Copy, currentState, command);
             }
@@ -79,7 +79,7 @@ public class CopyFieldsOnCreateEnricher<E extends EntityType<E>> implements Post
         return fields2Copy.stream().map(pair -> pair.target);
     }
     
-    private <T> void copyField(Field2Copy<E, T> field2Copy, Entity currentState, ChangeEntityCommand<E> command) {
+    private <T> void copyField(Field2Copy<E, T> field2Copy, CurrentEntityState currentState, ChangeEntityCommand<E> command) {
         command.set(field2Copy.target,  currentState.get(field2Copy.source));
     }
 

--- a/main/src/main/java/com/kenshoo/pl/entity/spi/helpers/EntityChangeCompositeValidator.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/spi/helpers/EntityChangeCompositeValidator.java
@@ -4,7 +4,7 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.kenshoo.pl.entity.ChangeContext;
 import com.kenshoo.pl.entity.ChangeOperation;
-import com.kenshoo.pl.entity.Entity;
+import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.EntityChange;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.EntityFieldPrototype;
@@ -129,7 +129,7 @@ public class EntityChangeCompositeValidator<E extends EntityType<E>> implements 
     @Override
     public void validate(Collection<? extends EntityChange<E>> entityChanges, ChangeOperation changeOperation, ChangeContext changeContext) {
         entityChanges.forEach(entityChange -> {
-            Entity currentState = changeContext.getEntity(entityChange);
+            CurrentEntityState currentState = changeContext.getEntity(entityChange);
             Collection<EntityChangeValidator<E>> validators = findValidators(entityChange);
             validators.stream()
                     .filter(validator -> validator.getSupportedChangeOperation().supports(changeOperation))

--- a/main/src/main/java/com/kenshoo/pl/entity/spi/helpers/FixedFieldValueSupplier.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/spi/helpers/FixedFieldValueSupplier.java
@@ -1,7 +1,7 @@
 package com.kenshoo.pl.entity.spi.helpers;
 
 import com.kenshoo.pl.entity.ChangeOperation;
-import com.kenshoo.pl.entity.Entity;
+import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.spi.FieldValueSupplier;
 
@@ -16,7 +16,7 @@ public class FixedFieldValueSupplier<T> implements FieldValueSupplier<T> {
     }
 
     @Override
-    public T supply(Entity currentState) {
+    public T supply(CurrentEntityState currentState) {
         return value;
     }
 

--- a/main/src/main/java/com/kenshoo/pl/entity/spi/helpers/ObservedResult.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/spi/helpers/ObservedResult.java
@@ -1,7 +1,7 @@
 package com.kenshoo.pl.entity.spi.helpers;
 
 
-import com.kenshoo.pl.entity.Entity;
+import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.EntityType;
 import com.kenshoo.pl.entity.FieldsValueMap;
@@ -20,16 +20,16 @@ public class ObservedResult<E extends EntityType<E>> implements FieldsValueMap<E
 
     private final boolean isSuccess;
     private final Identifier<E> identifier;
-    private final Entity currentState;
+    private final CurrentEntityState currentState;
     private final Optional<String> errorCode;
     private InspectedStatus inspectedStatus = InspectedStatus.IDENTICAL;
 
 
-    private ObservedResult(Identifier<E> identifier, Entity currentState) {
+    private ObservedResult(Identifier<E> identifier, CurrentEntityState currentState) {
         this(identifier, currentState, true, null);
     }
 
-    private ObservedResult(Identifier<E> identifier, Entity currentState, boolean isSuccess, String errorCode) {
+    private ObservedResult(Identifier<E> identifier, CurrentEntityState currentState, boolean isSuccess, String errorCode) {
         this.isSuccess = isSuccess;
         this.identifier = identifier;
         this.currentState = currentState;
@@ -67,7 +67,7 @@ public class ObservedResult<E extends EntityType<E>> implements FieldsValueMap<E
         return errorCode;
     }
 
-    public static <E extends EntityType<E>> ObservedResult<E> of(Identifier<E> identifier, Entity currentState)  {
+    public static <E extends EntityType<E>> ObservedResult<E> of(Identifier<E> identifier, CurrentEntityState currentState)  {
         return new ObservedResult<>(identifier, currentState);
     }
 
@@ -77,7 +77,7 @@ public class ObservedResult<E extends EntityType<E>> implements FieldsValueMap<E
 
     public static class Builder<E extends EntityType<E>> {
         private Identifier<E> identifier;
-        private Entity currentState;
+        private CurrentEntityState currentState;
         private boolean isSuccess = true;
         private String errorCode;
 
@@ -86,7 +86,7 @@ public class ObservedResult<E extends EntityType<E>> implements FieldsValueMap<E
             return this;
         }
 
-        public Builder<E> withEntity(Entity currentState) {
+        public Builder<E> withEntity(CurrentEntityState currentState) {
             this.currentState = currentState;
             return this;
         }

--- a/main/src/main/java/com/kenshoo/pl/entity/spi/helpers/UniquenessValidator.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/spi/helpers/UniquenessValidator.java
@@ -2,7 +2,7 @@ package com.kenshoo.pl.entity.spi.helpers;
 
 import com.kenshoo.pl.entity.ChangeContext;
 import com.kenshoo.pl.entity.ChangeOperation;
-import com.kenshoo.pl.entity.Entity;
+import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.EntityChange;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.EntityType;
@@ -55,7 +55,7 @@ public class UniquenessValidator<E extends EntityType<E>> implements ChangesVali
         UniqueKey<E> pk = uniqueKey.getEntityType().getPrimaryKey();
         EntityField<E, ?>[] uniqueKeyAndPK = ArrayUtils.addAll(uniqueKey.getFields(), pk.getFields());
 
-        Map<Identifier<E>, Entity> duplicates = fetcher.fetch(uniqueKey.getEntityType(), commandsByIds.keySet(), condition, uniqueKeyAndPK)
+        Map<Identifier<E>, CurrentEntityState> duplicates = fetcher.fetch(uniqueKey.getEntityType(), commandsByIds.keySet(), condition, uniqueKeyAndPK)
                 .stream().collect(toMap(e -> createKeyValue(e, uniqueKey), identity()));
 
         duplicates.forEach((dupKey, dupEntity) -> ctx.addValidationError(commandsByIds.get(dupKey), errorForDatabaseConflict(dupEntity, pk)));
@@ -67,7 +67,7 @@ public class UniquenessValidator<E extends EntityType<E>> implements ChangesVali
                 .collect(toMap(cmd -> createKeyValue(cmd, uniqueKey), identity(), fail2ndConflictingCommand(ctx)));
     }
 
-    private ValidationError errorForDatabaseConflict(Entity dupEntity, UniqueKey<E> pk) {
+    private ValidationError errorForDatabaseConflict(CurrentEntityState dupEntity, UniqueKey<E> pk) {
         return new ValidationError(errorCode, Seq.of(pk.getFields()).toMap(Object::toString, field -> String.valueOf(dupEntity.get(field))));
     }
 
@@ -83,7 +83,7 @@ public class UniquenessValidator<E extends EntityType<E>> implements ChangesVali
         return new UniqueKeyValue<>(key, values);
     }
 
-    private Identifier<E> createKeyValue(Entity cmd, UniqueKey<E> key) {
+    private Identifier<E> createKeyValue(CurrentEntityState cmd, UniqueKey<E> key) {
         Object[] values = Stream.of(key.getFields()).map(cmd::get).toArray();
         return new UniqueKeyValue<>(key, values);
     }

--- a/main/src/test/java/com/kenshoo/pl/entity/CommonTypesStringConverterTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/CommonTypesStringConverterTest.java
@@ -17,7 +17,7 @@ public class CommonTypesStringConverterTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void unsupportedClass() {
-        new CommonTypesStringConverter<>(Entity.class);
+        new CommonTypesStringConverter<>(CurrentEntityState.class);
     }
 
     @Test

--- a/main/src/test/java/com/kenshoo/pl/entity/EntityTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/EntityTest.java
@@ -39,7 +39,7 @@ public class EntityTest {
         assertThat(currentState.safeGet(mockField), is(Triptional.absent()));
     }
 
-    private static final class StubEntity extends CurrentEntityState {
+    private static final class StubEntity implements CurrentEntityState {
 
         private final boolean fieldPresent;
         private final Object value;

--- a/main/src/test/java/com/kenshoo/pl/entity/EntityTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/EntityTest.java
@@ -20,26 +20,26 @@ public class EntityTest {
 
     @Test
     public void safeGet_WhenNotNull_ShouldReturnIt() {
-        final Entity currentState = new StubEntity(true, DUMMY_VALUE);
+        final CurrentEntityState currentState = new StubEntity(true, DUMMY_VALUE);
 
         assertThat(currentState.safeGet(mockField), is(Triptional.of(DUMMY_VALUE)));
     }
 
     @Test
     public void safeGet_WhenPresentAndNull_ShouldReturnNull() {
-        final Entity currentState = new StubEntity(true, null);
+        final CurrentEntityState currentState = new StubEntity(true, null);
 
         assertThat(currentState.safeGet(mockField), is(Triptional.nullInstance()));
     }
 
     @Test
     public void safeGet_WhenAbsent_ShouldReturnAbsent() {
-        final Entity currentState = new StubEntity(false, null);
+        final CurrentEntityState currentState = new StubEntity(false, null);
 
         assertThat(currentState.safeGet(mockField), is(Triptional.absent()));
     }
 
-    private static final class StubEntity implements Entity {
+    private static final class StubEntity extends CurrentEntityState {
 
         private final boolean fieldPresent;
         private final Object value;

--- a/main/src/test/java/com/kenshoo/pl/entity/FalseUpdatesPurgerTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/FalseUpdatesPurgerTest.java
@@ -172,8 +172,8 @@ public class FalseUpdatesPurgerTest {
         }
     }
 
-    private Entity currentState(Map<EntityField<TestEntity, ?>, Object> state) {
-        return new Entity() {
+    private CurrentEntityState currentState(Map<EntityField<TestEntity, ?>, Object> state) {
+        return new CurrentEntityState() {
 
             @Override
             public boolean containsField(EntityField<?, ?> field) {

--- a/main/src/test/java/com/kenshoo/pl/entity/FieldsToFetchBuilderTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/FieldsToFetchBuilderTest.java
@@ -321,7 +321,7 @@ public class FieldsToFetchBuilderTest {
     private <T> FieldValueSupplier<T> supplierRequiring(final EntityField<?, ?> requestedField) {
         return new FieldValueSupplier<T>() {
             @Override
-            public T supply(Entity currentState) throws NotSuppliedException {
+            public T supply(CurrentEntityState currentState) throws NotSuppliedException {
                 return null;
             }
             public Stream<EntityField<?, ?>> fetchFields(ChangeOperation changeOperation) {

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/EntitiesToContextFetcherTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/EntitiesToContextFetcherTest.java
@@ -28,7 +28,7 @@ import static java.util.Arrays.asList;
 @RunWith(MockitoJUnitRunner.class)
 public class EntitiesToContextFetcherTest {
 
-    private final static Entity MISSING = Entity.EMPTY;
+    private final static CurrentEntityState MISSING = CurrentEntityState.EMPTY;
 
     @Mock
     private EntitiesFetcher fetcher;

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/EntityIdExtractorTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/EntityIdExtractorTest.java
@@ -20,7 +20,7 @@ public class EntityIdExtractorTest {
     public void extractWhenExistsInCommandDirectly() {
         final EntityChange<TestEntity> cmd = new TestCommand()
             .with(TestEntity.ID, ID_VALUE);
-        final Entity currentState = Entity.EMPTY;
+        final CurrentEntityState currentState = CurrentEntityState.EMPTY;
 
         assertThat(EntityIdExtractor.INSTANCE.extract(cmd, currentState), isPresentAndIs(STRING_ID_VALUE));
     }
@@ -29,7 +29,7 @@ public class EntityIdExtractorTest {
     public void extractWhenExistsInIdentifierButNotDirectlyInCommand() {
         final EntityChange<TestEntity> cmd = new TestCommand()
             .withIdentifier(new TestEntity.Key(ID_VALUE));
-        final Entity currentState = Entity.EMPTY;
+        final CurrentEntityState currentState = CurrentEntityState.EMPTY;
 
         assertThat(EntityIdExtractor.INSTANCE.extract(cmd, currentState), isPresentAndIs(STRING_ID_VALUE));
     }
@@ -38,7 +38,7 @@ public class EntityIdExtractorTest {
     public void extractWhenExistsInEntityButNotInIdentifier() {
         final EntityChange<TestEntity> cmd = new TestCommand()
             .withIdentifier(new SingleUniqueKeyValue<>(TestEntity.FIELD_1, "abc"));
-        final EntityImpl currentState = new EntityImpl();
+        final CurrentEntityState currentState = new CurrentEntityState();
          currentState.set(TestEntity.ID, ID_VALUE);
 
         assertThat(EntityIdExtractor.INSTANCE.extract(cmd, currentState), isPresentAndIs(STRING_ID_VALUE));
@@ -47,7 +47,7 @@ public class EntityIdExtractorTest {
     @Test
     public void extractWhenExistsInEntityOnly() {
         final EntityChange<TestEntity> cmd = TestCommand.EMPTY;
-        final EntityImpl currentState = new EntityImpl();
+        final CurrentEntityState currentState = new CurrentEntityState();
          currentState.set(TestEntity.ID, ID_VALUE);
 
         assertThat(EntityIdExtractor.INSTANCE.extract(cmd, currentState), isPresentAndIs(STRING_ID_VALUE));
@@ -56,7 +56,7 @@ public class EntityIdExtractorTest {
     @Test
     public void extractWhenDoesntExistAnywhere() {
         final EntityChange<TestEntity> cmd = TestCommand.EMPTY;
-        final Entity currentState = Entity.EMPTY;
+        final CurrentEntityState currentState = CurrentEntityState.EMPTY;
 
         assertThat(EntityIdExtractor.INSTANCE.extract(cmd, currentState), isEmpty());
     }

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/EntityIdExtractorTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/EntityIdExtractorTest.java
@@ -38,8 +38,8 @@ public class EntityIdExtractorTest {
     public void extractWhenExistsInEntityButNotInIdentifier() {
         final EntityChange<TestEntity> cmd = new TestCommand()
             .withIdentifier(new SingleUniqueKeyValue<>(TestEntity.FIELD_1, "abc"));
-        final CurrentEntityState currentState = new CurrentEntityState();
-         currentState.set(TestEntity.ID, ID_VALUE);
+        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
+        currentState.set(TestEntity.ID, ID_VALUE);
 
         assertThat(EntityIdExtractor.INSTANCE.extract(cmd, currentState), isPresentAndIs(STRING_ID_VALUE));
     }
@@ -47,8 +47,8 @@ public class EntityIdExtractorTest {
     @Test
     public void extractWhenExistsInEntityOnly() {
         final EntityChange<TestEntity> cmd = TestCommand.EMPTY;
-        final CurrentEntityState currentState = new CurrentEntityState();
-         currentState.set(TestEntity.ID, ID_VALUE);
+        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
+        currentState.set(TestEntity.ID, ID_VALUE);
 
         assertThat(EntityIdExtractor.INSTANCE.extract(cmd, currentState), isPresentAndIs(STRING_ID_VALUE));
     }

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/SingleFieldEnricherTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/SingleFieldEnricherTest.java
@@ -113,7 +113,7 @@ public class SingleFieldEnricherTest {
 
     private ChangeContext prepareCtx(CreateEntityCommand<TestEntity> cmd, String value) {
         ChangeContextImpl ctx = new ChangeContextImpl(null, FeatureSet.EMPTY);
-        EntityImpl currentState = new EntityImpl();
+        CurrentEntityState currentState = new CurrentEntityState();
          currentState.set(TestEntity.FIELD_2, value);
         ctx.addEntity(cmd, currentState);
         return ctx;
@@ -133,12 +133,12 @@ public class SingleFieldEnricherTest {
         }
 
         @Override
-        protected String enrichedValue(EntityChange<TestEntity> entityChange, Entity currentState) {
+        protected String enrichedValue(EntityChange<TestEntity> entityChange, CurrentEntityState currentState) {
             return  currentState.get(TestEntity.FIELD_2);
         }
 
         @Override
-        protected BiPredicate<EntityChange<TestEntity>, Entity> additionalPostFetchCommandFilter() {
+        protected BiPredicate<EntityChange<TestEntity>, CurrentEntityState> additionalPostFetchCommandFilter() {
             return (entityChange, currentState) -> !(currentState.containsField(TestEntity.FIELD_2) &&  currentState.get(TestEntity.FIELD_2).equals(DO_NOT_ENRICH_VALUE));
         }
 

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/SingleFieldEnricherTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/SingleFieldEnricherTest.java
@@ -113,7 +113,7 @@ public class SingleFieldEnricherTest {
 
     private ChangeContext prepareCtx(CreateEntityCommand<TestEntity> cmd, String value) {
         ChangeContextImpl ctx = new ChangeContextImpl(null, FeatureSet.EMPTY);
-        CurrentEntityState currentState = new CurrentEntityState();
+        CurrentEntityMutableState currentState = new CurrentEntityMutableState();
          currentState.set(TestEntity.FIELD_2, value);
         ctx.addEntity(cmd, currentState);
         return ctx;

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorForCreateTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorForCreateTest.java
@@ -2,6 +2,7 @@ package com.kenshoo.pl.entity.internal.audit;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.kenshoo.pl.entity.CurrentEntityMutableState;
 import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.audit.AuditRecord;
@@ -71,9 +72,9 @@ public class AuditRecordGeneratorForCreateTest {
     public void generate_WithMandatoryFieldsOnly_ShouldGenerateBasicDataAndMandatoryFields() {
         final AuditedCommand cmd = new AuditedCommand(ID, CREATE);
 
-        final CurrentEntityState currentState = new CurrentEntityState();
-         currentState.set(NotAuditedAncestorType.NAME, ANCESTOR_NAME);
-         currentState.set(NotAuditedAncestorType.DESC, ANCESTOR_DESC);
+        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
+        currentState.set(NotAuditedAncestorType.NAME, ANCESTOR_NAME);
+        currentState.set(NotAuditedAncestorType.DESC, ANCESTOR_DESC);
 
         final AuditedFieldSet<AuditedType> expectedIntersectionFieldSet =
             AuditedFieldSet.builder(AuditedType.ID)
@@ -101,9 +102,9 @@ public class AuditRecordGeneratorForCreateTest {
     public void generate_WithMandatoryFieldsHavingNullValues_ShouldNotGenerateMandatoryFields() {
         final AuditedCommand cmd = new AuditedCommand(ID, CREATE);
 
-        final CurrentEntityState currentState = new CurrentEntityState();
-         currentState.set(NotAuditedAncestorType.NAME, null);
-         currentState.set(NotAuditedAncestorType.DESC, null);
+        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
+        currentState.set(NotAuditedAncestorType.NAME, null);
+        currentState.set(NotAuditedAncestorType.DESC, null);
 
         final AuditedFieldSet<AuditedType> expectedIntersectionFieldSet =
             AuditedFieldSet.builder(AuditedType.ID)
@@ -179,7 +180,7 @@ public class AuditRecordGeneratorForCreateTest {
     public void generate_WithMandatoryFieldsAndChildRecordsOnly_ShouldGenerateMandatoryFieldsAndChildRecords() {
         final AuditedCommand cmd = new AuditedCommand(ID, CREATE);
 
-        final CurrentEntityState currentState = new CurrentEntityState();
+        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
          currentState.set(NotAuditedAncestorType.NAME, ANCESTOR_NAME);
          currentState.set(NotAuditedAncestorType.DESC, ANCESTOR_DESC);
 
@@ -210,7 +211,7 @@ public class AuditRecordGeneratorForCreateTest {
             .with(AuditedType.DESC, "desc");
         final Set<? extends EntityField<AuditedType, ?>> cmdChangedFields = cmd.getChangedFields().collect(toSet());
 
-        final CurrentEntityState currentState = new CurrentEntityState();
+        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
          currentState.set(NotAuditedAncestorType.NAME, ANCESTOR_NAME);
          currentState.set(NotAuditedAncestorType.DESC, ANCESTOR_DESC);
 

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorForCreateTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorForCreateTest.java
@@ -2,11 +2,11 @@ package com.kenshoo.pl.entity.internal.audit;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.kenshoo.pl.entity.Entity;
+import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.audit.AuditRecord;
 import com.kenshoo.pl.entity.internal.EntityIdExtractor;
-import com.kenshoo.pl.entity.internal.EntityImpl;
+import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.internal.audit.entitytypes.AuditedType;
 import com.kenshoo.pl.entity.internal.audit.entitytypes.NotAuditedAncestorType;
 import org.junit.Test;
@@ -51,7 +51,7 @@ public class AuditRecordGeneratorForCreateTest {
     public void generate_WithIdOnly_ShouldGenerateMandatoryData() {
         final AuditedCommand cmd = new AuditedCommand(ID, CREATE);
 
-        final Entity currentState = Entity.EMPTY;
+        final CurrentEntityState currentState = CurrentEntityState.EMPTY;
 
         final AuditedFieldSet<AuditedType> expectedIntersectionFieldSet = AuditedFieldSet.builder(AuditedType.ID).build();
 
@@ -71,7 +71,7 @@ public class AuditRecordGeneratorForCreateTest {
     public void generate_WithMandatoryFieldsOnly_ShouldGenerateBasicDataAndMandatoryFields() {
         final AuditedCommand cmd = new AuditedCommand(ID, CREATE);
 
-        final EntityImpl currentState = new EntityImpl();
+        final CurrentEntityState currentState = new CurrentEntityState();
          currentState.set(NotAuditedAncestorType.NAME, ANCESTOR_NAME);
          currentState.set(NotAuditedAncestorType.DESC, ANCESTOR_DESC);
 
@@ -101,7 +101,7 @@ public class AuditRecordGeneratorForCreateTest {
     public void generate_WithMandatoryFieldsHavingNullValues_ShouldNotGenerateMandatoryFields() {
         final AuditedCommand cmd = new AuditedCommand(ID, CREATE);
 
-        final EntityImpl currentState = new EntityImpl();
+        final CurrentEntityState currentState = new CurrentEntityState();
          currentState.set(NotAuditedAncestorType.NAME, null);
          currentState.set(NotAuditedAncestorType.DESC, null);
 
@@ -130,7 +130,7 @@ public class AuditRecordGeneratorForCreateTest {
             .with(AuditedType.DESC, "desc");
         final Set<? extends EntityField<AuditedType, ?>> cmdChangedFields = cmd.getChangedFields().collect(toSet());
 
-        final Entity currentState = Entity.EMPTY;
+        final CurrentEntityState currentState = CurrentEntityState.EMPTY;
 
         final AuditedFieldSet<AuditedType> expectedIntersectionFieldSet =
             AuditedFieldSet.builder(AuditedType.ID)
@@ -155,7 +155,7 @@ public class AuditRecordGeneratorForCreateTest {
     public void generate_WithChildRecordsOnly_ShouldGenerateBasicDataAndChildRecords() {
         final AuditedCommand cmd = new AuditedCommand(ID, CREATE);
 
-        final Entity currentState = Entity.EMPTY;
+        final CurrentEntityState currentState = CurrentEntityState.EMPTY;
 
         final AuditedFieldSet<AuditedType> expectedIntersectionFieldSet = AuditedFieldSet.builder(AuditedType.ID).build();
 
@@ -179,7 +179,7 @@ public class AuditRecordGeneratorForCreateTest {
     public void generate_WithMandatoryFieldsAndChildRecordsOnly_ShouldGenerateMandatoryFieldsAndChildRecords() {
         final AuditedCommand cmd = new AuditedCommand(ID, CREATE);
 
-        final EntityImpl currentState = new EntityImpl();
+        final CurrentEntityState currentState = new CurrentEntityState();
          currentState.set(NotAuditedAncestorType.NAME, ANCESTOR_NAME);
          currentState.set(NotAuditedAncestorType.DESC, ANCESTOR_DESC);
 
@@ -210,7 +210,7 @@ public class AuditRecordGeneratorForCreateTest {
             .with(AuditedType.DESC, "desc");
         final Set<? extends EntityField<AuditedType, ?>> cmdChangedFields = cmd.getChangedFields().collect(toSet());
 
-        final EntityImpl currentState = new EntityImpl();
+        final CurrentEntityState currentState = new CurrentEntityState();
          currentState.set(NotAuditedAncestorType.NAME, ANCESTOR_NAME);
          currentState.set(NotAuditedAncestorType.DESC, ANCESTOR_DESC);
 

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorForDeleteTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorForDeleteTest.java
@@ -2,6 +2,7 @@ package com.kenshoo.pl.entity.internal.audit;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.kenshoo.pl.entity.CurrentEntityMutableState;
 import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.audit.AuditRecord;
@@ -50,9 +51,9 @@ public class AuditRecordGeneratorForDeleteTest {
     public void generate_WithIdOnly_ShouldGenerateMandatoryData() {
         final AuditedCommand cmd = new AuditedCommand(ID, DELETE);
 
-        final CurrentEntityState currentState = new CurrentEntityState();
-         currentState.set(AuditedType.NAME, "oldName");
-         currentState.set(AuditedType.DESC, "oldDesc");
+        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
+        currentState.set(AuditedType.NAME, "oldName");
+        currentState.set(AuditedType.DESC, "oldDesc");
 
         when(completeFieldSet.intersectWith(eqStreamAsSet(emptySet()))).thenReturn(AuditedFieldSet.builder(AuditedType.ID).build());
         doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
@@ -72,9 +73,9 @@ public class AuditRecordGeneratorForDeleteTest {
             .with(AuditedType.NAME, "name");
         final Set<? extends EntityField<AuditedType, ?>> cmdChangedFields = cmd.getChangedFields().collect(toSet());
 
-        final CurrentEntityState currentState = new CurrentEntityState();
-         currentState.set(NotAuditedAncestorType.NAME, ANCESTOR_NAME);
-         currentState.set(NotAuditedAncestorType.DESC, ANCESTOR_DESC);
+        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
+        currentState.set(NotAuditedAncestorType.NAME, ANCESTOR_NAME);
+        currentState.set(NotAuditedAncestorType.DESC, ANCESTOR_DESC);
 
         final AuditedFieldSet<AuditedType> expectedIntersectionFieldSet =
             AuditedFieldSet.builder(AuditedType.ID)
@@ -135,9 +136,9 @@ public class AuditRecordGeneratorForDeleteTest {
             .with(AuditedType.NAME, "name");
         final Set<? extends EntityField<AuditedType, ?>> cmdChangedFields = cmd.getChangedFields().collect(toSet());
 
-        final CurrentEntityState currentState = new CurrentEntityState();
-         currentState.set(NotAuditedAncestorType.NAME, ANCESTOR_NAME);
-         currentState.set(NotAuditedAncestorType.DESC, ANCESTOR_DESC);
+        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
+        currentState.set(NotAuditedAncestorType.NAME, ANCESTOR_NAME);
+        currentState.set(NotAuditedAncestorType.DESC, ANCESTOR_DESC);
 
         final AuditedFieldSet<AuditedType> expectedIntersectionFieldSet =
             AuditedFieldSet.builder(AuditedType.ID)

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorForDeleteTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorForDeleteTest.java
@@ -2,11 +2,11 @@ package com.kenshoo.pl.entity.internal.audit;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.kenshoo.pl.entity.Entity;
+import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.audit.AuditRecord;
 import com.kenshoo.pl.entity.internal.EntityIdExtractor;
-import com.kenshoo.pl.entity.internal.EntityImpl;
+import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.internal.audit.entitytypes.AuditedType;
 import com.kenshoo.pl.entity.internal.audit.entitytypes.NotAuditedAncestorType;
 import org.junit.Test;
@@ -50,7 +50,7 @@ public class AuditRecordGeneratorForDeleteTest {
     public void generate_WithIdOnly_ShouldGenerateMandatoryData() {
         final AuditedCommand cmd = new AuditedCommand(ID, DELETE);
 
-        final EntityImpl currentState = new EntityImpl();
+        final CurrentEntityState currentState = new CurrentEntityState();
          currentState.set(AuditedType.NAME, "oldName");
          currentState.set(AuditedType.DESC, "oldDesc");
 
@@ -72,7 +72,7 @@ public class AuditRecordGeneratorForDeleteTest {
             .with(AuditedType.NAME, "name");
         final Set<? extends EntityField<AuditedType, ?>> cmdChangedFields = cmd.getChangedFields().collect(toSet());
 
-        final EntityImpl currentState = new EntityImpl();
+        final CurrentEntityState currentState = new CurrentEntityState();
          currentState.set(NotAuditedAncestorType.NAME, ANCESTOR_NAME);
          currentState.set(NotAuditedAncestorType.DESC, ANCESTOR_DESC);
 
@@ -106,7 +106,7 @@ public class AuditRecordGeneratorForDeleteTest {
             .with(AuditedType.NAME, "name");
         final Set<? extends EntityField<AuditedType, ?>> cmdChangedFields = cmd.getChangedFields().collect(toSet());
 
-        final Entity currentState = Entity.EMPTY;
+        final CurrentEntityState currentState = CurrentEntityState.EMPTY;
 
         final AuditedFieldSet<AuditedType> expectedIntersectionFieldSet =
             AuditedFieldSet.builder(AuditedType.ID)
@@ -135,7 +135,7 @@ public class AuditRecordGeneratorForDeleteTest {
             .with(AuditedType.NAME, "name");
         final Set<? extends EntityField<AuditedType, ?>> cmdChangedFields = cmd.getChangedFields().collect(toSet());
 
-        final EntityImpl currentState = new EntityImpl();
+        final CurrentEntityState currentState = new CurrentEntityState();
          currentState.set(NotAuditedAncestorType.NAME, ANCESTOR_NAME);
          currentState.set(NotAuditedAncestorType.DESC, ANCESTOR_DESC);
 

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorForUpdateTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorForUpdateTest.java
@@ -5,7 +5,7 @@ import com.google.common.collect.ImmutableSet;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.audit.AuditRecord;
 import com.kenshoo.pl.entity.internal.EntityIdExtractor;
-import com.kenshoo.pl.entity.internal.EntityImpl;
+import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.internal.audit.entitytypes.AuditedType;
 import com.kenshoo.pl.entity.internal.audit.entitytypes.NotAuditedAncestorType;
 import org.junit.Test;
@@ -51,7 +51,7 @@ public class AuditRecordGeneratorForUpdateTest {
     public void generate_WithIdOnly_ShouldReturnEmpty() {
         final AuditedCommand cmd = new AuditedCommand(ID, UPDATE);
 
-        final EntityImpl currentState = new EntityImpl();
+        final CurrentEntityState currentState = new CurrentEntityState();
          currentState.set(AuditedType.ID, ID);
 
         final AuditedFieldSet<AuditedType> expectedIntersectionFieldSet =
@@ -70,7 +70,7 @@ public class AuditRecordGeneratorForUpdateTest {
     public void generate_WithMandatoryFieldsOnly_ShouldReturnEmpty() {
         final AuditedCommand cmd = new AuditedCommand(ID, UPDATE);
 
-        final EntityImpl currentState = new EntityImpl();
+        final CurrentEntityState currentState = new CurrentEntityState();
          currentState.set(AuditedType.ID, ID);
          currentState.set(NotAuditedAncestorType.NAME, ANCESTOR_NAME);
          currentState.set(NotAuditedAncestorType.DESC, ANCESTOR_DESC);
@@ -97,7 +97,7 @@ public class AuditRecordGeneratorForUpdateTest {
             .with(AuditedType.DESC, "newDesc");
         final Set<? extends EntityField<AuditedType, ?>> cmdChangedFields = cmd.getChangedFields().collect(toSet());
 
-        final EntityImpl currentState = new EntityImpl();
+        final CurrentEntityState currentState = new CurrentEntityState();
          currentState.set(AuditedType.NAME, "oldName");
          currentState.set(AuditedType.DESC, "oldDesc");
 
@@ -128,7 +128,7 @@ public class AuditRecordGeneratorForUpdateTest {
             .with(AuditedType.DESC2, "desc2");
         final Set<? extends EntityField<AuditedType, ?>> cmdChangedFields = cmd.getChangedFields().collect(toSet());
 
-        final EntityImpl currentState = new EntityImpl();
+        final CurrentEntityState currentState = new CurrentEntityState();
          currentState.set(AuditedType.NAME, "oldName");
          currentState.set(AuditedType.DESC, "oldDesc");
          currentState.set(AuditedType.DESC2, "desc2");
@@ -160,7 +160,7 @@ public class AuditRecordGeneratorForUpdateTest {
             .with(AuditedType.DESC2, "desc2");
         final Set<? extends EntityField<AuditedType, ?>> cmdChangedFields = cmd.getChangedFields().collect(toSet());
 
-        final EntityImpl currentState = new EntityImpl();
+        final CurrentEntityState currentState = new CurrentEntityState();
          currentState.set(AuditedType.NAME, "name");
          currentState.set(AuditedType.DESC, "desc");
          currentState.set(AuditedType.DESC2, "desc2");
@@ -189,7 +189,7 @@ public class AuditRecordGeneratorForUpdateTest {
             .with(AuditedType.DESC2, "desc2");
         final Set<? extends EntityField<AuditedType, ?>> cmdChangedFields = cmd.getChangedFields().collect(toSet());
 
-        final EntityImpl currentState = new EntityImpl();
+        final CurrentEntityState currentState = new CurrentEntityState();
          currentState.set(AuditedType.NAME, "oldName");
          currentState.set(AuditedType.DESC, "oldDesc");
          currentState.set(AuditedType.DESC2, "desc2");
@@ -220,7 +220,7 @@ public class AuditRecordGeneratorForUpdateTest {
             .with(AuditedType.DESC2, "desc2");
         final Set<? extends EntityField<AuditedType, ?>> cmdChangedFields = cmd.getChangedFields().collect(toSet());
 
-        final EntityImpl currentState = new EntityImpl();
+        final CurrentEntityState currentState = new CurrentEntityState();
          currentState.set(AuditedType.NAME, "oldName");
          currentState.set(AuditedType.DESC, "desc");
          currentState.set(AuditedType.DESC2, "desc2");
@@ -251,7 +251,7 @@ public class AuditRecordGeneratorForUpdateTest {
             .with(AuditedType.DESC2, "desc2");
         final Set<? extends EntityField<AuditedType, ?>> cmdChangedFields = cmd.getChangedFields().collect(toSet());
 
-        final EntityImpl currentState = new EntityImpl();
+        final CurrentEntityState currentState = new CurrentEntityState();
          currentState.set(AuditedType.NAME, "name");
          currentState.set(AuditedType.DESC, "desc");
          currentState.set(AuditedType.DESC2, "desc2");
@@ -278,7 +278,7 @@ public class AuditRecordGeneratorForUpdateTest {
             .with(AuditedType.DESC, "newDesc");
         final Set<? extends EntityField<AuditedType, ?>> cmdChangedFields = cmd.getChangedFields().collect(toSet());
 
-        final EntityImpl currentState = new EntityImpl();
+        final CurrentEntityState currentState = new CurrentEntityState();
          currentState.set(AuditedType.NAME, "oldName");
          currentState.set(AuditedType.NAME, "oldDesc");
 
@@ -297,7 +297,7 @@ public class AuditRecordGeneratorForUpdateTest {
         final AuditedCommand cmd = new AuditedCommand(ID, UPDATE)
             .with(AuditedType.NAME, "newName");
 
-        final EntityImpl currentState = new EntityImpl();
+        final CurrentEntityState currentState = new CurrentEntityState();
          currentState.set(AuditedType.NAME, null);
 
         final AuditedFieldSet<AuditedType> expectedIntersectionFieldSet =
@@ -320,7 +320,7 @@ public class AuditRecordGeneratorForUpdateTest {
         final AuditedCommand cmd = new AuditedCommand(ID, UPDATE)
             .with(AuditedType.NAME, null);
 
-        final EntityImpl currentState = new EntityImpl();
+        final CurrentEntityState currentState = new CurrentEntityState();
          currentState.set(AuditedType.NAME, "oldName");
 
         final AuditedFieldSet<AuditedType> expectedIntersectionFieldSet =
@@ -345,7 +345,7 @@ public class AuditRecordGeneratorForUpdateTest {
             .with(AuditedType.DESC, "newDesc");
         final Set<? extends EntityField<AuditedType, ?>> cmdChangedFields = cmd.getChangedFields().collect(toSet());
 
-        final EntityImpl currentState = new EntityImpl();
+        final CurrentEntityState currentState = new CurrentEntityState();
          currentState.set(AuditedType.NAME, "oldName");
          currentState.set(AuditedType.DESC, "oldDesc");
 
@@ -376,7 +376,7 @@ public class AuditRecordGeneratorForUpdateTest {
     public void generate_WithIdAndChildRecordsOnly_ShouldGenerateBasicDataAndChildRecords() {
         final AuditedCommand cmd = new AuditedCommand(ID, UPDATE);
 
-        final EntityImpl currentState = new EntityImpl();
+        final CurrentEntityState currentState = new CurrentEntityState();
          currentState.set(AuditedType.ID, ID);
 
         doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
@@ -400,7 +400,7 @@ public class AuditRecordGeneratorForUpdateTest {
     public void generate_WithMandatoryFieldsAndChildRecordsOnly_ShouldGenerateBasicAndMandatoryFieldsAndChildRecords() {
         final AuditedCommand cmd = new AuditedCommand(ID, UPDATE);
 
-        final EntityImpl currentState = new EntityImpl();
+        final CurrentEntityState currentState = new CurrentEntityState();
          currentState.set(AuditedType.ID, ID);
          currentState.set(NotAuditedAncestorType.NAME, ANCESTOR_NAME);
          currentState.set(NotAuditedAncestorType.DESC, ANCESTOR_DESC);
@@ -431,7 +431,7 @@ public class AuditRecordGeneratorForUpdateTest {
             .with(AuditedType.DESC, "newDesc");
         final Set<? extends EntityField<AuditedType, ?>> cmdChangedFields = cmd.getChangedFields().collect(toSet());
 
-        final EntityImpl currentState = new EntityImpl();
+        final CurrentEntityState currentState = new CurrentEntityState();
          currentState.set(AuditedType.ID, ID);
          currentState.set(AuditedType.NAME, "oldName");
          currentState.set(AuditedType.DESC, "oldDesc");

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorForUpdateTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorForUpdateTest.java
@@ -2,10 +2,10 @@ package com.kenshoo.pl.entity.internal.audit;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.kenshoo.pl.entity.CurrentEntityMutableState;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.audit.AuditRecord;
 import com.kenshoo.pl.entity.internal.EntityIdExtractor;
-import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.internal.audit.entitytypes.AuditedType;
 import com.kenshoo.pl.entity.internal.audit.entitytypes.NotAuditedAncestorType;
 import org.junit.Test;
@@ -51,7 +51,7 @@ public class AuditRecordGeneratorForUpdateTest {
     public void generate_WithIdOnly_ShouldReturnEmpty() {
         final AuditedCommand cmd = new AuditedCommand(ID, UPDATE);
 
-        final CurrentEntityState currentState = new CurrentEntityState();
+        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
          currentState.set(AuditedType.ID, ID);
 
         final AuditedFieldSet<AuditedType> expectedIntersectionFieldSet =
@@ -70,7 +70,7 @@ public class AuditRecordGeneratorForUpdateTest {
     public void generate_WithMandatoryFieldsOnly_ShouldReturnEmpty() {
         final AuditedCommand cmd = new AuditedCommand(ID, UPDATE);
 
-        final CurrentEntityState currentState = new CurrentEntityState();
+        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
          currentState.set(AuditedType.ID, ID);
          currentState.set(NotAuditedAncestorType.NAME, ANCESTOR_NAME);
          currentState.set(NotAuditedAncestorType.DESC, ANCESTOR_DESC);
@@ -97,7 +97,7 @@ public class AuditRecordGeneratorForUpdateTest {
             .with(AuditedType.DESC, "newDesc");
         final Set<? extends EntityField<AuditedType, ?>> cmdChangedFields = cmd.getChangedFields().collect(toSet());
 
-        final CurrentEntityState currentState = new CurrentEntityState();
+        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
          currentState.set(AuditedType.NAME, "oldName");
          currentState.set(AuditedType.DESC, "oldDesc");
 
@@ -128,7 +128,7 @@ public class AuditRecordGeneratorForUpdateTest {
             .with(AuditedType.DESC2, "desc2");
         final Set<? extends EntityField<AuditedType, ?>> cmdChangedFields = cmd.getChangedFields().collect(toSet());
 
-        final CurrentEntityState currentState = new CurrentEntityState();
+        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
          currentState.set(AuditedType.NAME, "oldName");
          currentState.set(AuditedType.DESC, "oldDesc");
          currentState.set(AuditedType.DESC2, "desc2");
@@ -160,7 +160,7 @@ public class AuditRecordGeneratorForUpdateTest {
             .with(AuditedType.DESC2, "desc2");
         final Set<? extends EntityField<AuditedType, ?>> cmdChangedFields = cmd.getChangedFields().collect(toSet());
 
-        final CurrentEntityState currentState = new CurrentEntityState();
+        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
          currentState.set(AuditedType.NAME, "name");
          currentState.set(AuditedType.DESC, "desc");
          currentState.set(AuditedType.DESC2, "desc2");
@@ -189,7 +189,7 @@ public class AuditRecordGeneratorForUpdateTest {
             .with(AuditedType.DESC2, "desc2");
         final Set<? extends EntityField<AuditedType, ?>> cmdChangedFields = cmd.getChangedFields().collect(toSet());
 
-        final CurrentEntityState currentState = new CurrentEntityState();
+        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
          currentState.set(AuditedType.NAME, "oldName");
          currentState.set(AuditedType.DESC, "oldDesc");
          currentState.set(AuditedType.DESC2, "desc2");
@@ -220,7 +220,7 @@ public class AuditRecordGeneratorForUpdateTest {
             .with(AuditedType.DESC2, "desc2");
         final Set<? extends EntityField<AuditedType, ?>> cmdChangedFields = cmd.getChangedFields().collect(toSet());
 
-        final CurrentEntityState currentState = new CurrentEntityState();
+        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
          currentState.set(AuditedType.NAME, "oldName");
          currentState.set(AuditedType.DESC, "desc");
          currentState.set(AuditedType.DESC2, "desc2");
@@ -251,7 +251,7 @@ public class AuditRecordGeneratorForUpdateTest {
             .with(AuditedType.DESC2, "desc2");
         final Set<? extends EntityField<AuditedType, ?>> cmdChangedFields = cmd.getChangedFields().collect(toSet());
 
-        final CurrentEntityState currentState = new CurrentEntityState();
+        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
          currentState.set(AuditedType.NAME, "name");
          currentState.set(AuditedType.DESC, "desc");
          currentState.set(AuditedType.DESC2, "desc2");
@@ -278,7 +278,7 @@ public class AuditRecordGeneratorForUpdateTest {
             .with(AuditedType.DESC, "newDesc");
         final Set<? extends EntityField<AuditedType, ?>> cmdChangedFields = cmd.getChangedFields().collect(toSet());
 
-        final CurrentEntityState currentState = new CurrentEntityState();
+        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
          currentState.set(AuditedType.NAME, "oldName");
          currentState.set(AuditedType.NAME, "oldDesc");
 
@@ -297,7 +297,7 @@ public class AuditRecordGeneratorForUpdateTest {
         final AuditedCommand cmd = new AuditedCommand(ID, UPDATE)
             .with(AuditedType.NAME, "newName");
 
-        final CurrentEntityState currentState = new CurrentEntityState();
+        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
          currentState.set(AuditedType.NAME, null);
 
         final AuditedFieldSet<AuditedType> expectedIntersectionFieldSet =
@@ -320,7 +320,7 @@ public class AuditRecordGeneratorForUpdateTest {
         final AuditedCommand cmd = new AuditedCommand(ID, UPDATE)
             .with(AuditedType.NAME, null);
 
-        final CurrentEntityState currentState = new CurrentEntityState();
+        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
          currentState.set(AuditedType.NAME, "oldName");
 
         final AuditedFieldSet<AuditedType> expectedIntersectionFieldSet =
@@ -345,7 +345,7 @@ public class AuditRecordGeneratorForUpdateTest {
             .with(AuditedType.DESC, "newDesc");
         final Set<? extends EntityField<AuditedType, ?>> cmdChangedFields = cmd.getChangedFields().collect(toSet());
 
-        final CurrentEntityState currentState = new CurrentEntityState();
+        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
          currentState.set(AuditedType.NAME, "oldName");
          currentState.set(AuditedType.DESC, "oldDesc");
 
@@ -376,7 +376,7 @@ public class AuditRecordGeneratorForUpdateTest {
     public void generate_WithIdAndChildRecordsOnly_ShouldGenerateBasicDataAndChildRecords() {
         final AuditedCommand cmd = new AuditedCommand(ID, UPDATE);
 
-        final CurrentEntityState currentState = new CurrentEntityState();
+        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
          currentState.set(AuditedType.ID, ID);
 
         doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
@@ -400,7 +400,7 @@ public class AuditRecordGeneratorForUpdateTest {
     public void generate_WithMandatoryFieldsAndChildRecordsOnly_ShouldGenerateBasicAndMandatoryFieldsAndChildRecords() {
         final AuditedCommand cmd = new AuditedCommand(ID, UPDATE);
 
-        final CurrentEntityState currentState = new CurrentEntityState();
+        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
          currentState.set(AuditedType.ID, ID);
          currentState.set(NotAuditedAncestorType.NAME, ANCESTOR_NAME);
          currentState.set(NotAuditedAncestorType.DESC, ANCESTOR_DESC);
@@ -431,7 +431,7 @@ public class AuditRecordGeneratorForUpdateTest {
             .with(AuditedType.DESC, "newDesc");
         final Set<? extends EntityField<AuditedType, ?>> cmdChangedFields = cmd.getChangedFields().collect(toSet());
 
-        final CurrentEntityState currentState = new CurrentEntityState();
+        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
          currentState.set(AuditedType.ID, ID);
          currentState.set(AuditedType.NAME, "oldName");
          currentState.set(AuditedType.DESC, "oldDesc");

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/RecursiveAuditRecordGeneratorTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/RecursiveAuditRecordGeneratorTest.java
@@ -56,7 +56,7 @@ public class RecursiveAuditRecordGeneratorTest {
     public void generateMany_OneAuditedEntity_WithChanges_ShouldGenerateRecord() {
         final ChangeEntityCommand<AuditedType> cmd = mockCommand();
         final AuditRecord<AuditedType> auditRecord = mockAuditRecord();
-        final Entity currentState = mock(Entity.class);
+        final CurrentEntityState currentState = mock(CurrentEntityState.class);
 
         when(flowConfig.auditRecordGenerator()).thenReturn(Optional.of(auditRecordGenerator));
         when(changeContext.getEntity(cmd)).thenReturn(currentState);
@@ -71,7 +71,7 @@ public class RecursiveAuditRecordGeneratorTest {
     @Test
     public void generateMany_OneAuditedEntity_WithoutChanges_ShouldReturnEmpty() {
         final ChangeEntityCommand<AuditedType> cmd = mockCommand();
-        final Entity currentState = mock(Entity.class);
+        final CurrentEntityState currentState = mock(CurrentEntityState.class);
 
         when(flowConfig.auditRecordGenerator()).thenReturn(Optional.of(auditRecordGenerator));
         when(changeContext.getEntity(cmd)).thenReturn(currentState);
@@ -100,8 +100,8 @@ public class RecursiveAuditRecordGeneratorTest {
         final ChangeEntityCommand<AuditedType> cmd1 = mockCommand();
         final ChangeEntityCommand<AuditedType> cmd2 = mockCommand();
 
-        final Entity entity1 = mock(Entity.class);
-        final Entity entity2 = mock(Entity.class);
+        final CurrentEntityState entity1 = mock(CurrentEntityState.class);
+        final CurrentEntityState entity2 = mock(CurrentEntityState.class);
 
         final AuditRecord<AuditedType> auditRecord1 = mockAuditRecord();
         final AuditRecord<AuditedType> auditRecord2 = mockAuditRecord();
@@ -128,8 +128,8 @@ public class RecursiveAuditRecordGeneratorTest {
         final ChangeEntityCommand<AuditedType> cmd1 = mockCommand();
         final ChangeEntityCommand<AuditedType> cmd2 = mockCommand();
 
-        final Entity entity1 = mock(Entity.class);
-        final Entity entity2 = mock(Entity.class);
+        final CurrentEntityState entity1 = mock(CurrentEntityState.class);
+        final CurrentEntityState entity2 = mock(CurrentEntityState.class);
 
         final AuditRecord<AuditedType> auditRecord1 = mockAuditRecord();
 
@@ -158,9 +158,9 @@ public class RecursiveAuditRecordGeneratorTest {
         final AuditRecord<TestChild1EntityType> childAuditRecord1B = mockAuditRecord();
         final List<AuditRecord<TestChild1EntityType>> childAuditRecords = ImmutableList.of(childAuditRecord1A, childAuditRecord1B);
 
-        final Entity currentState = mock(Entity.class);
-        final Entity childEntity1A = mock(Entity.class);
-        final Entity childEntity1B = mock(Entity.class);
+        final CurrentEntityState currentState = mock(CurrentEntityState.class);
+        final CurrentEntityState childEntity1A = mock(CurrentEntityState.class);
+        final CurrentEntityState childEntity1B = mock(CurrentEntityState.class);
 
         when(flowConfig.auditRecordGenerator()).thenReturn(Optional.of(auditRecordGenerator));
         when(flowConfig.childFlows()).thenReturn(singletonList(child1FlowConfig));
@@ -195,9 +195,9 @@ public class RecursiveAuditRecordGeneratorTest {
         final AuditRecord<AuditedType> expectedAuditRecord = mockAuditRecord();
         final AuditRecord<TestChild1EntityType> childAuditRecord1A = mockAuditRecord();
 
-        final Entity currentState = mock(Entity.class);
-        final Entity childEntity1A = mock(Entity.class);
-        final Entity childEntity1B = mock(Entity.class);
+        final CurrentEntityState currentState = mock(CurrentEntityState.class);
+        final CurrentEntityState childEntity1A = mock(CurrentEntityState.class);
+        final CurrentEntityState childEntity1B = mock(CurrentEntityState.class);
 
         when(flowConfig.auditRecordGenerator()).thenReturn(Optional.of(auditRecordGenerator));
         when(flowConfig.childFlows()).thenReturn(singletonList(child1FlowConfig));
@@ -232,8 +232,8 @@ public class RecursiveAuditRecordGeneratorTest {
         final AuditRecord<AuditedType> expectedAuditRecord = mockAuditRecord();
         final AuditRecord<TestChild1EntityType> auditedChildRecord = mockAuditRecord();
 
-        final Entity currentState = mock(Entity.class);
-        final Entity auditedChildEntity = mock(Entity.class);
+        final CurrentEntityState currentState = mock(CurrentEntityState.class);
+        final CurrentEntityState auditedChildEntity = mock(CurrentEntityState.class);
 
         when(flowConfig.auditRecordGenerator()).thenReturn(Optional.of(auditRecordGenerator));
         when(flowConfig.childFlows()).thenReturn(ImmutableList.of(child1FlowConfig, child2FlowConfig));
@@ -278,11 +278,11 @@ public class RecursiveAuditRecordGeneratorTest {
                                                                            childAuditRecord2A,
                                                                            childAuditRecord2B);
 
-        final Entity currentState = mock(Entity.class);
-        final Entity childEntity1A = mock(Entity.class);
-        final Entity childEntity1B = mock(Entity.class);
-        final Entity childEntity2A = mock(Entity.class);
-        final Entity childEntity2B = mock(Entity.class);
+        final CurrentEntityState currentState = mock(CurrentEntityState.class);
+        final CurrentEntityState childEntity1A = mock(CurrentEntityState.class);
+        final CurrentEntityState childEntity1B = mock(CurrentEntityState.class);
+        final CurrentEntityState childEntity2A = mock(CurrentEntityState.class);
+        final CurrentEntityState childEntity2B = mock(CurrentEntityState.class);
 
         when(flowConfig.auditRecordGenerator()).thenReturn(Optional.of(auditRecordGenerator));
         when(flowConfig.childFlows()).thenReturn(ImmutableList.of(child1FlowConfig, child2FlowConfig));
@@ -327,9 +327,9 @@ public class RecursiveAuditRecordGeneratorTest {
         final AuditRecord<TestChild1EntityType> childAuditRecord = mockAuditRecord();
         final AuditRecord<TestGrandchildEntityType> grandchildAuditRecord = mockAuditRecord();
 
-        final Entity currentState = mock(Entity.class);
-        final Entity childEntity = mock(Entity.class);
-        final Entity grandchildEntity = mock(Entity.class);
+        final CurrentEntityState currentState = mock(CurrentEntityState.class);
+        final CurrentEntityState childEntity = mock(CurrentEntityState.class);
+        final CurrentEntityState grandchildEntity = mock(CurrentEntityState.class);
 
         when(flowConfig.auditRecordGenerator()).thenReturn(Optional.of(auditRecordGenerator));
         when(flowConfig.childFlows()).thenReturn(singletonList(child1FlowConfig));

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/validators/FieldComplexValidationAdapterTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/validators/FieldComplexValidationAdapterTest.java
@@ -1,7 +1,7 @@
 package com.kenshoo.pl.entity.internal.validators;
 
 import com.kenshoo.pl.entity.ChangeEntityCommand;
-import com.kenshoo.pl.entity.Entity;
+import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.EntityChange;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.SupportedChangeOperation;
@@ -43,7 +43,7 @@ public class FieldComplexValidationAdapterTest {
     private EntityChange<TestEntity> entityChange;
 
     @Mock
-    private Entity currentState;
+    private CurrentEntityState currentState;
 
     @InjectMocks
     private FieldComplexValidationAdapter<TestEntity, String> adapter;

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/validators/FieldValidationAdapterTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/validators/FieldValidationAdapterTest.java
@@ -1,7 +1,7 @@
 package com.kenshoo.pl.entity.internal.validators;
 
 import com.kenshoo.pl.entity.ChangeEntityCommand;
-import com.kenshoo.pl.entity.Entity;
+import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.EntityChange;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.SupportedChangeOperation;
@@ -43,7 +43,7 @@ public class FieldValidationAdapterTest {
     private EntityChange<TestEntity> entityChange;
 
     @Mock
-    private Entity currentState;
+    private CurrentEntityState currentState;
 
     @InjectMocks
     private FieldValidationAdapter<TestEntity, String> adapter;

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/validators/FieldsCombinationValidationAdapterTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/validators/FieldsCombinationValidationAdapterTest.java
@@ -47,7 +47,7 @@ public class FieldsCombinationValidationAdapterTest {
     private EntityChange<TestEntity> entityChange;
 
     @Mock
-    private Entity currentState;
+    private CurrentEntityState currentState;
 
     @Mock
     private FieldsCombinationValidator.Substitution<TestEntity, String> fieldSubstitution;

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/validators/ImmutableFieldValidationAdapterTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/validators/ImmutableFieldValidationAdapterTest.java
@@ -1,7 +1,7 @@
 package com.kenshoo.pl.entity.internal.validators;
 
 import com.kenshoo.pl.entity.ChangeEntityCommand;
-import com.kenshoo.pl.entity.Entity;
+import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.EntityChange;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.SupportedChangeOperation;
@@ -49,7 +49,7 @@ public class ImmutableFieldValidationAdapterTest {
     private EntityChange<TestEntity> entityChange;
 
     @Mock
-    private Entity currentState;
+    private CurrentEntityState currentState;
 
     @InjectMocks
     private ImmutableFieldValidationAdapter<TestEntity, String> adapter;

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/validators/PrototypeFieldComplexValidationAdapterTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/validators/PrototypeFieldComplexValidationAdapterTest.java
@@ -1,7 +1,7 @@
 package com.kenshoo.pl.entity.internal.validators;
 
 import com.kenshoo.pl.entity.ChangeEntityCommand;
-import com.kenshoo.pl.entity.Entity;
+import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.EntityChange;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.SupportedChangeOperation;
@@ -38,7 +38,7 @@ public class PrototypeFieldComplexValidationAdapterTest {
     private EntityChange<TestEntity> entityChange;
 
     @Mock
-    private Entity currentState;
+    private CurrentEntityState currentState;
 
     @Mock
     private PrototypeFieldComplexValidator<String> validator;

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/validators/PrototypeFieldValidationAdapterTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/validators/PrototypeFieldValidationAdapterTest.java
@@ -1,7 +1,7 @@
 package com.kenshoo.pl.entity.internal.validators;
 
 import com.kenshoo.pl.entity.ChangeEntityCommand;
-import com.kenshoo.pl.entity.Entity;
+import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.EntityChange;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.SupportedChangeOperation;
@@ -38,7 +38,7 @@ public class PrototypeFieldValidationAdapterTest  {
     private EntityChange<TestEntity> entityChange;
 
     @Mock
-    private Entity currentState;
+    private CurrentEntityState currentState;
 
     @InjectMocks
     PrototypeFieldValidationAdapter<TestEntity, String> adapter;

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/validators/PrototypeFieldsCombinationValidationAdapterTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/validators/PrototypeFieldsCombinationValidationAdapterTest.java
@@ -36,7 +36,7 @@ public class PrototypeFieldsCombinationValidationAdapterTest {
     private EntityChange<TestEntity> entityChange;
 
     @Mock
-    private Entity currentState;
+    private CurrentEntityState currentState;
 
     @InjectMocks
     private PrototypeFieldsCombinationValidationAdapter<TestEntity> adapter;

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/validators/RequiredFieldValidationAdapterTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/validators/RequiredFieldValidationAdapterTest.java
@@ -1,6 +1,6 @@
 package com.kenshoo.pl.entity.internal.validators;
 
-import com.kenshoo.pl.entity.Entity;
+import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.EntityChange;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.SupportedChangeOperation;
@@ -37,7 +37,7 @@ public class RequiredFieldValidationAdapterTest {
     private EntityChange<TestEntity> entityChange;
 
     @Mock
-    private Entity currentState;
+    private CurrentEntityState currentState;
 
     @Mock
     private EntityField<TestEntity, String> fetchField;

--- a/main/src/test/java/com/kenshoo/pl/entity/spi/ExistingFieldModifierTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/spi/ExistingFieldModifierTest.java
@@ -2,7 +2,6 @@ package com.kenshoo.pl.entity.spi;
 
 import com.google.common.collect.ImmutableList;
 import com.kenshoo.pl.entity.*;
-import com.kenshoo.pl.entity.spi.ExistingFieldModifier;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -20,7 +19,7 @@ public class ExistingFieldModifierTest {
     private ChangeContext changeContext;
 
     @Mock
-    private Entity currentState;
+    private CurrentEntityState currentState;
 
     private final TestFieldEnricher testFieldEnricher = new TestFieldEnricher();
 
@@ -62,7 +61,7 @@ public class ExistingFieldModifierTest {
         }
 
         @Override
-        protected String enrichedValue(EntityChange<TestEntity> entityChange, Entity currentState) {
+        protected String enrichedValue(EntityChange<TestEntity> entityChange, CurrentEntityState currentState) {
             return "override " + entityChange.get(TestEntity.FIELD_1);
         }
     }

--- a/main/src/test/java/com/kenshoo/pl/entity/spi/MissingFieldEnricherTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/spi/MissingFieldEnricherTest.java
@@ -2,7 +2,6 @@ package com.kenshoo.pl.entity.spi;
 
 import com.google.common.collect.ImmutableList;
 import com.kenshoo.pl.entity.*;
-import com.kenshoo.pl.entity.spi.MissingFieldEnricher;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -20,7 +19,7 @@ public class MissingFieldEnricherTest {
     private ChangeContext changeContext;
 
     @Mock
-    private Entity currentState;
+    private CurrentEntityState currentState;
 
     private final CreateEntityCommand<TestEntity> cmd = new CreateEntityCommand<>(TestEntity.INSTANCE);
 
@@ -103,7 +102,7 @@ public class MissingFieldEnricherTest {
         }
 
         @Override
-        protected String enrichedValue(EntityChange<TestEntity> entityChange, Entity currentState) {
+        protected String enrichedValue(EntityChange<TestEntity> entityChange, CurrentEntityState currentState) {
             return "value";
         }
 

--- a/main/src/test/java/com/kenshoo/pl/entity/spi/helpers/ChangeResultInspectorTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/spi/helpers/ChangeResultInspectorTest.java
@@ -2,22 +2,14 @@ package com.kenshoo.pl.entity.spi.helpers;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
-import com.kenshoo.pl.entity.CreateEntityCommand;
-import com.kenshoo.pl.entity.CreateResult;
-import com.kenshoo.pl.entity.CurrentEntityState;
-import com.kenshoo.pl.entity.EntityCreateResult;
-import com.kenshoo.pl.entity.EntityUpdateResult;
-import com.kenshoo.pl.entity.Identifier;
-import com.kenshoo.pl.entity.TestEntity;
-import com.kenshoo.pl.entity.UpdateEntityCommand;
-import com.kenshoo.pl.entity.UpdateResult;
-import com.kenshoo.pl.entity.ValidationError;
+import com.kenshoo.pl.entity.*;
 import com.kenshoo.pl.entity.CurrentEntityState;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -26,13 +18,15 @@ import static org.junit.Assert.assertEquals;
 @RunWith(MockitoJUnitRunner.Silent.class)
 public class ChangeResultInspectorTest {
 
+    public static final HashMap<Identifier<TestEntity>, CurrentEntityState> SOME_CURRENT_ENTITY_STATE = Maps.newHashMap();
+
     @Test
     public void testUpdate() {
         Map<Identifier<TestEntity>, CurrentEntityState> beforeEntities = Maps.newHashMap();
         UpdateTestEntityCommand command = new UpdateTestEntityCommand();
         command.set(TestEntity.FIELD_1, "value1");
-        CurrentEntityState currentState = new CurrentEntityState();
-         currentState.set(TestEntity.FIELD_1, "value1");
+        CurrentEntityMutableState currentState = new CurrentEntityMutableState();
+        currentState.set(TestEntity.FIELD_1, "value1");
         UpdateTestEntityChangeResult testEntityChangeResult = new UpdateTestEntityChangeResult(command);
         UpdateResult<TestEntity, TestEntity.Key> results = new UpdateResult<>(ImmutableList.of(testEntityChangeResult));
 
@@ -49,11 +43,11 @@ public class ChangeResultInspectorTest {
     @Test
     public void testFalseUpdate() {
         UpdateTestEntityCommand command = new UpdateTestEntityCommand();
-        CurrentEntityState befoeEntity = new CurrentEntityState();
+        CurrentEntityMutableState befoeEntity = new CurrentEntityMutableState();
         befoeEntity.set(TestEntity.FIELD_1, "value1");
         Map<Identifier<TestEntity>, CurrentEntityState> beforeEntities = Maps.newHashMap();
         beforeEntities.put(command.getIdentifier(), befoeEntity);
-        CurrentEntityState currentState = new CurrentEntityState();
+        CurrentEntityMutableState currentState = new CurrentEntityMutableState();
          currentState.set(TestEntity.FIELD_1, "value1");
         UpdateTestEntityChangeResult testEntityChangeResult = new UpdateTestEntityChangeResult(command);
         UpdateResult<TestEntity, TestEntity.Key> results = new UpdateResult<>(ImmutableList.of(testEntityChangeResult));
@@ -75,8 +69,8 @@ public class ChangeResultInspectorTest {
         command.set(TestEntity.FIELD_1, "value1");
         UpdateTestEntityChangeResult testEntityChangeResult = new UpdateTestEntityChangeResult(command);
         UpdateResult<TestEntity, TestEntity.Key> results = new UpdateResult<>(ImmutableList.of(testEntityChangeResult));
-        CurrentEntityState currentState = new CurrentEntityState();
-         currentState.set(TestEntity.FIELD_1, "value2");
+        CurrentEntityMutableState currentState = new CurrentEntityMutableState();
+        currentState.set(TestEntity.FIELD_1, "value2");
 
         ChangeResultInspector<TestEntity> inspector = new ChangeResultInspector.Builder<TestEntity>()
                 .withInspectedFields(ImmutableList.of(TestEntity.FIELD_1))
@@ -112,8 +106,8 @@ public class ChangeResultInspectorTest {
         command.set(TestEntity.FIELD_1, "value1");
         UpdateTestEntityChangeResult testEntityChangeResult = new UpdateTestEntityChangeResult(command, ImmutableList.of(new ValidationError("Validation error")));
         UpdateResult<TestEntity, TestEntity.Key> results = new UpdateResult<>(ImmutableList.of(testEntityChangeResult));
-        CurrentEntityState currentState = new CurrentEntityState();
-         currentState.set(TestEntity.FIELD_1, "value1");
+        CurrentEntityMutableState currentState = new CurrentEntityMutableState();
+        currentState.set(TestEntity.FIELD_1, "value1");
 
         ChangeResultInspector<TestEntity> inspector = new ChangeResultInspector.Builder<TestEntity>()
                 .withInspectedFields(ImmutableList.of(TestEntity.FIELD_1))
@@ -133,7 +127,7 @@ public class ChangeResultInspectorTest {
         command.setIdentifier(new TestEntity.Key(1));
         EntityCreateResult<TestEntity, TestEntity.Key> testEntityChangeResult = new EntityCreateResult<>(command);
         CreateResult<TestEntity, TestEntity.Key> results = new CreateResult<>(ImmutableList.of(testEntityChangeResult));
-        CurrentEntityState currentState = new CurrentEntityState();
+        CurrentEntityMutableState currentState = new CurrentEntityMutableState();
          currentState.set(TestEntity.FIELD_1, "value1");
 
         ChangeResultInspector<TestEntity> inspector = new ChangeResultInspector.Builder<TestEntity>()
@@ -148,27 +142,25 @@ public class ChangeResultInspectorTest {
 
     @Test
     public void testCreateValueMismatch() {
-        Map<Identifier<TestEntity>, CurrentEntityState> beforeEntities = Maps.newHashMap();
         CreateTestEntityCommand command = new CreateTestEntityCommand();
         command.set(TestEntity.FIELD_1, "value1");
         command.setIdentifier(new TestEntity.Key(1));
         EntityCreateResult<TestEntity, TestEntity.Key> testEntityChangeResult = new EntityCreateResult<>(command);
         CreateResult<TestEntity, TestEntity.Key> results = new CreateResult<>(ImmutableList.of(testEntityChangeResult));
-        CurrentEntityState currentState = new CurrentEntityState();
-         currentState.set(TestEntity.FIELD_1, "value2");
+        CurrentEntityMutableState currentState = new CurrentEntityMutableState();
+        currentState.set(TestEntity.FIELD_1, "value2");
 
         ChangeResultInspector<TestEntity> inspector = new ChangeResultInspector.Builder<TestEntity>()
                 .withInspectedFields(ImmutableList.of(TestEntity.FIELD_1))
                 .inspectedFlow("Inspected flow").build();
 
         ObservedResult<TestEntity> observedResult = ObservedResult.of(new TestEntity.Key(1), currentState);
-        inspector.inspect(beforeEntities, results, ImmutableList.of(observedResult));
+        inspector.inspect(SOME_CURRENT_ENTITY_STATE, results, ImmutableList.of(observedResult));
         assertEquals("Value mismatch", observedResult.getInspectedStatus(), ObservedResult.InspectedStatus.VALUE_MISMATCH);
     }
 
     @Test
     public void testCreateLegacyWithError() {
-        Map<Identifier<TestEntity>, CurrentEntityState> beforeEntities = Maps.newHashMap();
         CreateTestEntityCommand command = new CreateTestEntityCommand();
         command.set(TestEntity.FIELD_1, "value1");
         command.setIdentifier(new TestEntity.Key(1));
@@ -180,26 +172,25 @@ public class ChangeResultInspectorTest {
                 .inspectedFlow("Inspected flow").build();
 
         ObservedResult<TestEntity> observedResult = ObservedResult.error(new TestEntity.Key(1), "Validation error");
-        inspector.inspect(beforeEntities, results, ImmutableList.of(observedResult));
+        inspector.inspect(SOME_CURRENT_ENTITY_STATE, results, ImmutableList.of(observedResult));
         assertEquals("Legacy error mismatch", observedResult.getInspectedStatus(), ObservedResult.InspectedStatus.LEGACY_ERROR_MISMATCH);
     }
 
     @Test
     public void testCreatePersistenceWithError() {
-        Map<Identifier<TestEntity>, CurrentEntityState> beforeEntities = Maps.newHashMap();
         CreateTestEntityCommand command = new CreateTestEntityCommand();
         command.set(TestEntity.FIELD_1, "value1");
         EntityCreateResult<TestEntity, TestEntity.Key> testEntityChangeResult = new EntityCreateResult<>(command, ImmutableList.of(new ValidationError("Validation error")));
         CreateResult<TestEntity, TestEntity.Key> results = new CreateResult<>(ImmutableList.of(testEntityChangeResult));
-        CurrentEntityState currentState = new CurrentEntityState();
-         currentState.set(TestEntity.FIELD_1, "value1");
+        CurrentEntityMutableState currentState = new CurrentEntityMutableState();
+        currentState.set(TestEntity.FIELD_1, "value1");
 
         ChangeResultInspector<TestEntity> inspector = new ChangeResultInspector.Builder<TestEntity>()
                 .withInspectedFields(ImmutableList.of(TestEntity.FIELD_1))
                 .inspectedFlow("Inspected flow").build();
 
         ObservedResult<TestEntity> observedResult = ObservedResult.of(new TestEntity.Key(1), currentState);
-        inspector.inspect(beforeEntities, results, ImmutableList.of(observedResult));
+        inspector.inspect(SOME_CURRENT_ENTITY_STATE, results, ImmutableList.of(observedResult));
         assertEquals("Persistence error mismatch", observedResult.getInspectedStatus(), ObservedResult.InspectedStatus.PERSISTENCE_ERROR_MISMATCH);
     }
 

--- a/main/src/test/java/com/kenshoo/pl/entity/spi/helpers/ChangeResultInspectorTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/spi/helpers/ChangeResultInspectorTest.java
@@ -4,7 +4,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import com.kenshoo.pl.entity.CreateEntityCommand;
 import com.kenshoo.pl.entity.CreateResult;
-import com.kenshoo.pl.entity.Entity;
+import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.EntityCreateResult;
 import com.kenshoo.pl.entity.EntityUpdateResult;
 import com.kenshoo.pl.entity.Identifier;
@@ -12,7 +12,7 @@ import com.kenshoo.pl.entity.TestEntity;
 import com.kenshoo.pl.entity.UpdateEntityCommand;
 import com.kenshoo.pl.entity.UpdateResult;
 import com.kenshoo.pl.entity.ValidationError;
-import com.kenshoo.pl.entity.internal.EntityImpl;
+import com.kenshoo.pl.entity.CurrentEntityState;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -28,10 +28,10 @@ public class ChangeResultInspectorTest {
 
     @Test
     public void testUpdate() {
-        Map<Identifier<TestEntity>, Entity> beforeEntities = Maps.newHashMap();
+        Map<Identifier<TestEntity>, CurrentEntityState> beforeEntities = Maps.newHashMap();
         UpdateTestEntityCommand command = new UpdateTestEntityCommand();
         command.set(TestEntity.FIELD_1, "value1");
-        EntityImpl currentState = new EntityImpl();
+        CurrentEntityState currentState = new CurrentEntityState();
          currentState.set(TestEntity.FIELD_1, "value1");
         UpdateTestEntityChangeResult testEntityChangeResult = new UpdateTestEntityChangeResult(command);
         UpdateResult<TestEntity, TestEntity.Key> results = new UpdateResult<>(ImmutableList.of(testEntityChangeResult));
@@ -49,11 +49,11 @@ public class ChangeResultInspectorTest {
     @Test
     public void testFalseUpdate() {
         UpdateTestEntityCommand command = new UpdateTestEntityCommand();
-        EntityImpl befoeEntity = new EntityImpl();
+        CurrentEntityState befoeEntity = new CurrentEntityState();
         befoeEntity.set(TestEntity.FIELD_1, "value1");
-        Map<Identifier<TestEntity>, Entity> beforeEntities = Maps.newHashMap();
+        Map<Identifier<TestEntity>, CurrentEntityState> beforeEntities = Maps.newHashMap();
         beforeEntities.put(command.getIdentifier(), befoeEntity);
-        EntityImpl currentState = new EntityImpl();
+        CurrentEntityState currentState = new CurrentEntityState();
          currentState.set(TestEntity.FIELD_1, "value1");
         UpdateTestEntityChangeResult testEntityChangeResult = new UpdateTestEntityChangeResult(command);
         UpdateResult<TestEntity, TestEntity.Key> results = new UpdateResult<>(ImmutableList.of(testEntityChangeResult));
@@ -70,12 +70,12 @@ public class ChangeResultInspectorTest {
 
     @Test
     public void testUpdateValueMismatch() {
-        Map<Identifier<TestEntity>, Entity> beforeEntities = Maps.newHashMap();
+        Map<Identifier<TestEntity>, CurrentEntityState> beforeEntities = Maps.newHashMap();
         UpdateTestEntityCommand command = new UpdateTestEntityCommand();
         command.set(TestEntity.FIELD_1, "value1");
         UpdateTestEntityChangeResult testEntityChangeResult = new UpdateTestEntityChangeResult(command);
         UpdateResult<TestEntity, TestEntity.Key> results = new UpdateResult<>(ImmutableList.of(testEntityChangeResult));
-        EntityImpl currentState = new EntityImpl();
+        CurrentEntityState currentState = new CurrentEntityState();
          currentState.set(TestEntity.FIELD_1, "value2");
 
         ChangeResultInspector<TestEntity> inspector = new ChangeResultInspector.Builder<TestEntity>()
@@ -90,7 +90,7 @@ public class ChangeResultInspectorTest {
 
     @Test
     public void testUpdateWithLegacyError() {
-        Map<Identifier<TestEntity>, Entity> beforeEntities = Maps.newHashMap();
+        Map<Identifier<TestEntity>, CurrentEntityState> beforeEntities = Maps.newHashMap();
         UpdateTestEntityCommand command = new UpdateTestEntityCommand();
         command.set(TestEntity.FIELD_1, "value1");
         UpdateTestEntityChangeResult testEntityChangeResult = new UpdateTestEntityChangeResult(command);
@@ -107,12 +107,12 @@ public class ChangeResultInspectorTest {
 
     @Test
     public void testUpdateWithPersistenceError() {
-        Map<Identifier<TestEntity>, Entity> beforeEntities = Maps.newHashMap();
+        Map<Identifier<TestEntity>, CurrentEntityState> beforeEntities = Maps.newHashMap();
         UpdateTestEntityCommand command = new UpdateTestEntityCommand();
         command.set(TestEntity.FIELD_1, "value1");
         UpdateTestEntityChangeResult testEntityChangeResult = new UpdateTestEntityChangeResult(command, ImmutableList.of(new ValidationError("Validation error")));
         UpdateResult<TestEntity, TestEntity.Key> results = new UpdateResult<>(ImmutableList.of(testEntityChangeResult));
-        EntityImpl currentState = new EntityImpl();
+        CurrentEntityState currentState = new CurrentEntityState();
          currentState.set(TestEntity.FIELD_1, "value1");
 
         ChangeResultInspector<TestEntity> inspector = new ChangeResultInspector.Builder<TestEntity>()
@@ -127,13 +127,13 @@ public class ChangeResultInspectorTest {
 
     @Test
     public void testCreate() {
-        Map<Identifier<TestEntity>, Entity> beforeEntities = Maps.newHashMap();
+        Map<Identifier<TestEntity>, CurrentEntityState> beforeEntities = Maps.newHashMap();
         CreateTestEntityCommand command = new CreateTestEntityCommand();
         command.set(TestEntity.FIELD_1, "value1");
         command.setIdentifier(new TestEntity.Key(1));
         EntityCreateResult<TestEntity, TestEntity.Key> testEntityChangeResult = new EntityCreateResult<>(command);
         CreateResult<TestEntity, TestEntity.Key> results = new CreateResult<>(ImmutableList.of(testEntityChangeResult));
-        EntityImpl currentState = new EntityImpl();
+        CurrentEntityState currentState = new CurrentEntityState();
          currentState.set(TestEntity.FIELD_1, "value1");
 
         ChangeResultInspector<TestEntity> inspector = new ChangeResultInspector.Builder<TestEntity>()
@@ -148,13 +148,13 @@ public class ChangeResultInspectorTest {
 
     @Test
     public void testCreateValueMismatch() {
-        Map<Identifier<TestEntity>, Entity> beforeEntities = Maps.newHashMap();
+        Map<Identifier<TestEntity>, CurrentEntityState> beforeEntities = Maps.newHashMap();
         CreateTestEntityCommand command = new CreateTestEntityCommand();
         command.set(TestEntity.FIELD_1, "value1");
         command.setIdentifier(new TestEntity.Key(1));
         EntityCreateResult<TestEntity, TestEntity.Key> testEntityChangeResult = new EntityCreateResult<>(command);
         CreateResult<TestEntity, TestEntity.Key> results = new CreateResult<>(ImmutableList.of(testEntityChangeResult));
-        EntityImpl currentState = new EntityImpl();
+        CurrentEntityState currentState = new CurrentEntityState();
          currentState.set(TestEntity.FIELD_1, "value2");
 
         ChangeResultInspector<TestEntity> inspector = new ChangeResultInspector.Builder<TestEntity>()
@@ -168,7 +168,7 @@ public class ChangeResultInspectorTest {
 
     @Test
     public void testCreateLegacyWithError() {
-        Map<Identifier<TestEntity>, Entity> beforeEntities = Maps.newHashMap();
+        Map<Identifier<TestEntity>, CurrentEntityState> beforeEntities = Maps.newHashMap();
         CreateTestEntityCommand command = new CreateTestEntityCommand();
         command.set(TestEntity.FIELD_1, "value1");
         command.setIdentifier(new TestEntity.Key(1));
@@ -186,12 +186,12 @@ public class ChangeResultInspectorTest {
 
     @Test
     public void testCreatePersistenceWithError() {
-        Map<Identifier<TestEntity>, Entity> beforeEntities = Maps.newHashMap();
+        Map<Identifier<TestEntity>, CurrentEntityState> beforeEntities = Maps.newHashMap();
         CreateTestEntityCommand command = new CreateTestEntityCommand();
         command.set(TestEntity.FIELD_1, "value1");
         EntityCreateResult<TestEntity, TestEntity.Key> testEntityChangeResult = new EntityCreateResult<>(command, ImmutableList.of(new ValidationError("Validation error")));
         CreateResult<TestEntity, TestEntity.Key> results = new CreateResult<>(ImmutableList.of(testEntityChangeResult));
-        EntityImpl currentState = new EntityImpl();
+        CurrentEntityState currentState = new CurrentEntityState();
          currentState.set(TestEntity.FIELD_1, "value1");
 
         ChangeResultInspector<TestEntity> inspector = new ChangeResultInspector.Builder<TestEntity>()

--- a/main/src/test/java/com/kenshoo/pl/entity/spi/helpers/EntityChangeCompositeValidatorTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/spi/helpers/EntityChangeCompositeValidatorTest.java
@@ -72,7 +72,7 @@ public class EntityChangeCompositeValidatorTest {
     private ChangeEntityCommand<TestEntity> entityChange;
 
     @Mock
-    private Entity currentState;
+    private CurrentEntityState currentState;
 
     @InjectMocks
     EntityChangeCompositeValidator<TestEntity> validator;

--- a/main/src/test/java/com/kenshoo/pl/entity/spi/helpers/ParentConditionCompositeValidatorTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/spi/helpers/ParentConditionCompositeValidatorTest.java
@@ -57,10 +57,10 @@ public class ParentConditionCompositeValidatorTest {
     private EntityChange<TestEntity> entityChange2;
 
     @Mock
-    private CurrentEntityState entity1;
+    private CurrentEntityState currentEntityState1;
 
     @Mock
-    private CurrentEntityState entity2;
+    private CurrentEntityState currentEntityState2;
 
     private Collection<EntityChange<TestEntity>> entityChanges;
 
@@ -75,8 +75,8 @@ public class ParentConditionCompositeValidatorTest {
         when(validator1.parentIdField()).thenReturn((EntityField) field1);
         //noinspection unchecked
         when(validator2.parentIdField()).thenReturn((EntityField) field2);
-        when(changeContext.getEntity(entityChange1)).thenReturn(entity1);
-        when(changeContext.getEntity(entityChange2)).thenReturn(entity2);
+        when(changeContext.getEntity(entityChange1)).thenReturn(currentEntityState1);
+        when(changeContext.getEntity(entityChange2)).thenReturn(currentEntityState2);
         entityChanges = ImmutableList.of(entityChange1, entityChange2);
     }
 
@@ -113,8 +113,8 @@ public class ParentConditionCompositeValidatorTest {
 
     @Test
     public void testOneValidParentToOneValidator() {
-        when(entity1.get(field1)).thenReturn(PARENT1);
-        when(entity2.get(field1)).thenReturn(PARENT1);
+        when(currentEntityState1.get(field1)).thenReturn(PARENT1);
+        when(currentEntityState2.get(field1)).thenReturn(PARENT1);
         parentConditionCompositeValidator.register(validator1);
         parentConditionCompositeValidator.validate(entityChanges, null, changeContext);
         verify(validator1, times(1)).validate(PARENT1);
@@ -122,8 +122,8 @@ public class ParentConditionCompositeValidatorTest {
 
     @Test
     public void testTwoValidParentsToOneValidator() {
-        when(entity1.get(field1)).thenReturn(PARENT1);
-        when(entity2.get(field1)).thenReturn(PARENT2);
+        when(currentEntityState1.get(field1)).thenReturn(PARENT1);
+        when(currentEntityState2.get(field1)).thenReturn(PARENT2);
         parentConditionCompositeValidator.register(validator1);
         parentConditionCompositeValidator.validate(entityChanges, null, changeContext);
         verify(validator1, times(1)).validate(PARENT1);
@@ -132,10 +132,10 @@ public class ParentConditionCompositeValidatorTest {
 
     @Test
     public void testValidateParentsWithDifferentType() {
-        when(entity1.get(field1)).thenReturn(PARENT1);
-        when(entity1.get(field2)).thenReturn(PARENT3);
-        when(entity2.get(field1)).thenReturn(PARENT1);
-        when(entity2.get(field2)).thenReturn(PARENT3);
+        when(currentEntityState1.get(field1)).thenReturn(PARENT1);
+        when(currentEntityState1.get(field2)).thenReturn(PARENT3);
+        when(currentEntityState2.get(field1)).thenReturn(PARENT1);
+        when(currentEntityState2.get(field2)).thenReturn(PARENT3);
         parentConditionCompositeValidator.register(validator1);
         parentConditionCompositeValidator.register(validator2);
         parentConditionCompositeValidator.validate(entityChanges, null, changeContext);
@@ -145,8 +145,8 @@ public class ParentConditionCompositeValidatorTest {
 
     @Test
     public void testInvalidParent() {
-        when(entity1.get(field1)).thenReturn(PARENT1);
-        when(entity2.get(field1)).thenReturn(PARENT1);
+        when(currentEntityState1.get(field1)).thenReturn(PARENT1);
+        when(currentEntityState2.get(field1)).thenReturn(PARENT1);
         ValidationError error = new ValidationError("Invalid parent operation", field1);
         when(validator1.validate(PARENT1)).thenReturn(error);
         parentConditionCompositeValidator.register(validator1);

--- a/main/src/test/java/com/kenshoo/pl/entity/spi/helpers/ParentConditionCompositeValidatorTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/spi/helpers/ParentConditionCompositeValidatorTest.java
@@ -4,7 +4,7 @@ import com.google.common.collect.ImmutableList;
 import com.kenshoo.pl.entity.ChangeContext;
 import com.kenshoo.pl.entity.ChangeEntityCommand;
 import com.kenshoo.pl.entity.ChangeOperation;
-import com.kenshoo.pl.entity.Entity;
+import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.EntityChange;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.TestEntity;
@@ -57,10 +57,10 @@ public class ParentConditionCompositeValidatorTest {
     private EntityChange<TestEntity> entityChange2;
 
     @Mock
-    private Entity entity1;
+    private CurrentEntityState entity1;
 
     @Mock
-    private Entity entity2;
+    private CurrentEntityState entity2;
 
     private Collection<EntityChange<TestEntity>> entityChanges;
 


### PR DESCRIPTION
This is a preparation for FinalEntityState.
We shall end up with:
* CurrentEntityState implements Entity
* FinalEntityState implements Entity

Existing usages of the `Entity` interface are replaced with `CurrentEntityState` because Entity used to be the current state.
Those usages could work with "Entity", but it would be confusing.