### PR TITLE
PL-95: Extract interfaces for AuditRecordGenerator

### DIFF
--- a/main/src/main/java/com/kenshoo/pl/entity/ChangeFlowConfig.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/ChangeFlowConfig.java
@@ -4,7 +4,8 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.kenshoo.pl.entity.internal.*;
-import com.kenshoo.pl.entity.internal.audit.AuditRecordGenerator;
+import com.kenshoo.pl.entity.internal.audit.AuditRecordGeneratorStateConsumer;
+import com.kenshoo.pl.entity.internal.audit.AuditRecordGeneratorStateConsumerImpl;
 import com.kenshoo.pl.entity.internal.audit.AuditedFieldsResolver;
 import com.kenshoo.pl.entity.spi.*;
 import com.kenshoo.pl.entity.spi.helpers.EntityChangeCompositeValidator;
@@ -35,7 +36,7 @@ public class ChangeFlowConfig<E extends EntityType<E>> {
     private final List<ChangesFilter<E>> postFetchFilters;
     private final List<ChangesFilter<E>> postSupplyFilters;
     private final PersistenceLayerRetryer retryer;
-    private final AuditRecordGenerator<E> auditRecordGenerator;
+    private final AuditRecordGeneratorStateConsumer<E> auditRecordGenerator;
     private final FeatureSet features;
 
 
@@ -47,7 +48,7 @@ public class ChangeFlowConfig<E extends EntityType<E>> {
                              Set<EntityField<E, ?>> requiredFields,
                              List<ChangeFlowConfig<? extends EntityType<?>>> childFlows,
                              PersistenceLayerRetryer retryer,
-                             AuditRecordGenerator<E> auditRecordGenerator,
+                             AuditRecordGeneratorStateConsumer<E> auditRecordGenerator,
                              FeatureSet features) {
         this.entityType = entityType;
         this.postFetchCommandEnrichers = postFetchCommandEnrichers;
@@ -71,7 +72,7 @@ public class ChangeFlowConfig<E extends EntityType<E>> {
         return retryer;
     }
 
-    public Optional<AuditRecordGenerator<E>> auditRecordGenerator() {
+    public Optional<AuditRecordGeneratorStateConsumer<E>> auditRecordGenerator() {
         return Optional.ofNullable(auditRecordGenerator);
     }
 
@@ -276,9 +277,9 @@ public class ChangeFlowConfig<E extends EntityType<E>> {
             ImmutableList.Builder<ChangesValidator<E>> validatorList = ImmutableList.builder();
             validators.forEach(validator -> validatorList.add(validator.element()));
             falseUpdatesPurger.ifPresent(enrichers::add);
-            final AuditRecordGenerator<E> auditRecordGenerator = auditedFieldsResolver.resolve(entityType)
-                                                                                      .map(AuditRecordGenerator::new)
-                                                                                      .orElse(null);
+            final AuditRecordGeneratorStateConsumer<E> auditRecordGenerator = auditedFieldsResolver.resolve(entityType)
+                                                                                                   .map(AuditRecordGeneratorStateConsumerImpl::new)
+                                                                                                   .orElse(null);
             return new ChangeFlowConfig<>(entityType,
                                           enrichers.build(),
                                           validatorList.build(),

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGenerator.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGenerator.java
@@ -1,130 +1,15 @@
 package com.kenshoo.pl.entity.internal.audit;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.kenshoo.pl.entity.*;
+import com.kenshoo.pl.entity.CurrentEntityState;
+import com.kenshoo.pl.entity.EntityChange;
+import com.kenshoo.pl.entity.EntityType;
 import com.kenshoo.pl.entity.audit.AuditRecord;
-import com.kenshoo.pl.entity.audit.FieldAuditRecord;
-import com.kenshoo.pl.entity.internal.EntityIdExtractor;
-import com.kenshoo.pl.entity.spi.CurrentStateConsumer;
-import org.apache.commons.lang3.tuple.ImmutablePair;
 
 import java.util.Collection;
 import java.util.Optional;
-import java.util.stream.Stream;
 
-import static com.kenshoo.pl.entity.ChangeOperation.UPDATE;
-import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.toList;
-
-public class AuditRecordGenerator<E extends EntityType<E>> implements CurrentStateConsumer<E> {
-
-    private final AuditedFieldSet<E> auditedFieldSet;
-    private final EntityIdExtractor entityIdExtractor;
-    private final AuditedFieldsToFetchResolver auditedFieldsToFetchResolver;
-
-    public AuditRecordGenerator(final AuditedFieldSet<E> auditedFieldSet) {
-        this(auditedFieldSet,
-             EntityIdExtractor.INSTANCE,
-             AuditedFieldsToFetchResolver.INSTANCE);
-    }
-
-    @VisibleForTesting
-    AuditRecordGenerator(final AuditedFieldSet<E> auditedFieldSet,
-                         final EntityIdExtractor entityIdExtractor,
-                         final AuditedFieldsToFetchResolver auditedFieldsToFetchResolver) {
-        this.auditedFieldSet = requireNonNull(auditedFieldSet, "An audited field set is required");
-        this.entityIdExtractor = entityIdExtractor;
-        this.auditedFieldsToFetchResolver = auditedFieldsToFetchResolver;
-    }
-
-    @Override
-    public Stream<? extends EntityField<?, ?>> requiredFields(final Collection<? extends EntityField<E, ?>> fieldsToUpdate,
-                                                              final ChangeOperation operator) {
-        return auditedFieldsToFetchResolver.resolve(auditedFieldSet, fieldsToUpdate);
-    }
-
-    public Optional<? extends AuditRecord<E>> generate(final EntityChange<E> entityChange,
-                                                       final CurrentEntityState currentState,
-                                                       final Collection<? extends AuditRecord<?>> childRecords) {
-        final AuditRecord<E> auditRecord = generateInner(entityChange,
-                                                         currentState,
-                                                         childRecords);
-
-        if (entityChange.getChangeOperation() == UPDATE && auditRecord.hasNoChanges()) {
-            return Optional.empty();
-        }
-        return Optional.of(auditRecord);
-    }
-
-    private AuditRecord<E> generateInner(final EntityChange<E> entityChange,
-                                         final CurrentEntityState currentState,
-                                         final Collection<? extends AuditRecord<?>> childRecords) {
-        requireNonNull(entityChange, "entityChange is required");
-        requireNonNull(currentState, "currentState is required");
-
-        final String entityId = extractEntityId(entityChange, currentState);
-
-        final FinalEntityState finalState = new FinalEntityState(currentState, entityChange);
-
-        final Collection<? extends EntityFieldValue> mandatoryFieldValues = generateMandatoryFieldValues(finalState);
-
-        final Collection<? extends FieldAuditRecord<E>> fieldRecords = generateChangedFieldRecords(currentState, finalState);
-
-        return new AuditRecord.Builder<E>()
-            .withEntityType(entityChange.getEntityType())
-            .withEntityId(entityId)
-            .withMandatoryFieldValues(mandatoryFieldValues)
-            .withOperator(entityChange.getChangeOperation())
-            .withFieldRecords(fieldRecords)
-            .withChildRecords(childRecords)
-            .build();
-    }
-
-    private Collection<? extends FieldAuditRecord<E>> generateChangedFieldRecords(final CurrentEntityState currentState, final FinalEntityState finalState) {
-        return auditedFieldSet.getInternalFields()
-                              .filter(field -> fieldWasChanged(currentState, finalState, field))
-                              .map(field -> buildFieldRecord(currentState, finalState, field))
-                              .collect(toList());
-    }
-
-    private FieldAuditRecord<E> buildFieldRecord(final CurrentEntityState currentState,
-                                                 final FinalEntityState finalState,
-                                                 final EntityField<E, ?> field) {
-        final FieldAuditRecord.Builder<E> fieldRecordBuilder = FieldAuditRecord.builder(field);
-        currentState.safeGet(field).ifNotNull(fieldRecordBuilder::oldValue);
-        finalState.safeGet(field).ifNotNull(fieldRecordBuilder::newValue);
-        return fieldRecordBuilder.build();
-    }
-
-    private String extractEntityId(final EntityChange<E> entityChange,
-                                   final CurrentEntityState currentState) {
-        return entityIdExtractor.extract(entityChange, currentState)
-                                .orElseThrow(() -> new IllegalStateException("Could not extract the entity id for entity type '" + entityChange.getEntityType() + "' " +
-                                                                                 "from either the EntityChange or the CurrentEntityState, so the audit record cannot be generated."));
-    }
-
-    private Collection<? extends EntityFieldValue> generateMandatoryFieldValues(final FinalEntityState finalState) {
-        return auditedFieldSet.getMandatoryFields()
-                              .map(field -> ImmutablePair.of(field, finalState.safeGet(field)))
-                              .filter(pair -> pair.getValue().isNotNull())
-                              .map(pair -> new EntityFieldValue(pair.getKey(), pair.getValue().get()))
-                              .collect(toList());
-    }
-
-    private <T> boolean fieldWasChanged(final CurrentEntityState currentState,
-                                        final FinalEntityState finalState,
-                                        final EntityField<E, T> field) {
-        return !fieldStayedTheSame(currentState, finalState, field);
-    }
-
-    private <T> boolean fieldStayedTheSame(final CurrentEntityState currentState,
-                                           final FinalEntityState finalState,
-                                           final EntityField<E, T> field) {
-        return currentState.safeGet(field).equals(finalState.safeGet(field), field::valuesEqual);
-    }
-
-    @VisibleForTesting
-    public AuditedFieldSet<E> getAuditedFieldSet() {
-        return auditedFieldSet;
-    }
+public interface AuditRecordGenerator<E extends EntityType<E>> {
+    Optional<? extends AuditRecord<E>> generate(EntityChange<E> entityChange,
+                                                CurrentEntityState currentState,
+                                                Collection<? extends AuditRecord<?>> childRecords);
 }

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorStateConsumer.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorStateConsumer.java
@@ -1,0 +1,7 @@
+package com.kenshoo.pl.entity.internal.audit;
+
+import com.kenshoo.pl.entity.EntityType;
+import com.kenshoo.pl.entity.spi.CurrentStateConsumer;
+
+public interface AuditRecordGeneratorStateConsumer<E extends EntityType<E>> extends AuditRecordGenerator<E>, CurrentStateConsumer<E> {
+}

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorStateConsumerImpl.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorStateConsumerImpl.java
@@ -1,0 +1,130 @@
+package com.kenshoo.pl.entity.internal.audit;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.kenshoo.pl.entity.*;
+import com.kenshoo.pl.entity.audit.AuditRecord;
+import com.kenshoo.pl.entity.audit.FieldAuditRecord;
+import com.kenshoo.pl.entity.internal.EntityIdExtractor;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static com.kenshoo.pl.entity.ChangeOperation.UPDATE;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
+
+public class AuditRecordGeneratorStateConsumerImpl<E extends EntityType<E>> implements AuditRecordGeneratorStateConsumer<E> {
+
+    private final AuditedFieldSet<E> auditedFieldSet;
+    private final EntityIdExtractor entityIdExtractor;
+    private final AuditedFieldsToFetchResolver auditedFieldsToFetchResolver;
+
+    public AuditRecordGeneratorStateConsumerImpl(final AuditedFieldSet<E> auditedFieldSet) {
+        this(auditedFieldSet,
+             EntityIdExtractor.INSTANCE,
+             AuditedFieldsToFetchResolver.INSTANCE);
+    }
+
+    @VisibleForTesting
+    AuditRecordGeneratorStateConsumerImpl(final AuditedFieldSet<E> auditedFieldSet,
+                                          final EntityIdExtractor entityIdExtractor,
+                                          final AuditedFieldsToFetchResolver auditedFieldsToFetchResolver) {
+        this.auditedFieldSet = requireNonNull(auditedFieldSet, "An audited field set is required");
+        this.entityIdExtractor = entityIdExtractor;
+        this.auditedFieldsToFetchResolver = auditedFieldsToFetchResolver;
+    }
+
+    @Override
+    public Stream<? extends EntityField<?, ?>> requiredFields(final Collection<? extends EntityField<E, ?>> fieldsToUpdate,
+                                                              final ChangeOperation operator) {
+        return auditedFieldsToFetchResolver.resolve(auditedFieldSet, fieldsToUpdate);
+    }
+
+    @Override
+    public Optional<? extends AuditRecord<E>> generate(final EntityChange<E> entityChange,
+                                                       final CurrentEntityState currentState,
+                                                       final Collection<? extends AuditRecord<?>> childRecords) {
+        final AuditRecord<E> auditRecord = generateInner(entityChange,
+                                                         currentState,
+                                                         childRecords);
+
+        if (entityChange.getChangeOperation() == UPDATE && auditRecord.hasNoChanges()) {
+            return Optional.empty();
+        }
+        return Optional.of(auditRecord);
+    }
+
+    private AuditRecord<E> generateInner(final EntityChange<E> entityChange,
+                                         final CurrentEntityState currentState,
+                                         final Collection<? extends AuditRecord<?>> childRecords) {
+        requireNonNull(entityChange, "entityChange is required");
+        requireNonNull(currentState, "currentState is required");
+
+        final String entityId = extractEntityId(entityChange, currentState);
+
+        final FinalEntityState finalState = new FinalEntityState(currentState, entityChange);
+
+        final Collection<? extends EntityFieldValue> mandatoryFieldValues = generateMandatoryFieldValues(finalState);
+
+        final Collection<? extends FieldAuditRecord<E>> fieldRecords = generateChangedFieldRecords(currentState, finalState);
+
+        return new AuditRecord.Builder<E>()
+            .withEntityType(entityChange.getEntityType())
+            .withEntityId(entityId)
+            .withMandatoryFieldValues(mandatoryFieldValues)
+            .withOperator(entityChange.getChangeOperation())
+            .withFieldRecords(fieldRecords)
+            .withChildRecords(childRecords)
+            .build();
+    }
+
+    private Collection<? extends FieldAuditRecord<E>> generateChangedFieldRecords(final CurrentEntityState currentState, final FinalEntityState finalState) {
+        return auditedFieldSet.getInternalFields()
+                              .filter(field -> fieldWasChanged(currentState, finalState, field))
+                              .map(field -> buildFieldRecord(currentState, finalState, field))
+                              .collect(toList());
+    }
+
+    private FieldAuditRecord<E> buildFieldRecord(final CurrentEntityState currentState,
+                                                 final FinalEntityState finalState,
+                                                 final EntityField<E, ?> field) {
+        final FieldAuditRecord.Builder<E> fieldRecordBuilder = FieldAuditRecord.builder(field);
+        currentState.safeGet(field).ifNotNull(fieldRecordBuilder::oldValue);
+        finalState.safeGet(field).ifNotNull(fieldRecordBuilder::newValue);
+        return fieldRecordBuilder.build();
+    }
+
+    private String extractEntityId(final EntityChange<E> entityChange,
+                                   final CurrentEntityState currentState) {
+        return entityIdExtractor.extract(entityChange, currentState)
+                                .orElseThrow(() -> new IllegalStateException("Could not extract the entity id for entity type '" + entityChange.getEntityType() + "' " +
+                                                                                 "from either the EntityChange or the CurrentEntityState, so the audit record cannot be generated."));
+    }
+
+    private Collection<? extends EntityFieldValue> generateMandatoryFieldValues(final FinalEntityState finalState) {
+        return auditedFieldSet.getMandatoryFields()
+                              .map(field -> ImmutablePair.of(field, finalState.safeGet(field)))
+                              .filter(pair -> pair.getValue().isNotNull())
+                              .map(pair -> new EntityFieldValue(pair.getKey(), pair.getValue().get()))
+                              .collect(toList());
+    }
+
+    private <T> boolean fieldWasChanged(final CurrentEntityState currentState,
+                                        final FinalEntityState finalState,
+                                        final EntityField<E, T> field) {
+        return !fieldStayedTheSame(currentState, finalState, field);
+    }
+
+    private <T> boolean fieldStayedTheSame(final CurrentEntityState currentState,
+                                           final FinalEntityState finalState,
+                                           final EntityField<E, T> field) {
+        return currentState.safeGet(field).equals(finalState.safeGet(field), field::valuesEqual);
+    }
+
+    @VisibleForTesting
+    public AuditedFieldSet<E> getAuditedFieldSet() {
+        return auditedFieldSet;
+    }
+}

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/audit/RecursiveAuditRecordGenerator.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/audit/RecursiveAuditRecordGenerator.java
@@ -19,7 +19,6 @@ public class RecursiveAuditRecordGenerator {
         final Stream<? extends EntityChange<E>> entityChanges,
         final ChangeContext changeContext) {
 
-        //noinspection RedundantTypeArguments
         return flowConfig.auditRecordGenerator()
                          .map(auditRecordGenerator -> this.<E>generateMany(flowConfig,
                                                                            auditRecordGenerator,
@@ -34,7 +33,6 @@ public class RecursiveAuditRecordGenerator {
         final Stream<? extends EntityChange<E>> entityChanges,
         final ChangeContext changeContext) {
 
-        //noinspection RedundantTypeArguments
         return entityChanges.map(entityChange -> this.<E>generateOne(flowConfig,
                                                                      auditRecordGenerator,
                                                                      entityChange,

--- a/main/src/test/java/com/kenshoo/pl/entity/ChangeFlowConfigTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/ChangeFlowConfigTest.java
@@ -173,7 +173,7 @@ public class ChangeFlowConfigTest {
     }
 
     @Test
-    public void should_create_audit_record_generator_with_field_set_if_audited_fields_defined() {
+    public void should_create_audit_record_generator_if_audited_fields_defined() {
 
         final AuditedFieldSet<TestEntity> auditedFieldSet = AuditedFieldSet.builder(TestEntity.ID)
                                                                            .withInternalFields(ON_CREATE_OR_UPDATE,
@@ -185,12 +185,6 @@ public class ChangeFlowConfigTest {
                                                                                        auditedFieldsResolver).build();
         assertThat("Audit record generator should exist",
                    flowConfig.auditRecordGenerator().isPresent(), is(true));
-
-        flowConfig.auditRecordGenerator().ifPresent(auditRecordGenerator ->
-            assertThat("Incorrect field set passed to audit generator: ",
-                       auditRecordGenerator.getAuditedFieldSet(), is(auditedFieldSet)
-            )
-        );
     }
 
     @Test

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorForCreateTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorForCreateTest.java
@@ -50,7 +50,7 @@ public class AuditRecordGeneratorForCreateTest {
         final CurrentEntityState currentState = CurrentEntityState.EMPTY;
 
         final AuditedFieldSet<AuditedType> auditedFieldSet = AuditedFieldSet.builder(AuditedType.ID).build();
-        final AuditRecordGenerator<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
+        final AuditRecordGeneratorStateConsumerImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
 
         doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
 
@@ -75,7 +75,7 @@ public class AuditRecordGeneratorForCreateTest {
             AuditedFieldSet.builder(AuditedType.ID)
                            .withExternalFields(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC)
                            .build();
-        final AuditRecordGenerator<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
+        final AuditRecordGeneratorStateConsumerImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
 
         doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
 
@@ -99,7 +99,7 @@ public class AuditRecordGeneratorForCreateTest {
             AuditedFieldSet.builder(AuditedType.ID)
                            .withExternalFields(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC)
                            .build();
-        final AuditRecordGenerator<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
+        final AuditRecordGeneratorStateConsumerImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
 
         doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
 
@@ -122,7 +122,7 @@ public class AuditRecordGeneratorForCreateTest {
             AuditedFieldSet.builder(AuditedType.ID)
                            .withInternalFields(ALWAYS, AuditedType.NAME, AuditedType.DESC)
                            .build();
-        final AuditRecordGenerator<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
+        final AuditRecordGeneratorStateConsumerImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
 
         doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
 
@@ -148,7 +148,7 @@ public class AuditRecordGeneratorForCreateTest {
             AuditedFieldSet.builder(AuditedType.ID)
                            .withInternalFields(ON_CREATE_OR_UPDATE, ImmutableSet.of(AuditedType.NAME, AuditedType.DESC))
                            .build();
-        final AuditRecordGenerator<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
+        final AuditRecordGeneratorStateConsumerImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
 
         doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
 
@@ -172,7 +172,7 @@ public class AuditRecordGeneratorForCreateTest {
             AuditedFieldSet.builder(AuditedType.ID)
                            .withInternalFields(ON_UPDATE, ImmutableSet.of(AuditedType.NAME, AuditedType.DESC))
                            .build();
-        final AuditRecordGenerator<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
+        final AuditRecordGeneratorStateConsumerImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
 
         doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
 
@@ -191,7 +191,7 @@ public class AuditRecordGeneratorForCreateTest {
         final CurrentEntityState currentState = CurrentEntityState.EMPTY;
 
         final AuditedFieldSet<AuditedType> auditedFieldSet = AuditedFieldSet.builder(AuditedType.ID).build();
-        final AuditRecordGenerator<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
+        final AuditRecordGeneratorStateConsumerImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
 
         doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
 
@@ -219,7 +219,7 @@ public class AuditRecordGeneratorForCreateTest {
                                                                             .withExternalFields(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC)
                                                                             .withInternalFields(ALWAYS, AuditedType.NAME, AuditedType.DESC)
                                                                             .build();
-        final AuditRecordGenerator<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
+        final AuditRecordGeneratorStateConsumerImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
 
         doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
 
@@ -248,7 +248,7 @@ public class AuditRecordGeneratorForCreateTest {
                                                                             .withInternalFields(ALWAYS, AuditedType.NAME, AuditedType.DESC)
                                                                             .withInternalFields(ON_CREATE_OR_UPDATE, AuditedType.DESC2)
                                                                             .build();
-        final AuditRecordGenerator<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
+        final AuditRecordGeneratorStateConsumerImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
 
         doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
 
@@ -274,7 +274,7 @@ public class AuditRecordGeneratorForCreateTest {
         final AuditedFieldSet<AuditedType> auditedFieldSet = AuditedFieldSet.builder(AuditedType.ID)
                                                                             .withExternalFields(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC)
                                                                             .build();
-        final AuditRecordGenerator<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
+        final AuditRecordGeneratorStateConsumerImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
 
         doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
 
@@ -308,7 +308,7 @@ public class AuditRecordGeneratorForCreateTest {
                            .withInternalFields(ON_CREATE_OR_UPDATE, AuditedType.DESC)
                            .withInternalFields(ON_UPDATE, AuditedType.DESC2)
                            .build();
-        final AuditRecordGenerator<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
+        final AuditRecordGeneratorStateConsumerImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
 
         doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
 
@@ -333,7 +333,7 @@ public class AuditRecordGeneratorForCreateTest {
         return mock(AuditRecord.class);
     }
 
-    private AuditRecordGenerator<AuditedType> newAuditRecordGenerator(final AuditedFieldSet<AuditedType> fieldSet) {
-        return new AuditRecordGenerator<>(fieldSet, entityIdExtractor, fieldsToFetchResolver);
+    private AuditRecordGeneratorStateConsumerImpl<AuditedType> newAuditRecordGenerator(final AuditedFieldSet<AuditedType> fieldSet) {
+        return new AuditRecordGeneratorStateConsumerImpl<>(fieldSet, entityIdExtractor, fieldsToFetchResolver);
     }
 }

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorForDeleteTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorForDeleteTest.java
@@ -52,7 +52,7 @@ public class AuditRecordGeneratorForDeleteTest {
         currentState.set(AuditedType.DESC, "oldDesc");
 
         final AuditedFieldSet<AuditedType> auditedFieldSet = AuditedFieldSet.builder(AuditedType.ID).build();
-        final AuditRecordGenerator<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
+        final AuditRecordGeneratorStateConsumerImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
 
         doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
 
@@ -77,7 +77,7 @@ public class AuditRecordGeneratorForDeleteTest {
             AuditedFieldSet.builder(AuditedType.ID)
                            .withExternalFields(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC)
                            .build();
-        final AuditRecordGenerator<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
+        final AuditRecordGeneratorStateConsumerImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
 
         doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
 
@@ -103,7 +103,7 @@ public class AuditRecordGeneratorForDeleteTest {
             AuditedFieldSet.builder(AuditedType.ID)
                            .withInternalFields(ALWAYS, AuditedType.NAME, AuditedType.DESC)
                            .build();
-        final AuditRecordGenerator<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
+        final AuditRecordGeneratorStateConsumerImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
 
         doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
 
@@ -126,7 +126,7 @@ public class AuditRecordGeneratorForDeleteTest {
             AuditedFieldSet.builder(AuditedType.ID)
                            .withInternalFields(ON_CREATE_OR_UPDATE, singleton(AuditedType.NAME))
                            .build();
-        final AuditRecordGenerator<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
+        final AuditRecordGeneratorStateConsumerImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
 
         doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
 
@@ -155,7 +155,7 @@ public class AuditRecordGeneratorForDeleteTest {
                            .withExternalFields(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC)
                            .withInternalFields(ALWAYS, AuditedType.NAME, AuditedType.DESC)
                            .build();
-        final AuditRecordGenerator<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
+        final AuditRecordGeneratorStateConsumerImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
 
         doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
 
@@ -182,7 +182,7 @@ public class AuditRecordGeneratorForDeleteTest {
             AuditedFieldSet.builder(AuditedType.ID)
                            .withExternalFields(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC)
                            .build();
-        final AuditRecordGenerator<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
+        final AuditRecordGeneratorStateConsumerImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
 
         doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
 
@@ -202,7 +202,7 @@ public class AuditRecordGeneratorForDeleteTest {
         return mock(AuditRecord.class);
     }
 
-    private AuditRecordGenerator<AuditedType> newAuditRecordGenerator(final AuditedFieldSet<AuditedType> fieldSet) {
-        return new AuditRecordGenerator<>(fieldSet, entityIdExtractor, fieldsToFetchResolver);
+    private AuditRecordGeneratorStateConsumerImpl<AuditedType> newAuditRecordGenerator(final AuditedFieldSet<AuditedType> fieldSet) {
+        return new AuditRecordGeneratorStateConsumerImpl<>(fieldSet, entityIdExtractor, fieldsToFetchResolver);
     }
 }

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorForUpdateTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorForUpdateTest.java
@@ -55,7 +55,7 @@ public class AuditRecordGeneratorForUpdateTest {
         currentState.set(AuditedType.ID, ID);
 
         final AuditedFieldSet<AuditedType> auditedFieldSet = AuditedFieldSet.builder(AuditedType.ID).build();
-        final AuditRecordGenerator<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
+        final AuditRecordGeneratorStateConsumerImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
 
         doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
 
@@ -78,7 +78,7 @@ public class AuditRecordGeneratorForUpdateTest {
             AuditedFieldSet.builder(AuditedType.ID)
                            .withExternalFields(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC)
                            .build();
-        final AuditRecordGenerator<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
+        final AuditRecordGeneratorStateConsumerImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
 
         doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
 
@@ -103,7 +103,7 @@ public class AuditRecordGeneratorForUpdateTest {
             AuditedFieldSet.builder(AuditedType.ID)
                            .withInternalFields(ALWAYS, AuditedType.NAME, AuditedType.DESC)
                            .build();
-        final AuditRecordGenerator<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
+        final AuditRecordGeneratorStateConsumerImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
 
         doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
 
@@ -132,7 +132,7 @@ public class AuditRecordGeneratorForUpdateTest {
             AuditedFieldSet.builder(AuditedType.ID)
                            .withInternalFields(ALWAYS, AuditedType.NAME, AuditedType.DESC)
                            .build();
-        final AuditRecordGenerator<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
+        final AuditRecordGeneratorStateConsumerImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
 
         doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
 
@@ -159,7 +159,7 @@ public class AuditRecordGeneratorForUpdateTest {
             AuditedFieldSet.builder(AuditedType.ID)
                            .withInternalFields(ALWAYS, AuditedType.NAME, AuditedType.DESC)
                            .build();
-        final AuditRecordGenerator<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
+        final AuditRecordGeneratorStateConsumerImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
 
         doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
 
@@ -184,7 +184,7 @@ public class AuditRecordGeneratorForUpdateTest {
             AuditedFieldSet.builder(AuditedType.ID)
                            .withInternalFields(ALWAYS, AuditedType.NAME)
                            .build();
-        final AuditRecordGenerator<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
+        final AuditRecordGeneratorStateConsumerImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
 
         doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
 
@@ -212,7 +212,7 @@ public class AuditRecordGeneratorForUpdateTest {
             AuditedFieldSet.builder(AuditedType.ID)
                            .withInternalFields(ALWAYS, AuditedType.NAME, AuditedType.DESC)
                            .build();
-        final AuditRecordGenerator<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
+        final AuditRecordGeneratorStateConsumerImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
 
         doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
 
@@ -241,7 +241,7 @@ public class AuditRecordGeneratorForUpdateTest {
             AuditedFieldSet.builder(AuditedType.ID)
                            .withInternalFields(ALWAYS, AuditedType.NAME)
                            .build();
-        final AuditRecordGenerator<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
+        final AuditRecordGeneratorStateConsumerImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
 
         doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
 
@@ -265,7 +265,7 @@ public class AuditRecordGeneratorForUpdateTest {
             AuditedFieldSet.builder(AuditedType.ID)
                            .withInternalFields(ON_CREATE_OR_UPDATE, ImmutableSet.of(AuditedType.NAME, AuditedType.DESC))
                            .build();
-        final AuditRecordGenerator<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
+        final AuditRecordGeneratorStateConsumerImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
 
         doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
 
@@ -297,7 +297,7 @@ public class AuditRecordGeneratorForUpdateTest {
                            .withInternalFields(ON_CREATE_OR_UPDATE,
                                                AuditedType.NAME, AuditedType.DESC, AuditedType.DESC2)
                            .build();
-        final AuditRecordGenerator<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
+        final AuditRecordGeneratorStateConsumerImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
 
         doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
 
@@ -327,7 +327,7 @@ public class AuditRecordGeneratorForUpdateTest {
                            .withInternalFields(ON_CREATE_OR_UPDATE,
                                                AuditedType.NAME, AuditedType.DESC, AuditedType.DESC2)
                            .build();
-        final AuditRecordGenerator<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
+        final AuditRecordGeneratorStateConsumerImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
 
         doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
 
@@ -353,7 +353,7 @@ public class AuditRecordGeneratorForUpdateTest {
             AuditedFieldSet.builder(AuditedType.ID)
                            .withInternalFields(ON_CREATE_OR_UPDATE, AuditedType.NAME, AuditedType.DESC)
                            .build();
-        final AuditRecordGenerator<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
+        final AuditRecordGeneratorStateConsumerImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
 
         doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
 
@@ -382,7 +382,7 @@ public class AuditRecordGeneratorForUpdateTest {
             AuditedFieldSet.builder(AuditedType.ID)
                            .withInternalFields(ON_CREATE_OR_UPDATE, AuditedType.NAME, AuditedType.DESC)
                            .build();
-        final AuditRecordGenerator<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
+        final AuditRecordGeneratorStateConsumerImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
 
         doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
 
@@ -411,7 +411,7 @@ public class AuditRecordGeneratorForUpdateTest {
             AuditedFieldSet.builder(AuditedType.ID)
                            .withInternalFields(ON_CREATE_OR_UPDATE, AuditedType.NAME, AuditedType.DESC)
                            .build();
-        final AuditRecordGenerator<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
+        final AuditRecordGeneratorStateConsumerImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
 
         doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
 
@@ -432,7 +432,7 @@ public class AuditRecordGeneratorForUpdateTest {
         currentState.set(AuditedType.DESC, OLD_DESC);
 
         final AuditedFieldSet<AuditedType> auditedFieldSet = AuditedFieldSet.builder(AuditedType.ID).build();
-        final AuditRecordGenerator<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
+        final AuditRecordGeneratorStateConsumerImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
 
         doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
 
@@ -456,7 +456,7 @@ public class AuditRecordGeneratorForUpdateTest {
             AuditedFieldSet.builder(AuditedType.ID)
                            .withInternalFields(ON_UPDATE, AuditedType.NAME, AuditedType.DESC)
                            .build();
-        final AuditRecordGenerator<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
+        final AuditRecordGeneratorStateConsumerImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
 
         doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
 
@@ -488,7 +488,7 @@ public class AuditRecordGeneratorForUpdateTest {
                            .withInternalFields(ON_UPDATE,
                                                AuditedType.NAME, AuditedType.DESC, AuditedType.DESC2)
                            .build();
-        final AuditRecordGenerator<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
+        final AuditRecordGeneratorStateConsumerImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
 
         doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
 
@@ -518,7 +518,7 @@ public class AuditRecordGeneratorForUpdateTest {
                            .withInternalFields(ON_UPDATE,
                                                AuditedType.NAME, AuditedType.DESC, AuditedType.DESC2)
                            .build();
-        final AuditRecordGenerator<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
+        final AuditRecordGeneratorStateConsumerImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
 
         doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
 
@@ -544,7 +544,7 @@ public class AuditRecordGeneratorForUpdateTest {
             AuditedFieldSet.builder(AuditedType.ID)
                            .withInternalFields(ON_UPDATE, AuditedType.NAME, AuditedType.DESC)
                            .build();
-        final AuditRecordGenerator<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
+        final AuditRecordGeneratorStateConsumerImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
 
         doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
 
@@ -573,7 +573,7 @@ public class AuditRecordGeneratorForUpdateTest {
             AuditedFieldSet.builder(AuditedType.ID)
                            .withInternalFields(ON_UPDATE, AuditedType.NAME, AuditedType.DESC)
                            .build();
-        final AuditRecordGenerator<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
+        final AuditRecordGeneratorStateConsumerImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
 
         doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
 
@@ -602,7 +602,7 @@ public class AuditRecordGeneratorForUpdateTest {
             AuditedFieldSet.builder(AuditedType.ID)
                            .withInternalFields(ON_UPDATE, AuditedType.NAME, AuditedType.DESC)
                            .build();
-        final AuditRecordGenerator<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
+        final AuditRecordGeneratorStateConsumerImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
 
         doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
 
@@ -623,7 +623,7 @@ public class AuditRecordGeneratorForUpdateTest {
         currentState.set(AuditedType.DESC, OLD_DESC);
 
         final AuditedFieldSet<AuditedType> auditedFieldSet = AuditedFieldSet.builder(AuditedType.ID).build();
-        final AuditRecordGenerator<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
+        final AuditRecordGeneratorStateConsumerImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
 
         doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
 
@@ -645,7 +645,7 @@ public class AuditRecordGeneratorForUpdateTest {
             AuditedFieldSet.builder(AuditedType.ID)
                            .withInternalFields(ON_UPDATE, AuditedType.NAME)
                            .build();
-        final AuditRecordGenerator<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
+        final AuditRecordGeneratorStateConsumerImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
 
         doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
 
@@ -668,7 +668,7 @@ public class AuditRecordGeneratorForUpdateTest {
             AuditedFieldSet.builder(AuditedType.ID)
                            .withInternalFields(ON_CREATE_OR_UPDATE, AuditedType.NAME)
                            .build();
-        final AuditRecordGenerator<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
+        final AuditRecordGeneratorStateConsumerImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
 
         doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
 
@@ -695,7 +695,7 @@ public class AuditRecordGeneratorForUpdateTest {
             AuditedFieldSet.builder(AuditedType.ID)
                            .withInternalFields(ON_CREATE_OR_UPDATE, AuditedType.NAME, AuditedType.DESC)
                            .build();
-        final AuditRecordGenerator<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
+        final AuditRecordGeneratorStateConsumerImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
 
         final List<AuditRecord<?>> childRecords = ImmutableList.of(mockChildRecord(), mockChildRecord());
 
@@ -723,7 +723,7 @@ public class AuditRecordGeneratorForUpdateTest {
         doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
 
         final AuditedFieldSet<AuditedType> auditedFieldSet = AuditedFieldSet.builder(AuditedType.ID).build();
-        final AuditRecordGenerator<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
+        final AuditRecordGeneratorStateConsumerImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
 
         final List<AuditRecord<?>> childRecords = ImmutableList.of(mockChildRecord(), mockChildRecord());
 
@@ -751,7 +751,7 @@ public class AuditRecordGeneratorForUpdateTest {
         final AuditedFieldSet<AuditedType> auditedFieldSet = AuditedFieldSet.builder(AuditedType.ID)
                                                                             .withExternalFields(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC)
                                                                             .build();
-        final AuditRecordGenerator<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
+        final AuditRecordGeneratorStateConsumerImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
 
         final List<AuditRecord<?>> childRecords = ImmutableList.of(mockChildRecord(), mockChildRecord());
 
@@ -787,7 +787,7 @@ public class AuditRecordGeneratorForUpdateTest {
                            .withInternalFields(ON_CREATE_OR_UPDATE, AuditedType.DESC)
                            .withInternalFields(ON_UPDATE, AuditedType.DESC2)
                            .build();
-        final AuditRecordGenerator<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
+        final AuditRecordGeneratorStateConsumerImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
 
         doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
 
@@ -812,7 +812,7 @@ public class AuditRecordGeneratorForUpdateTest {
         return mock(AuditRecord.class);
     }
 
-    private AuditRecordGenerator<AuditedType> newAuditRecordGenerator(final AuditedFieldSet<AuditedType> fieldSet) {
-        return new AuditRecordGenerator<>(fieldSet, entityIdExtractor, fieldsToFetchResolver);
+    private AuditRecordGeneratorStateConsumerImpl<AuditedType> newAuditRecordGenerator(final AuditedFieldSet<AuditedType> fieldSet) {
+        return new AuditRecordGeneratorStateConsumerImpl<>(fieldSet, entityIdExtractor, fieldsToFetchResolver);
     }
 }

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorRequiredFieldsTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorRequiredFieldsTest.java
@@ -51,7 +51,7 @@ public class AuditRecordGeneratorRequiredFieldsTest {
         assertThat(actualRequiredFields, is(intersectionFields));
     }
 
-    private AuditRecordGenerator<AuditedType> newAuditRecordGenerator(final AuditedFieldSet<AuditedType> fieldSet) {
-        return new AuditRecordGenerator<>(fieldSet, entityIdExtractor, fieldsToFetchResolver);
+    private AuditRecordGeneratorStateConsumerImpl<AuditedType> newAuditRecordGenerator(final AuditedFieldSet<AuditedType> fieldSet) {
+        return new AuditRecordGeneratorStateConsumerImpl<>(fieldSet, entityIdExtractor, fieldsToFetchResolver);
     }
 }

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/RecursiveAuditRecordGeneratorTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/RecursiveAuditRecordGeneratorTest.java
@@ -44,13 +44,13 @@ public class RecursiveAuditRecordGeneratorTest {
     private ChangeContext changeContext;
 
     @Mock
-    private AuditRecordGenerator<AuditedType> auditRecordGenerator;
+    private AuditRecordGeneratorStateConsumerImpl<AuditedType> auditRecordGenerator;
     @Mock
-    private AuditRecordGenerator<TestChild1EntityType> child1AuditRecordGenerator;
+    private AuditRecordGeneratorStateConsumerImpl<TestChild1EntityType> child1AuditRecordGenerator;
     @Mock
-    private AuditRecordGenerator<TestChild2EntityType> child2AuditRecordGenerator;
+    private AuditRecordGeneratorStateConsumerImpl<TestChild2EntityType> child2AuditRecordGenerator;
     @Mock
-    private AuditRecordGenerator<TestGrandchildEntityType> grandchildAuditRecordGenerator;
+    private AuditRecordGeneratorStateConsumerImpl<TestGrandchildEntityType> grandchildAuditRecordGenerator;
 
     @Test
     public void generateMany_OneAuditedEntity_WithChanges_ShouldGenerateRecord() {


### PR DESCRIPTION
Since more logic needs to be added and the class is already complicated - I'm starting a series of refactorings to break up `AuditRecordGenerator` into smaller parts.
The first step is here as follows:
1) Renamed `AuditRecordGenerator` class to `AuditRecordGeneratorStateConsumerImpl` 
2) Extracted an interface `AuditRecordGeneratorStateConsumer` for the whole class
3) Extracted an interface `AuditRecordGenerator` for the `generate()` method only, and made the interface above extend it