### PR TITLE
PL-74: Auditing: Support mandatory fields from same entity - part 2: Populate in AuditRecord

### DIFF
--- a/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForCreateOneLevelWithMandatoryTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForCreateOneLevelWithMandatoryTest.java
@@ -5,11 +5,16 @@ import com.kenshoo.jooq.DataTable;
 import com.kenshoo.jooq.DataTableUtils;
 import com.kenshoo.jooq.TestJooqConfig;
 import com.kenshoo.pl.audit.commands.CreateAuditedWithAncestorMandatoryCommand;
+import com.kenshoo.pl.audit.commands.CreateAuditedWithSelfAndAncestorMandatoryCommand;
+import com.kenshoo.pl.audit.commands.CreateAuditedWithSelfMandatoryCommand;
 import com.kenshoo.pl.entity.*;
 import com.kenshoo.pl.entity.audit.AuditRecord;
 import com.kenshoo.pl.entity.internal.audit.AncestorTable;
+import com.kenshoo.pl.entity.internal.audit.MainTable;
 import com.kenshoo.pl.entity.internal.audit.MainWithAncestorTable;
 import com.kenshoo.pl.entity.internal.audit.entitytypes.AuditedWithAncestorMandatoryType;
+import com.kenshoo.pl.entity.internal.audit.entitytypes.AuditedWithSelfAndAncestorMandatoryType;
+import com.kenshoo.pl.entity.internal.audit.entitytypes.AuditedWithSelfMandatoryType;
 import com.kenshoo.pl.entity.internal.audit.entitytypes.NotAuditedAncestorType;
 import org.jooq.DSLContext;
 import org.junit.After;
