### PR TITLE
PL-65: Support auditing on update only - part 1: Add trigger type

### DIFF
--- a/main/src/main/java/com/kenshoo/pl/entity/annotation/audit/Audited.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/annotation/audit/Audited.java
@@ -9,7 +9,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import static com.kenshoo.pl.entity.audit.AuditTrigger.ON_CHANGE;
+import static com.kenshoo.pl.entity.audit.AuditTrigger.ON_CREATE_OR_UPDATE;
 
 /**
  * Whenever an entity or field has this annotation, it indicates that any changes to the entity / field
@@ -22,9 +22,10 @@ public @interface Audited {
 
     /**
      * @return the rule by which to trigger auditing for the annotated entity type or field.<br>
-     * This attribute is valid for <b>field-level annotations only</b>, and will be ignored if appearing on entities (for the entity-level, ON_CHANGE is implied always).
+     * This attribute is valid for <b>field-level annotations only</b>, and will be ignored if appearing on entities.<br>
+     * For the entity-level,{@link AuditTrigger#ON_CREATE_OR_UPDATE} is implied always.
      */
-    AuditTrigger trigger() default ON_CHANGE;
+    AuditTrigger trigger() default ON_CREATE_OR_UPDATE;
 
     /**
      * <b>NOTE</b>: This attribute is valid for entity-level annotations only, and will be ignored if appearing on fields.

--- a/main/src/main/java/com/kenshoo/pl/entity/audit/AuditTrigger.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/audit/AuditTrigger.java
@@ -8,13 +8,22 @@ package com.kenshoo.pl.entity.audit;
 public enum AuditTrigger {
 
     /**
-     * Indicates that a field should be audited always, regardless of whether its value has changed - whenever there is some other change in the  currentState.<br>
+     * Indicates that a field should be audited always, regardless of whether its value has changed - whenever there is some change in the entity.<br>
      * This means that the <b>current</b> value of the field will always be included in {@link AuditRecord#getMandatoryFieldValues()}.
      */
     ALWAYS,
+
     /**
-     * Indicates that a field should be audited only if its value has changed.<br>
-     * This means that whenever the value changes, the old and new values will be included in {@link AuditRecord#getFieldRecords()}.
+     * Indicates that a field should be audited only if it is either being created, or its value has changed during an update.<br>
+     * This means that:<br>
+     * Upon create, the new value will be included in {@link AuditRecord#getFieldRecords()}.<br>
+     * Upon update if the value has changed - the old and new values will be included in {@link AuditRecord#getFieldRecords()}.
      */
-    ON_CHANGE
+    ON_CREATE_OR_UPDATE,
+
+    /**
+     * Indicates that a field should be audited only if its value has changed during an update.<br>
+     * This means that upon update if the value has changed - the old and new values will be included in {@link AuditRecord#getFieldRecords()}.
+     */
+    ON_UPDATE
 }

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditedFieldsResolver.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditedFieldsResolver.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import static com.kenshoo.pl.entity.audit.AuditTrigger.ALWAYS;
-import static com.kenshoo.pl.entity.audit.AuditTrigger.ON_CHANGE;
+import static com.kenshoo.pl.entity.audit.AuditTrigger.ON_CREATE_OR_UPDATE;
 import static com.kenshoo.pl.entity.internal.EntityTypeReflectionUtil.getFieldAnnotation;
 import static com.kenshoo.pl.entity.internal.EntityTypeReflectionUtil.isAnnotatedWith;
 import static java.util.Objects.requireNonNull;
@@ -47,7 +47,7 @@ public class AuditedFieldsResolver {
         final AuditedFieldSet<E> fieldSet = AuditedFieldSet.builder(idField)
                                                            .withExternalMandatoryFields(seq(externalMandatoryFields))
                                                            .withSelfMandatoryFields(filterFieldsByTrigger(fieldTriggers, ALWAYS))
-                                                           .withOnChangeFields(filterFieldsByTrigger(fieldTriggers, ON_CHANGE))
+                                                           .withOnChangeFields(filterFieldsByTrigger(fieldTriggers, ON_CREATE_OR_UPDATE))
                                                            .build();
 
         if (entityLevelAudited || fieldSet.hasSelfFields()) {
@@ -69,7 +69,7 @@ public class AuditedFieldsResolver {
 
     private <E extends EntityType<E>> Optional<AuditedFieldTrigger<E>> resolveFieldTrigger(final EntityField<E, ?> field,
                                                                                            final boolean entityLevelAudited) {
-        final Optional<AuditTrigger> optionalEntityTrigger = entityLevelAudited ? Optional.of(ON_CHANGE) : Optional.empty();
+        final Optional<AuditTrigger> optionalEntityTrigger = entityLevelAudited ? Optional.of(ON_CREATE_OR_UPDATE) : Optional.empty();
         return Stream.of(extractFieldTrigger(field),
                          optionalEntityTrigger)
                      .filter(Optional::isPresent)


### PR DESCRIPTION
Adding support for a new audit trigger rule: Audit a field only if it has been changed by an update, and not upon create.

This is part 1 handling the trigger enums only: 
- Renamed **ON_CHANGE** to **ON_CREATE_OR_UPDATE** 
- Added **ON_UPDATE** which means to audit only if changed by an update.

In part 2, the new annotation will be resolved and placed in a new member in `AuditedFieldSet`

_Note_: This feature is required by the Kenshoo Search application