@@ -33,22 +38,35 @@ public class AuditForCreateOneLevelWithMandatoryTest {
     private static final String ANCESTOR_NAME = "ancestorName";
     private static final String ANCESTOR_DESC = "ancestorDesc";
 
-    private static final EntityField<AuditedWithAncestorMandatoryType, Long> ANCESTOR_FK_FIELD = AuditedWithAncestorMandatoryType.ANCESTOR_ID;
-    private static final EntityField<AuditedWithAncestorMandatoryType, String> NAME_FIELD = AuditedWithAncestorMandatoryType.NAME;
-    private static final EntityField<AuditedWithAncestorMandatoryType, String> DESC_FIELD = AuditedWithAncestorMandatoryType.DESC;
+    private static final EntityField<AuditedWithAncestorMandatoryType, Long> AUD_WITH_ANC_FK_FIELD = AuditedWithAncestorMandatoryType.ANCESTOR_ID;
+    private static final EntityField<AuditedWithSelfAndAncestorMandatoryType, Long> AUD_WITH_BOTH_FK_FIELD = AuditedWithSelfAndAncestorMandatoryType.ANCESTOR_ID;
+
+    private static final EntityField<AuditedWithAncestorMandatoryType, String> AUD_WITH_ANC_NAME_FIELD = AuditedWithAncestorMandatoryType.NAME;
+    private static final EntityField<AuditedWithAncestorMandatoryType, String> AUD_WITH_ANC_DESC_FIELD = AuditedWithAncestorMandatoryType.DESC;
+
+    private static final EntityField<AuditedWithSelfMandatoryType, String> AUD_WITH_SELF_NAME_FIELD = AuditedWithSelfMandatoryType.NAME;
+    private static final EntityField<AuditedWithSelfMandatoryType, String> AUD_WITH_SELF_DESC_FIELD = AuditedWithSelfMandatoryType.DESC;
+
+    private static final EntityField<AuditedWithSelfAndAncestorMandatoryType, String> AUD_WITH_BOTH_NAME_FIELD = AuditedWithSelfAndAncestorMandatoryType.NAME;
+    private static final EntityField<AuditedWithSelfAndAncestorMandatoryType, String> AUD_WITH_BOTH_DESC_FIELD = AuditedWithSelfAndAncestorMandatoryType.DESC;
 
     private static final EntityField<NotAuditedAncestorType, String> ANCESTOR_NAME_FIELD = NotAuditedAncestorType.NAME;
     private static final EntityField<NotAuditedAncestorType, String> ANCESTOR_DESC_FIELD = NotAuditedAncestorType.DESC;
 
-    private static final List<DataTable> ALL_TABLES = ImmutableList.of(MainWithAncestorTable.INSTANCE,
+    private static final List<DataTable> ALL_TABLES = ImmutableList.of(MainTable.INSTANCE,
+                                                                       MainWithAncestorTable.INSTANCE,
                                                                        AncestorTable.INSTANCE);
 
     private PLContext plContext;
     private InMemoryAuditRecordPublisher auditRecordPublisher;
 
-    private ChangeFlowConfig<AuditedWithAncestorMandatoryType> mainWithAncestorMandatoryConfig;
+    private ChangeFlowConfig<AuditedWithAncestorMandatoryType> auditedWithAncestorConfig;
+    private ChangeFlowConfig<AuditedWithSelfMandatoryType> auditedWithSelfConfig;
+    private ChangeFlowConfig<AuditedWithSelfAndAncestorMandatoryType> auditedWithBothConfig;
 
-    private PersistenceLayer<AuditedWithAncestorMandatoryType> mainWithAncestorMandatoryPL;
+    private PersistenceLayer<AuditedWithAncestorMandatoryType> auditedWithAncestorPL;
+    private PersistenceLayer<AuditedWithSelfMandatoryType> auditedWithSelfPL;
+    private PersistenceLayer<AuditedWithSelfAndAncestorMandatoryType> auditedWithBothPL;
 
     @Before
     public void setUp() {
@@ -59,9 +77,13 @@ public class AuditForCreateOneLevelWithMandatoryTest {
             .withAuditRecordPublisher(auditRecordPublisher)
             .build();
 
-        mainWithAncestorMandatoryConfig = flowConfig(AuditedWithAncestorMandatoryType.INSTANCE);
+        auditedWithAncestorConfig = flowConfig(AuditedWithAncestorMandatoryType.INSTANCE);
+        auditedWithSelfConfig = flowConfig(AuditedWithSelfMandatoryType.INSTANCE);
+        auditedWithBothConfig = flowConfig(AuditedWithSelfAndAncestorMandatoryType.INSTANCE);
 
-        mainWithAncestorMandatoryPL = persistenceLayer();
+        auditedWithAncestorPL = persistenceLayer();
+        auditedWithSelfPL = persistenceLayer();
+        auditedWithBothPL = persistenceLayer();
 
         ALL_TABLES.forEach(table -> DataTableUtils.createTable(dslContext, table));
 
@@ -78,12 +100,12 @@ public class AuditForCreateOneLevelWithMandatoryTest {
     }
 
     @Test
-    public void oneEntity_WithEntityLevelMandatoryFields_AndFieldsInCmd_ShouldCreateMandatoryFieldsAndFieldRecords() {
-        mainWithAncestorMandatoryPL.create(singletonList(createCommand()
-                                                             .with(ANCESTOR_FK_FIELD, ANCESTOR_ID)
-                                                             .with(NAME_FIELD, NAME)
-                                                             .with(DESC_FIELD, DESC)),
-                                           mainWithAncestorMandatoryConfig);
+    public void entityWithExternalMandatory_AndFieldsInCmd_ShouldCreateMandatoryFieldsAndFieldRecords() {
+        auditedWithAncestorPL.create(singletonList(createAuditedWithAncestorCommand()
+                                                       .with(AUD_WITH_ANC_FK_FIELD, ANCESTOR_ID)
+                                                       .with(AUD_WITH_ANC_NAME_FIELD, NAME)
+                                                       .with(AUD_WITH_ANC_DESC_FIELD, DESC)),
+                                     auditedWithAncestorConfig);
 
         final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
@@ -92,19 +114,52 @@ public class AuditForCreateOneLevelWithMandatoryTest {
         final AuditRecord<AuditedWithAncestorMandatoryType> auditRecord = typed(auditRecords.get(0));
         assertThat(auditRecord, allOf(hasMandatoryFieldValue(ANCESTOR_NAME_FIELD, ANCESTOR_NAME),
                                       hasMandatoryFieldValue(ANCESTOR_DESC_FIELD, ANCESTOR_DESC),
-                                      hasCreatedFieldRecord(NAME_FIELD, NAME),
-                                      hasCreatedFieldRecord(DESC_FIELD, DESC)));
-    }
-
-    private CreateAuditedWithAncestorMandatoryCommand createCommand() {
-        return new CreateAuditedWithAncestorMandatoryCommand();
+                                      hasCreatedFieldRecord(AUD_WITH_ANC_NAME_FIELD, NAME),
+                                      hasCreatedFieldRecord(AUD_WITH_ANC_DESC_FIELD, DESC)));
     }
 
     @Test
-    public void oneEntity_WithEntityLevelMandatoryFields_AndNoFieldsInCmd_ShouldCreateMandatoryFieldsOnly() {
-        mainWithAncestorMandatoryPL.create(singletonList(createCommand()
-                                                             .with(ANCESTOR_FK_FIELD, ANCESTOR_ID)),
-                                           mainWithAncestorMandatoryConfig);
+    public void entityWithSelfMandatory_AndFieldsInCmd_ShouldCreateMandatoryFieldsAndFieldRecords() {
+        auditedWithSelfPL.create(singletonList(createAuditedWithSelfCommand()
+                                                   .with(AUD_WITH_SELF_NAME_FIELD, NAME)
+                                                   .with(AUD_WITH_SELF_DESC_FIELD, DESC)),
+                                 auditedWithSelfConfig);
+
+        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+
+        assertThat("Incorrect number of published records",
+                   auditRecords, hasSize(1));
+        final AuditRecord<AuditedWithSelfMandatoryType> auditRecord = typed(auditRecords.get(0));
+        assertThat(auditRecord, allOf(hasMandatoryFieldValue(AUD_WITH_SELF_NAME_FIELD, NAME),
+                                      hasCreatedFieldRecord(AUD_WITH_SELF_NAME_FIELD, NAME),
+                                      hasCreatedFieldRecord(AUD_WITH_SELF_DESC_FIELD, DESC)));
+    }
+
+    @Test
+    public void entityWithSelfAndExternalMandatory_AndFieldsInCmd_ShouldCreateMandatoryFieldsForBothAndFieldRecords() {
+        auditedWithBothPL.create(singletonList(createAuditedWithBothCommand()
+                                                   .with(AUD_WITH_BOTH_FK_FIELD, ANCESTOR_ID)
+                                                   .with(AUD_WITH_BOTH_NAME_FIELD, NAME)
+                                                   .with(AUD_WITH_BOTH_DESC_FIELD, DESC)),
+                                 auditedWithBothConfig);
+
+        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+
+        assertThat("Incorrect number of published records",
+                   auditRecords, hasSize(1));
+        final AuditRecord<AuditedWithSelfAndAncestorMandatoryType> auditRecord = typed(auditRecords.get(0));
+        assertThat(auditRecord, allOf(hasMandatoryFieldValue(AUD_WITH_BOTH_NAME_FIELD, NAME),
+                                      hasMandatoryFieldValue(ANCESTOR_NAME_FIELD, ANCESTOR_NAME),
+                                      hasMandatoryFieldValue(ANCESTOR_DESC_FIELD, ANCESTOR_DESC),
+                                      hasCreatedFieldRecord(AUD_WITH_BOTH_NAME_FIELD, NAME),
+                                      hasCreatedFieldRecord(AUD_WITH_BOTH_DESC_FIELD, DESC)));
+    }
+
+    @Test
+    public void entityWithExternalMandatory_AndNoFieldsInCmd_ShouldCreateMandatoryFieldsOnly() {
+        auditedWithAncestorPL.create(singletonList(createAuditedWithAncestorCommand()
+                                                       .with(AUD_WITH_ANC_FK_FIELD, ANCESTOR_ID)),
+                                     auditedWithAncestorConfig);
 
         final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
@@ -116,12 +171,39 @@ public class AuditForCreateOneLevelWithMandatoryTest {
                                       hasNoFieldRecords()));
     }
 
+    @Test
+    public void entityWithSelfMandatory_AndOnlyMandatoryInCmd_ShouldCreateMandatoryFieldsAndFieldRecordsForSameFields() {
+        auditedWithSelfPL.create(singletonList(createAuditedWithSelfCommand()
+                                                   .with(AUD_WITH_SELF_NAME_FIELD, NAME)),
+                                 auditedWithSelfConfig);
+
+        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+
+        assertThat("Incorrect number of published records",
+                   auditRecords, hasSize(1));
+        final AuditRecord<AuditedWithSelfMandatoryType> auditRecord = typed(auditRecords.get(0));
+        assertThat(auditRecord, allOf(hasMandatoryFieldValue(AUD_WITH_SELF_NAME_FIELD, NAME),
+                                      hasCreatedFieldRecord(AUD_WITH_SELF_NAME_FIELD, NAME)));
+    }
+
     private <E extends EntityType<E>> ChangeFlowConfig<E> flowConfig(final E entityType) {
         return ChangeFlowConfigBuilderFactory.newInstance(plContext, entityType).build();
     }
 
     private <E extends EntityType<E>> PersistenceLayer<E> persistenceLayer() {
         return new PersistenceLayer<>(plContext);
+    }
+
+    private CreateAuditedWithAncestorMandatoryCommand createAuditedWithAncestorCommand() {
+        return new CreateAuditedWithAncestorMandatoryCommand();
+    }
+
+    private CreateAuditedWithSelfMandatoryCommand createAuditedWithSelfCommand() {
+        return new CreateAuditedWithSelfMandatoryCommand();
+    }
+
+    private CreateAuditedWithSelfAndAncestorMandatoryCommand createAuditedWithBothCommand() {
+        return new CreateAuditedWithSelfAndAncestorMandatoryCommand();
     }
 
     @SuppressWarnings("unchecked")

--- a/integration-tests/src/test/java/com/kenshoo/pl/audit/commands/CreateAuditedWithSelfAndAncestorMandatoryCommand.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/audit/commands/CreateAuditedWithSelfAndAncestorMandatoryCommand.java
@@ -1,0 +1,13 @@
+package com.kenshoo.pl.audit.commands;
+
+import com.kenshoo.pl.entity.CreateEntityCommand;
+import com.kenshoo.pl.entity.EntityCommandExt;
+import com.kenshoo.pl.entity.internal.audit.entitytypes.AuditedWithSelfAndAncestorMandatoryType;
+
+public class CreateAuditedWithSelfAndAncestorMandatoryCommand extends CreateEntityCommand<AuditedWithSelfAndAncestorMandatoryType>
+    implements EntityCommandExt<AuditedWithSelfAndAncestorMandatoryType, CreateAuditedWithSelfAndAncestorMandatoryCommand> {
+
+    public CreateAuditedWithSelfAndAncestorMandatoryCommand() {
+        super(AuditedWithSelfAndAncestorMandatoryType.INSTANCE);
+    }
+}

--- a/integration-tests/src/test/java/com/kenshoo/pl/audit/commands/CreateAuditedWithSelfMandatoryCommand.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/audit/commands/CreateAuditedWithSelfMandatoryCommand.java
@@ -1,0 +1,13 @@
+package com.kenshoo.pl.audit.commands;
+
+import com.kenshoo.pl.entity.CreateEntityCommand;
+import com.kenshoo.pl.entity.EntityCommandExt;
+import com.kenshoo.pl.entity.internal.audit.entitytypes.AuditedWithSelfMandatoryType;
+
+public class CreateAuditedWithSelfMandatoryCommand extends CreateEntityCommand<AuditedWithSelfMandatoryType>
+    implements EntityCommandExt<AuditedWithSelfMandatoryType, CreateAuditedWithSelfMandatoryCommand> {
+
+    public CreateAuditedWithSelfMandatoryCommand() {
+        super(AuditedWithSelfMandatoryType.INSTANCE);
+    }
+}

--- a/integration-tests/src/test/java/com/kenshoo/pl/audit/commands/DeleteAuditedWithSelfMandatoryCommand.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/audit/commands/DeleteAuditedWithSelfMandatoryCommand.java
@@ -1,0 +1,15 @@
+package com.kenshoo.pl.audit.commands;
+
+import com.kenshoo.pl.entity.DeleteEntityCommand;
+import com.kenshoo.pl.entity.EntityCommandExt;
+import com.kenshoo.pl.entity.Identifier;
+import com.kenshoo.pl.entity.SingleUniqueKeyValue;
+import com.kenshoo.pl.entity.internal.audit.entitytypes.AuditedWithSelfMandatoryType;
+
+public class DeleteAuditedWithSelfMandatoryCommand extends DeleteEntityCommand<AuditedWithSelfMandatoryType, Identifier<AuditedWithSelfMandatoryType>>
+    implements EntityCommandExt<AuditedWithSelfMandatoryType, DeleteAuditedWithSelfMandatoryCommand> {
+
+    public DeleteAuditedWithSelfMandatoryCommand(final long id) {
+        super(AuditedWithSelfMandatoryType.INSTANCE, new SingleUniqueKeyValue<>(AuditedWithSelfMandatoryType.ID, id));
+    }
+}

--- a/integration-tests/src/test/java/com/kenshoo/pl/audit/commands/UpdateAuditedWithSelfMandatoryCommand.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/audit/commands/UpdateAuditedWithSelfMandatoryCommand.java
@@ -1,0 +1,15 @@
+package com.kenshoo.pl.audit.commands;
+
+import com.kenshoo.pl.entity.EntityCommandExt;
+import com.kenshoo.pl.entity.Identifier;
+import com.kenshoo.pl.entity.SingleUniqueKeyValue;
+import com.kenshoo.pl.entity.UpdateEntityCommand;
+import com.kenshoo.pl.entity.internal.audit.entitytypes.AuditedWithSelfMandatoryType;
+
+public class UpdateAuditedWithSelfMandatoryCommand extends UpdateEntityCommand<AuditedWithSelfMandatoryType, Identifier<AuditedWithSelfMandatoryType>>
+    implements EntityCommandExt<AuditedWithSelfMandatoryType, UpdateAuditedWithSelfMandatoryCommand> {
+
+    public UpdateAuditedWithSelfMandatoryCommand(final long id) {
+        super(AuditedWithSelfMandatoryType.INSTANCE, new SingleUniqueKeyValue<>(AuditedWithSelfMandatoryType.ID, id));
+    }
+}

--- a/main/src/main/java/com/kenshoo/pl/entity/Triptional.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/Triptional.java
@@ -142,7 +142,6 @@ public class Triptional<T> {
     public boolean equals(final Object obj, final BiFunction<T, T, Boolean> valueEqualityFunction) {
         requireNonNull(valueEqualityFunction, "A value equality function must be provided");
 
-        // The next line covers the cases of both NULL / both ABSENT (as both are singletons), so further down we only need to check FILLED
         if (this == obj) {
             return true;
         }
@@ -151,18 +150,14 @@ public class Triptional<T> {
             return false;
         }
 
-        final Triptional<?> other = (Triptional<?>) obj;
+        //noinspection unchecked
+        final Triptional<T> other = (Triptional<T>) obj;
 
-        if (!filledWithSameType(other)) {
+        if (!(isPresent() && other.isPresent())) {
             return false;
         }
 
-        //noinspection unchecked
-        return valueEqualityFunction.apply(value, ((Triptional<T>)other).value);
-    }
-
-    private boolean filledWithSameType(final Triptional<?> other) {
-        return isFilled() && other.isFilled() && value.getClass() == other.value.getClass();
+        return valueEqualityFunction.apply(value, other.value);
     }
 
     @Override

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGenerator.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGenerator.java
@@ -65,7 +65,7 @@ public class AuditRecordGenerator<E extends EntityType<E>> implements CurrentSta
 
         final Collection<? extends EntityFieldValue> mandatoryFieldValues = generateMandatoryFieldValues(finalState);
 
-        final Collection<? extends FieldAuditRecord<E>> fieldRecords = generateFieldRecords(currentState, finalState);
+        final Collection<? extends FieldAuditRecord<E>> fieldRecords = generateChangedFieldRecords(currentState, finalState);
 
         return new AuditRecord.Builder<E>()
             .withEntityType(entityChange.getEntityType())
@@ -77,7 +77,7 @@ public class AuditRecordGenerator<E extends EntityType<E>> implements CurrentSta
             .build();
     }
 
-    private Collection<? extends FieldAuditRecord<E>> generateFieldRecords(final CurrentEntityState currentState, final FinalEntityState finalState) {
+    private Collection<? extends FieldAuditRecord<E>> generateChangedFieldRecords(final CurrentEntityState currentState, final FinalEntityState finalState) {
         return auditedFieldSet.getAllSelfFields()
                               .filter(field -> fieldWasChanged(currentState, finalState, field))
                               .map(field -> buildFieldRecord(currentState, finalState, field))

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGenerator.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGenerator.java
@@ -10,7 +10,6 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 
 import java.util.Collection;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Stream;
 
 import static com.kenshoo.pl.entity.ChangeOperation.UPDATE;
@@ -62,14 +61,11 @@ public class AuditRecordGenerator<E extends EntityType<E>> implements CurrentSta
 
         final String entityId = extractEntityId(entityChange, currentState);
 
-        final Collection<? extends EntityFieldValue> mandatoryFieldValues = generateMandatoryFieldValues(currentState);
+        final FinalEntityState finalState = new FinalEntityState(currentState, entityChange);
 
-        final Set<? extends EntityField<E, ?>> candidateOnChangeFields = auditedFieldSet.intersectWith(entityChange.getChangedFields())
-                                                                                        .getOnChangeFields();
+        final Collection<? extends EntityFieldValue> mandatoryFieldValues = generateMandatoryFieldValues(finalState);
 
-        final Collection<? extends FieldAuditRecord<E>> fieldRecords = generateFieldRecords(entityChange,
-                                                                                            currentState,
-                                                                                            candidateOnChangeFields);
+        final Collection<? extends FieldAuditRecord<E>> fieldRecords = generateFieldRecords(currentState, finalState);
 
         return new AuditRecord.Builder<E>()
             .withEntityType(entityChange.getEntityType())
@@ -81,21 +77,19 @@ public class AuditRecordGenerator<E extends EntityType<E>> implements CurrentSta
             .build();
     }
 
-    private Collection<? extends FieldAuditRecord<E>> generateFieldRecords(final EntityChange<E> entityChange,
-                                                                           final CurrentEntityState currentState,
-                                                                           final Collection<? extends EntityField<E, ?>> candidateOnChangeFields) {
-        return candidateOnChangeFields.stream()
-                                      .filter(field -> fieldWasChanged(entityChange, currentState, field))
-                                      .map(field -> buildFieldRecord(entityChange, currentState, field))
-                                      .collect(toList());
+    private Collection<? extends FieldAuditRecord<E>> generateFieldRecords(final CurrentEntityState currentState, final FinalEntityState finalState) {
+        return auditedFieldSet.getAllSelfFields()
+                              .filter(field -> fieldWasChanged(currentState, finalState, field))
+                              .map(field -> buildFieldRecord(currentState, finalState, field))
+                              .collect(toList());
     }
 
-    private FieldAuditRecord<E> buildFieldRecord(final EntityChange<E> entityChange,
-                                                 final CurrentEntityState currentState,
+    private FieldAuditRecord<E> buildFieldRecord(final CurrentEntityState currentState,
+                                                 final FinalEntityState finalState,
                                                  final EntityField<E, ?> field) {
         final FieldAuditRecord.Builder<E> fieldRecordBuilder = FieldAuditRecord.builder(field);
-         currentState.safeGet(field).ifFilled(fieldRecordBuilder::oldValue);
-        entityChange.safeGet(field).ifFilled(fieldRecordBuilder::newValue);
+        currentState.safeGet(field).ifFilled(fieldRecordBuilder::oldValue);
+        finalState.safeGet(field).ifFilled(fieldRecordBuilder::newValue);
         return fieldRecordBuilder.build();
     }
 
@@ -106,30 +100,24 @@ public class AuditRecordGenerator<E extends EntityType<E>> implements CurrentSta
                                                                                  "from either the EntityChange or the CurrentEntityState, so the audit record cannot be generated."));
     }
 
-    private Collection<? extends EntityFieldValue> generateMandatoryFieldValues(final CurrentEntityState currentState) {
-        return auditedFieldSet.getExternalMandatoryFields().stream()
-                              .map(field -> ImmutablePair.of(field,  currentState.safeGet(field)))
+    private Collection<? extends EntityFieldValue> generateMandatoryFieldValues(final FinalEntityState finalState) {
+        return auditedFieldSet.getAllMandatoryFields()
+                              .map(field -> ImmutablePair.of(field, finalState.safeGet(field)))
                               .filter(pair -> pair.getValue().isFilled())
                               .map(pair -> new EntityFieldValue(pair.getKey(), pair.getValue().get()))
                               .collect(toList());
     }
 
-    private boolean fieldWasChanged(final EntityChange<E> entityChange,
-                                    final CurrentEntityState currentState,
-                                    final EntityField<E, ?> field) {
-        return !fieldStayedTheSame(entityChange, currentState, field);
+    private <T> boolean fieldWasChanged(final CurrentEntityState currentState,
+                                        final FinalEntityState finalState,
+                                        final EntityField<E, T> field) {
+        return !fieldStayedTheSame(currentState, finalState, field);
     }
 
-    private boolean fieldStayedTheSame(final EntityChange<E> entityChange,
-                                       final CurrentEntityState currentState,
-                                       final EntityField<E, ?> field) {
-        return  currentState.containsField(field) && fieldValuesEqual(entityChange, currentState, field);
-    }
-
-    private <T> boolean fieldValuesEqual(final EntityChange<E> entityChange,
-                                         final CurrentEntityState currentState,
-                                         final EntityField<E, T> field) {
-        return field.valuesEqual(entityChange.get(field),  currentState.get(field));
+    private <T> boolean fieldStayedTheSame(final CurrentEntityState currentState,
+                                           final FinalEntityState finalState,
+                                           final EntityField<E, T> field) {
+        return currentState.safeGet(field).equals(finalState.safeGet(field), field::valuesEqual);
     }
 
     @VisibleForTesting

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditedFieldSet.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditedFieldSet.java
@@ -48,8 +48,14 @@ public class AuditedFieldSet<E extends EntityType<E>> {
         return selfMandatoryFields;
     }
 
-    public Set<? extends EntityField<E, ?>> getOnChangeFields() {
-        return onChangeFields;
+    public Stream<? extends EntityField<?, ?>> getAllMandatoryFields() {
+        return Stream.of(externalMandatoryFields, selfMandatoryFields)
+                     .flatMap(Set::stream);
+    }
+
+    public Stream<? extends EntityField<E, ?>> getAllSelfFields() {
+        return Stream.of(selfMandatoryFields, onChangeFields)
+                     .flatMap(Set::stream);
     }
 
     public boolean hasSelfFields() {
@@ -69,14 +75,6 @@ public class AuditedFieldSet<E extends EntityType<E>> {
             .withExternalMandatoryFields(externalMandatoryFields)
             .withSelfMandatoryFields(selfMandatoryFields)
             .withOnChangeFields(Seq.seq(fields).filter(onChangeFields::contains))
-            .build();
-    }
-
-    public AuditedFieldSet<E> setExternalMandatoryFields(final Iterable<? extends EntityField<?, ?>> externalMandatoryFields) {
-        return builder(idField)
-            .withExternalMandatoryFields(externalMandatoryFields)
-            .withSelfMandatoryFields(selfMandatoryFields)
-            .withOnChangeFields(onChangeFields)
             .build();
     }
 

--- a/main/src/test/java/com/kenshoo/pl/entity/TriptionalTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/TriptionalTest.java
@@ -10,6 +10,8 @@ import java.util.Objects;
 import static com.github.npathai.hamcrestopt.OptionalMatchers.isEmpty;
 import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresentAndIs;
 import static java.util.Collections.singletonList;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
@@ -371,7 +373,14 @@ public class TriptionalTest {
     }
 
     @Test
-    public void equalsTwoArgs_WhenOneFilledAndOneNull_ShouldReturnFalse() {
+    public void equalsTwoArgs_WhenOneFilledAndOneNull_AndEqualityFunctionTrue_ShouldReturnTrue() {
+        assertThat(Triptional.of(EMPTY).equals(Triptional.nullInstance(),
+                                               (s1, s2) -> defaultIfEmpty(s1, "bla").equals(defaultIfEmpty(s2, "bla"))),
+                   is(true));
+    }
+
+    @Test
+    public void equalsTwoArgs_WhenOneFilledAndOneNull_AndEqualityFunctionFalse_ShouldReturnFalse() {
         assertThat(Triptional.of(2).equals(Triptional.nullInstance(), Objects::equals),
                    is(false));
     }

--- a/main/src/test/java/com/kenshoo/pl/entity/TriptionalTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/TriptionalTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 
 import static com.github.npathai.hamcrestopt.OptionalMatchers.isEmpty;
 import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresentAndIs;
@@ -328,35 +329,70 @@ public class TriptionalTest {
     }
 
     @Test
-    public void equals_WhenBothFilledWithSameValue_ShouldReturnTrue() {
+    public void equalsOneArg_WhenBothFilledWithSameValue_ShouldReturnTrue() {
         assertThat(Triptional.of(2).equals(Triptional.of(1 + 1)), is(true));
     }
 
     @Test
-    public void equals_WhenBothFilledWithDifferentValues_ShouldReturnFalse() {
+    public void equalsOneArg_WhenBothFilledWithDifferentValues_ShouldReturnFalse() {
         assertThat(Triptional.of(2).equals(Triptional.of(3)), is(false));
     }
 
     @Test
-    public void equals_WhenOneFilledAndOneNull_ShouldReturnFalse() {
+    public void equalsOneArg_WhenOneFilledAndOneNull_ShouldReturnFalse() {
         assertThat(Triptional.of(2).equals(Triptional.nullInstance()), is(false));
     }
 
     @Test
-    public void equals_WhenOneFilledAndOneAbsent_ShouldReturnFalse() {
+    public void equalsOneArg_WhenOneFilledAndOneAbsent_ShouldReturnFalse() {
         assertThat(Triptional.of(2).equals(Triptional.absent()), is(false));
     }
 
     @Test
-    public void equals_WhenBothNull_ShouldReturnTrue() {
+    public void equalsOneArg_WhenBothNull_ShouldReturnTrue() {
         assertThat(Triptional.nullInstance().equals(Triptional.of(null)), is(true));
     }
 
     @Test
-    public void equals_WhenOneNullAndOneAbsent_ShouldReturnFalse() {
+    public void equalsOneArg_WhenOneNullAndOneAbsent_ShouldReturnFalse() {
         assertThat(Triptional.nullInstance().equals(Triptional.absent()), is(false));
     }
 
+    @Test
+    public void equalsTwoArgs_ForTwoDoublesCloseEnough_ShouldReturnTrue() {
+        assertThat(Triptional.of(2.001).equals(Triptional.of(2.0), (x, y) -> Math.abs(x - y) < 0.01),
+                   is(true));
+    }
+
+    @Test
+    public void equalsTwoArgs_ForTwoDoublesNotCloseEnough_ShouldReturnFalse() {
+        assertThat(Triptional.of(2.1).equals(Triptional.of(2.0), (x, y) -> Math.abs(x - y) < 0.01),
+                   is(false));
+    }
+
+    @Test
+    public void equalsTwoArgs_WhenOneFilledAndOneNull_ShouldReturnFalse() {
+        assertThat(Triptional.of(2).equals(Triptional.nullInstance(), Objects::equals),
+                   is(false));
+    }
+
+    @Test
+    public void equalsTwoArgs_WhenOneFilledAndOneAbsent_ShouldReturnFalse() {
+        assertThat(Triptional.of(2).equals(Triptional.absent(), Objects::equals),
+                   is(false));
+    }
+
+    @Test
+    public void equalsTwoArgs_WhenBothNull_ShouldReturnTrue() {
+        assertThat(Triptional.nullInstance().equals(Triptional.of(null), Objects::equals),
+                   is(true));
+    }
+
+    @Test
+    public void equalsTwoArgs_WhenOneNullAndOneAbsent_ShouldReturnFalse() {
+        assertThat(Triptional.nullInstance().equals(Triptional.absent(), Objects::equals),
+                   is(false));
+    }
     private Triptional<String> toTriptionalString(final Object val) {
         return Triptional.of(String.valueOf(val));
     }


### PR DESCRIPTION
See [part 1](https://github.com/kenshoo/persistence-layer/pull/148).

This part completes the feature by taking the "self-mandatory" fields that were resolved from annotations, and populating them in the resulting AuditRecord for a given command.

This means the following two things:
- Whenever a field is marked as `@Audited(trigger = ALWAYS)` and there is **any** change in the entity, it will appear in the top level of the generated record with the latest value.
- Whenever a field is marked as `@Audited(trigger = ALWAYS)` and the **field itself has changed**, it will appear **additionally** in the field records with the old and new values (like other fields).

So whenever the entity is created, and also on update if the mandatory field is changed - it will appear twice overall in the record.
This seeming duplication will help to keep the structure of the published record consistent and easy for parsing / analyzing.

**For example:**  

If the keyword entity is defined like this:

```
@Audited
public class KeywordType extends AbstractEntityType<KeywordType> {

    @Id
    public static final EntityField<Long> ID = INSTANCE.field(KeywordTable.INSTANCE.id);

    @Audited(trigger = ALWAYS)
    public static final EntityField<KeywordType, String> MATCH_TYPE = INSTANCE.field(KeywordTable.INSTANCE.match_type);

    public static final EntityField<KeywordType, String> TEXT = INSTANCE.field(KeywordTable.INSTANCE.text);
}
```

Then after creating a new keyword the audit record might look like this:

```
{
    "entityType": "Keyword",
    "entityId: 1234,
    "matchType": "BROAD",
    "operator": "CREATE",
    "fieldChanges": [
         "matchType" : {
               "newValue" : "BROAD"
         },
         "text": {
               "newValue" : "Shoes"
         }
    ]
}
```

After updating the text it may look like this:

```
{
    "entityType": "Keyword",
    "entityId: 1234,
    "matchType": "BROAD",
    "operator": "UPDATE",
    "fieldChanges": [
         "text": {
               "oldValue" : "Shoes",
               "newValue" : "Pants"
         }
    ]
}
```

After updating the match type it may look like this:

```
{
    "entityType": "Keyword",
    "entityId: 1234,
    "matchType": "PHRASE",
    "operator": "UPDATE",
    "fieldChanges": [
         "matchType": {
               "oldValue" : "BROAD",
               "newValue" : "PHRASE"
         }
    ]
}
```