### PR TITLE
PL-98: Split AuditRecordGenerator

### DIFF
--- a/main/src/main/java/com/kenshoo/pl/entity/ChangeFlowConfig.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/ChangeFlowConfig.java
@@ -283,7 +283,7 @@ public class ChangeFlowConfig<E extends EntityType<E>> {
             final AuditRequiredFieldsCalculator<E> auditRequiredFieldsCalculator =
                 optionalAuditedFieldSet.map(AuditRequiredFieldsCalculator::new).orElse(null);
             final AuditRecordGenerator<E> auditRecordGenerator =
-                optionalAuditedFieldSet.map(AuditRecordGeneratorImpl::new).orElse(null);
+                optionalAuditedFieldSet.map(this::createAuditRecordGenerator).orElse(null);
 
             return new ChangeFlowConfig<>(entityType,
                                           enrichers.build(),
@@ -297,6 +297,15 @@ public class ChangeFlowConfig<E extends EntityType<E>> {
                                           auditRecordGenerator,
                                           features
             );
+        }
+
+        private AuditRecordGenerator<E> createAuditRecordGenerator(final AuditedFieldSet<E> auditedFieldSet) {
+            final AuditMandatoryFieldValuesGenerator mandatoryFieldValuesGenerator =
+                new AuditMandatoryFieldValuesGenerator(auditedFieldSet.getMandatoryFields());
+
+            final AuditFieldChangesGenerator<E> fieldChangesGenerator = new AuditFieldChangesGenerator<>(auditedFieldSet.getInternalFields());
+
+            return new AuditRecordGeneratorImpl<>(mandatoryFieldValuesGenerator, fieldChangesGenerator);
         }
 
         static private class Labeled<Element> {

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditFieldChangeGenerator.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditFieldChangeGenerator.java
@@ -10,9 +10,7 @@ import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
-class AuditFieldChangeGenerator {
-
-    static final AuditFieldChangeGenerator INSTANCE = new AuditFieldChangeGenerator();
+public class AuditFieldChangeGenerator {
 
     <E extends EntityType<E>> Optional<FieldAuditRecord<E>> generate(final CurrentEntityState currentState,
                                                                      final FinalEntityState finalState,

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditFieldChangeGenerator.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditFieldChangeGenerator.java
@@ -1,0 +1,49 @@
+package com.kenshoo.pl.entity.internal.audit;
+
+import com.kenshoo.pl.entity.CurrentEntityState;
+import com.kenshoo.pl.entity.EntityField;
+import com.kenshoo.pl.entity.EntityType;
+import com.kenshoo.pl.entity.FinalEntityState;
+import com.kenshoo.pl.entity.audit.FieldAuditRecord;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+class AuditFieldChangeGenerator {
+
+    static final AuditFieldChangeGenerator INSTANCE = new AuditFieldChangeGenerator();
+
+    <E extends EntityType<E>> Optional<FieldAuditRecord<E>> generate(final CurrentEntityState currentState,
+                                                                     final FinalEntityState finalState,
+                                                                     final EntityField<E, ?> field) {
+        requireNonNull(currentState, "A current state is required");
+        requireNonNull(finalState, "A final state is required");
+        requireNonNull(field, "A field is required");
+
+        return Optional.of(field)
+                       .filter(f -> fieldWasChanged(currentState, finalState, f))
+                       .map(f -> buildFieldRecord(currentState, finalState, f));
+    }
+
+    private <E extends EntityType<E>, T> boolean fieldWasChanged(final CurrentEntityState currentState,
+                                                                 final FinalEntityState finalState,
+                                                                 final EntityField<E, T> field) {
+        return !fieldStayedTheSame(currentState, finalState, field);
+    }
+
+    private <E extends EntityType<E>, T> boolean fieldStayedTheSame(final CurrentEntityState currentState,
+                                                                    final FinalEntityState finalState,
+                                                                    final EntityField<E, T> field) {
+        return currentState.safeGet(field).equals(finalState.safeGet(field), field::valuesEqual);
+    }
+
+    private <E extends EntityType<E>> FieldAuditRecord<E> buildFieldRecord(final CurrentEntityState currentState,
+                                                                           final FinalEntityState finalState,
+                                                                           final EntityField<E, ?> field) {
+        final FieldAuditRecord.Builder<E> fieldRecordBuilder = FieldAuditRecord.builder(field);
+        currentState.safeGet(field).ifNotNull(fieldRecordBuilder::oldValue);
+        finalState.safeGet(field).ifNotNull(fieldRecordBuilder::newValue);
+        return fieldRecordBuilder.build();
+    }
+}

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditFieldChangesGenerator.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditFieldChangesGenerator.java
@@ -21,7 +21,7 @@ public class AuditFieldChangesGenerator<E extends EntityType<E>> {
     private final AuditFieldChangeGenerator singleGenerator;
 
     public AuditFieldChangesGenerator(final Stream<? extends EntityField<E, ?>> onChangeFields) {
-        this(onChangeFields, AuditFieldChangeGenerator.INSTANCE);
+        this(onChangeFields, new AuditFieldChangeGenerator());
     }
 
     @VisibleForTesting

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditFieldChangesGenerator.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditFieldChangesGenerator.java
@@ -1,0 +1,43 @@
+package com.kenshoo.pl.entity.internal.audit;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.kenshoo.pl.entity.CurrentEntityState;
+import com.kenshoo.pl.entity.EntityField;
+import com.kenshoo.pl.entity.EntityType;
+import com.kenshoo.pl.entity.FinalEntityState;
+import com.kenshoo.pl.entity.audit.FieldAuditRecord;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
+import static org.jooq.lambda.Seq.seq;
+
+public class AuditFieldChangesGenerator<E extends EntityType<E>> {
+
+    private final Collection<EntityField<E, ?>> onChangeFields;
+    private final AuditFieldChangeGenerator singleGenerator;
+
+    public AuditFieldChangesGenerator(final Stream<? extends EntityField<E, ?>> onChangeFields) {
+        this(onChangeFields, AuditFieldChangeGenerator.INSTANCE);
+    }
+
+    @VisibleForTesting
+    AuditFieldChangesGenerator(final Stream<? extends EntityField<E, ?>> onChangeFields,
+                               final AuditFieldChangeGenerator singleGenerator) {
+        requireNonNull(onChangeFields, "onChangeFields must not be null (can be empty)");
+        this.onChangeFields = onChangeFields.collect(toList());
+        this.singleGenerator = singleGenerator;
+    }
+
+    Collection<FieldAuditRecord<E>> generate(final CurrentEntityState currentState,
+                                             final FinalEntityState finalState) {
+        return seq(onChangeFields)
+            .map(field -> singleGenerator.generate(currentState, finalState, field))
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .collect(toList());
+    }
+}

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditMandatoryFieldValuesGenerator.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditMandatoryFieldValuesGenerator.java
@@ -1,0 +1,32 @@
+package com.kenshoo.pl.entity.internal.audit;
+
+import com.kenshoo.pl.entity.EntityField;
+import com.kenshoo.pl.entity.EntityFieldValue;
+import com.kenshoo.pl.entity.FinalEntityState;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+
+import java.util.Collection;
+import java.util.stream.Stream;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
+import static org.jooq.lambda.Seq.seq;
+
+public class AuditMandatoryFieldValuesGenerator {
+
+    private final Collection<EntityField<?, ?>> mandatoryFields;
+
+    public AuditMandatoryFieldValuesGenerator(final Stream<? extends EntityField<?, ?>> mandatoryFields) {
+        requireNonNull(mandatoryFields, "mandatoryFields must not be null (can be empty)");
+        this.mandatoryFields = mandatoryFields.collect(toList());
+    }
+
+    Collection<EntityFieldValue> generate(final FinalEntityState finalState) {
+        requireNonNull(finalState, "finalState is required");
+        return seq(mandatoryFields)
+            .map(field -> ImmutablePair.of(field, finalState.safeGet(field)))
+            .filter(pair -> pair.getValue().isNotNull())
+            .map(pair -> new EntityFieldValue(pair.getKey(), pair.getValue().get()))
+            .collect(toList());
+    }
+}

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGenerator.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGenerator.java
@@ -1,6 +1,6 @@
 package com.kenshoo.pl.entity.internal.audit;
 
-import com.kenshoo.pl.entity.CurrentEntityState;
+import com.kenshoo.pl.entity.ChangeContext;
 import com.kenshoo.pl.entity.EntityChange;
 import com.kenshoo.pl.entity.EntityType;
 import com.kenshoo.pl.entity.audit.AuditRecord;
@@ -10,6 +10,6 @@ import java.util.Optional;
 
 public interface AuditRecordGenerator<E extends EntityType<E>> {
     Optional<AuditRecord<E>> generate(EntityChange<E> entityChange,
-                                      CurrentEntityState currentState,
+                                      ChangeContext context,
                                       Collection<? extends AuditRecord<?>> childRecords);
 }

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGenerator.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGenerator.java
@@ -9,7 +9,7 @@ import java.util.Collection;
 import java.util.Optional;
 
 public interface AuditRecordGenerator<E extends EntityType<E>> {
-    Optional<? extends AuditRecord<E>> generate(EntityChange<E> entityChange,
-                                                CurrentEntityState currentState,
-                                                Collection<? extends AuditRecord<?>> childRecords);
+    Optional<AuditRecord<E>> generate(EntityChange<E> entityChange,
+                                      CurrentEntityState currentState,
+                                      Collection<? extends AuditRecord<?>> childRecords);
 }

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/audit/RecursiveAuditRecordGenerator.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/audit/RecursiveAuditRecordGenerator.java
@@ -55,7 +55,7 @@ public class RecursiveAuditRecordGenerator {
                       .collect(toList());
 
         return auditRecordGenerator.generate(entityChange,
-                                             changeContext.getEntity(entityChange),
+                                             changeContext,
                                              childAuditRecords);
     }
 

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditFieldChangeGeneratorTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditFieldChangeGeneratorTest.java
@@ -32,13 +32,13 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class AuditFieldChangeGeneratorTest {
 
-    private static final AuditFieldChangeGenerator GENERATOR = AuditFieldChangeGenerator.INSTANCE;
-
     @Mock
     private CurrentEntityState currentState;
 
     @Mock
     private FinalEntityState finalState;
+
+    private final AuditFieldChangeGenerator generator = new AuditFieldChangeGenerator();
 
     @Test
     public void generate_CurrentNotNull_FinalNotNull_ChangedTrivially_ShouldReturnUpdatedFieldChange() {
@@ -132,6 +132,6 @@ public class AuditFieldChangeGeneratorTest {
     }
 
     private Optional<? extends FieldAuditRecord<AuditedType>> generate(final EntityField<AuditedType, ?> field) {
-        return GENERATOR.generate(currentState, finalState, field);
+        return generator.generate(currentState, finalState, field);
     }
 }

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditFieldChangeGeneratorTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditFieldChangeGeneratorTest.java
@@ -1,0 +1,137 @@
+package com.kenshoo.pl.entity.internal.audit;
+
+import com.kenshoo.pl.entity.CurrentEntityState;
+import com.kenshoo.pl.entity.EntityField;
+import com.kenshoo.pl.entity.FinalEntityState;
+import com.kenshoo.pl.entity.Triptional;
+import com.kenshoo.pl.entity.audit.FieldAuditRecord;
+import com.kenshoo.pl.entity.internal.audit.entitytypes.AuditedType;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Optional;
+
+import static com.github.npathai.hamcrestopt.OptionalMatchers.isEmpty;
+import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresentAnd;
+import static com.kenshoo.pl.entity.internal.audit.entitytypes.AuditedType.AMOUNT;
+import static com.kenshoo.pl.entity.internal.audit.entitytypes.AuditedType.NAME;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+/**
+ * ---- NOTE ----
+ * The final state  is mocked here to make testing easier.<br>
+ * However in practice the final state logic is such that it's impossible for the final state
+ * to be 'absent' when the current state is 'present', therefore we don't need to test that.
+ * This gap in the coverage is closed by the integration tests.
+ */
+
+@RunWith(MockitoJUnitRunner.class)
+public class AuditFieldChangeGeneratorTest {
+
+    private static final AuditFieldChangeGenerator GENERATOR = AuditFieldChangeGenerator.INSTANCE;
+
+    @Mock
+    private CurrentEntityState currentState;
+
+    @Mock
+    private FinalEntityState finalState;
+
+    @Test
+    public void generate_CurrentNotNull_FinalNotNull_ChangedTrivially_ShouldReturnUpdatedFieldChange() {
+        when(currentState.safeGet(NAME)).thenReturn(Triptional.of("old"));
+        when(finalState.safeGet(NAME)).thenReturn(Triptional.of("new"));
+
+        assertThat(generate(NAME),
+                   isPresentAnd(is(FieldAuditRecord.builder(NAME)
+                                                   .oldValue("old")
+                                                   .newValue("new")
+                                                   .build())));
+    }
+
+    @Test
+    public void generate_CurrentNotNull_FinalNotNull_ChangedUsingEqFunction_ShouldReturnUpdatedFieldChange() {
+        when(currentState.safeGet(AMOUNT)).thenReturn(Triptional.of(2.01));
+        when(finalState.safeGet(AMOUNT)).thenReturn(Triptional.of(2.02));
+
+        assertThat(generate(AMOUNT),
+                   isPresentAnd(is(FieldAuditRecord.builder(AMOUNT)
+                                                   .oldValue(2.01)
+                                                   .newValue(2.02)
+                                                   .build())));
+    }
+
+    @Test
+    public void generate_CurrentNotNull_FinalNotNull_UnchangedTrivially_ShouldReturnEmpty() {
+        when(currentState.safeGet(NAME)).thenReturn(Triptional.of("old"));
+        when(finalState.safeGet(NAME)).thenReturn(Triptional.of("old"));
+
+        assertThat(generate(NAME), isEmpty());
+    }
+
+    @Test
+    public void generate_CurrentNotNull_FinalNotNull_UnchangedUsingEqFunction_ShouldReturnEmpty() {
+        when(currentState.safeGet(AMOUNT)).thenReturn(Triptional.of(2.015));
+        when(finalState.safeGet(AMOUNT)).thenReturn(Triptional.of(2.018));
+
+        assertThat(generate(AMOUNT), isEmpty());
+    }
+
+    @Test
+    public void generate_CurrentNotNull_FinalNull_ShouldReturnDeletedFieldChange() {
+        when(currentState.safeGet(NAME)).thenReturn(Triptional.of("old"));
+        when(finalState.safeGet(NAME)).thenReturn(Triptional.nullInstance());
+
+        assertThat(generate(NAME),
+                   isPresentAnd(is(FieldAuditRecord.builder(NAME).oldValue("old").build())));
+    }
+
+    @Test
+    public void generate_CurrentNull_FinalNotNull_ShouldReturnCreatedFieldChange() {
+        when(currentState.safeGet(NAME)).thenReturn(Triptional.nullInstance());
+        when(finalState.safeGet(NAME)).thenReturn(Triptional.of("new"));
+
+        assertThat(generate(NAME),
+                   isPresentAnd(is(FieldAuditRecord.builder(NAME).newValue("new").build())));
+    }
+
+    @Test
+    public void generate_CurrentNull_FinalNull_ShouldReturnEmpty() {
+        when(currentState.safeGet(NAME)).thenReturn(Triptional.nullInstance());
+        when(finalState.safeGet(NAME)).thenReturn(Triptional.nullInstance());
+
+        assertThat(generate(NAME), isEmpty());
+    }
+
+    @Test
+    public void generate_CurrentAbsent_FinalNotNull_ShouldReturnCreatedFieldChange() {
+        when(currentState.safeGet(NAME)).thenReturn(Triptional.absent());
+        when(finalState.safeGet(NAME)).thenReturn(Triptional.of("new"));
+
+        assertThat(generate(NAME),
+                   isPresentAnd(is(FieldAuditRecord.builder(NAME).newValue("new").build())));
+    }
+
+    @Test
+    public void generate_CurrentAbsent_FinalNull_ShouldReturnFieldChangeWithEmptyContents() {
+        when(currentState.safeGet(NAME)).thenReturn(Triptional.absent());
+        when(finalState.safeGet(NAME)).thenReturn(Triptional.nullInstance());
+
+        assertThat(generate(NAME), isPresentAnd(is(FieldAuditRecord.builder(NAME).build())));
+    }
+
+    @Test
+    public void generate_CurrentAbsent_FinalAbsent_ShouldReturnEmpty() {
+        when(currentState.safeGet(NAME)).thenReturn(Triptional.absent());
+        when(finalState.safeGet(NAME)).thenReturn(Triptional.absent());
+
+        assertThat(generate(NAME), isEmpty());
+    }
+
+    private Optional<? extends FieldAuditRecord<AuditedType>> generate(final EntityField<AuditedType, ?> field) {
+        return GENERATOR.generate(currentState, finalState, field);
+    }
+}

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditFieldChangesGeneratorTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditFieldChangesGeneratorTest.java
@@ -1,0 +1,117 @@
+package com.kenshoo.pl.entity.internal.audit;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.kenshoo.pl.entity.CurrentEntityState;
+import com.kenshoo.pl.entity.EntityField;
+import com.kenshoo.pl.entity.FinalEntityState;
+import com.kenshoo.pl.entity.audit.FieldAuditRecord;
+import com.kenshoo.pl.entity.internal.audit.entitytypes.AuditedType;
+import org.jooq.lambda.Seq;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static java.util.Collections.singleton;
+import static java.util.stream.Collectors.toList;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.empty;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AuditFieldChangesGeneratorTest {
+
+    @Mock
+    private AuditFieldChangeGenerator singleGenerator;
+
+    @Mock
+    private CurrentEntityState currentState;
+
+    @Mock
+    private FinalEntityState finalState;
+
+    @Test
+    public void generate_twoFields_BothGenerated_ShouldReturnBothFieldChanges() {
+        final List<FieldAuditRecord<AuditedType>> expectedFieldChanges = ImmutableList.of(mockFieldChange(), mockFieldChange());
+
+        Seq.of(AuditedType.NAME, AuditedType.DESC)
+           .zipWithIndex()
+           .forEach(fieldWithIdx ->
+                        when(singleGenerator.generate(currentState, finalState, fieldWithIdx.v1))
+                            .thenReturn(Optional.of(expectedFieldChanges.get(fieldWithIdx.v2.intValue())))
+                   );
+
+        final Collection<FieldAuditRecord<AuditedType>> actualFieldChanges =
+            newGenerator(Stream.of(AuditedType.NAME, AuditedType.DESC)).generate(currentState, finalState);
+
+        final List<FieldAuditRecord<AuditedType>> sortedActualFieldChanges =
+            actualFieldChanges.stream()
+                              .sorted(Comparator.comparing(expectedFieldChanges::indexOf))
+                              .collect(toList());
+
+        assertThat(sortedActualFieldChanges, is(expectedFieldChanges));
+    }
+
+    @Test
+    public void generate_twoFields_OnlyFirstGenerated_ShouldReturnFirstFieldChange() {
+        final FieldAuditRecord<AuditedType> expectedFieldChange = mockFieldChange();
+
+        when(singleGenerator.generate(currentState, finalState, AuditedType.NAME)).thenReturn(Optional.of(expectedFieldChange));
+        when(singleGenerator.generate(currentState, finalState, AuditedType.DESC)).thenReturn(Optional.empty());
+
+        final Collection<FieldAuditRecord<AuditedType>> actualFieldChanges =
+            newGenerator(Stream.of(AuditedType.NAME, AuditedType.DESC)).generate(currentState, finalState);
+
+        assertThat(ImmutableSet.copyOf(actualFieldChanges), is(singleton(expectedFieldChange)));
+    }
+
+    @Test
+    public void generate_twoFields_OnlySecondGenerated_ShouldReturnSecondFieldChange() {
+        final FieldAuditRecord<AuditedType> expectedFieldChange = mockFieldChange();
+
+        when(singleGenerator.generate(currentState, finalState, AuditedType.NAME)).thenReturn(Optional.empty());
+        when(singleGenerator.generate(currentState, finalState, AuditedType.DESC)).thenReturn(Optional.of(expectedFieldChange));
+
+        final Collection<FieldAuditRecord<AuditedType>> actualFieldChanges =
+            newGenerator(Stream.of(AuditedType.NAME, AuditedType.DESC)).generate(currentState, finalState);
+
+        assertThat(ImmutableSet.copyOf(actualFieldChanges), is(singleton(expectedFieldChange)));
+    }
+
+    @Test
+    public void generate_twoFields_NoneGenerated_ShouldReturnEmpty() {
+        when(singleGenerator.generate(currentState, finalState, AuditedType.NAME)).thenReturn(Optional.empty());
+        when(singleGenerator.generate(currentState, finalState, AuditedType.DESC)).thenReturn(Optional.empty());
+
+        final Collection<FieldAuditRecord<AuditedType>> actualFieldChanges =
+            newGenerator(Stream.of(AuditedType.NAME, AuditedType.DESC)).generate(currentState, finalState);
+
+        assertThat(actualFieldChanges, empty());
+    }
+
+    @Test
+    public void generate_noFields_ShouldReturnEmpty() {
+        final Collection<FieldAuditRecord<AuditedType>> actualFieldChanges =
+            newGenerator(Stream.empty()).generate(currentState, finalState);
+
+        assertThat(actualFieldChanges, empty());
+    }
+
+    private AuditFieldChangesGenerator<AuditedType> newGenerator(final Stream<? extends EntityField<AuditedType, ?>> onChangeFields) {
+        return new AuditFieldChangesGenerator<>(onChangeFields, singleGenerator);
+    }
+
+    @SuppressWarnings("unchecked")
+    private FieldAuditRecord<AuditedType> mockFieldChange() {
+        return mock(FieldAuditRecord.class);
+    }
+}

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditMandatoryFieldValuesGeneratorTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditMandatoryFieldValuesGeneratorTest.java
@@ -1,0 +1,117 @@
+package com.kenshoo.pl.entity.internal.audit;
+
+import com.google.common.collect.ImmutableSet;
+import com.kenshoo.pl.entity.EntityField;
+import com.kenshoo.pl.entity.EntityFieldValue;
+import com.kenshoo.pl.entity.FinalEntityState;
+import com.kenshoo.pl.entity.Triptional;
+import com.kenshoo.pl.entity.internal.audit.entitytypes.NotAuditedAncestorType;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static java.util.Collections.singleton;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AuditMandatoryFieldValuesGeneratorTest {
+
+    private static final String ANCESTOR_NAME = "ancestorName";
+    private static final String ANCESTOR_DESC = "ancestorDesc";
+
+    @Mock
+    private FinalEntityState finalState;
+
+    @Test
+    public void generate_twoFields_BothNotNull_ShouldReturnBothFieldValues() {
+        when(finalState.safeGet(NotAuditedAncestorType.NAME)).thenReturn(Triptional.of(ANCESTOR_NAME));
+        when(finalState.safeGet(NotAuditedAncestorType.DESC)).thenReturn(Triptional.of(ANCESTOR_DESC));
+
+        final AuditMandatoryFieldValuesGenerator generator = newGenerator(Stream.of(NotAuditedAncestorType.NAME,
+                                                                                    NotAuditedAncestorType.DESC));
+
+        final Collection<? extends EntityFieldValue> actualFieldValues = generator.generate(finalState);
+
+        final Set<EntityFieldValue> expectedFieldValues = ImmutableSet.of(new EntityFieldValue(NotAuditedAncestorType.NAME, ANCESTOR_NAME),
+                                                                          new EntityFieldValue(NotAuditedAncestorType.DESC, ANCESTOR_DESC));
+
+        assertThat(ImmutableSet.copyOf(actualFieldValues), is(expectedFieldValues));
+    }
+
+    @Test
+    public void generate_twoFields_BothNull_ShouldReturnEmpty() {
+        Stream.of(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC)
+              .forEach(field -> when(finalState.safeGet(field)).thenReturn(Triptional.nullInstance()));
+
+        final AuditMandatoryFieldValuesGenerator generator = newGenerator(Stream.of(NotAuditedAncestorType.NAME,
+                                                                                    NotAuditedAncestorType.DESC));
+
+        final Collection<? extends EntityFieldValue> actualFieldValues = generator.generate(finalState);
+
+        assertThat(ImmutableSet.copyOf(actualFieldValues), is(empty()));
+    }
+
+    @Test
+    public void generate_twoFields_BothAbsentShouldReturnEmpty() {
+        Stream.of(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC)
+              .forEach(field -> when(finalState.safeGet(field)).thenReturn(Triptional.absent()));
+
+        final AuditMandatoryFieldValuesGenerator generator = newGenerator(Stream.of(NotAuditedAncestorType.NAME,
+                                                                                    NotAuditedAncestorType.DESC));
+
+        final Collection<? extends EntityFieldValue> actualFieldValues = generator.generate(finalState);
+
+        assertThat(ImmutableSet.copyOf(actualFieldValues), is(empty()));
+    }
+
+    @Test
+    public void generate_twoFields_FirstNotNull_SecondNull_ShouldReturnFirstFieldValue() {
+        when(finalState.safeGet(NotAuditedAncestorType.NAME)).thenReturn(Triptional.of(ANCESTOR_NAME));
+        when(finalState.safeGet(NotAuditedAncestorType.DESC)).thenReturn(Triptional.nullInstance());
+
+        final AuditMandatoryFieldValuesGenerator generator = newGenerator(Stream.of(NotAuditedAncestorType.NAME,
+                                                                                    NotAuditedAncestorType.DESC));
+
+
+        final Set<EntityFieldValue> expectedFieldValues = singleton(new EntityFieldValue(NotAuditedAncestorType.NAME, ANCESTOR_NAME));
+
+        final Collection<? extends EntityFieldValue> actualFieldValues = generator.generate(finalState);
+
+        assertThat(ImmutableSet.copyOf(actualFieldValues), is(expectedFieldValues));
+    }
+
+    @Test
+    public void generate_twoFields_FirstAbsent_SecondNull_ShouldReturnSecondFieldValue() {
+        when(finalState.safeGet(NotAuditedAncestorType.NAME)).thenReturn(Triptional.absent());
+        when(finalState.safeGet(NotAuditedAncestorType.DESC)).thenReturn(Triptional.of(ANCESTOR_DESC));
+
+        final AuditMandatoryFieldValuesGenerator generator = newGenerator(Stream.of(NotAuditedAncestorType.NAME,
+                                                                                    NotAuditedAncestorType.DESC));
+
+
+        final Set<EntityFieldValue> expectedFieldValues = singleton(new EntityFieldValue(NotAuditedAncestorType.DESC, ANCESTOR_DESC));
+
+        final Collection<? extends EntityFieldValue> actualFieldValues = generator.generate(finalState);
+
+        assertThat(ImmutableSet.copyOf(actualFieldValues), is(expectedFieldValues));
+    }
+
+    @Test
+    public void generate_noFields_ShouldReturnEmpty() {
+        final AuditMandatoryFieldValuesGenerator generator = newGenerator(Stream.empty());
+
+        assertThat(generator.generate(finalState), is(empty()));
+    }
+
+    private AuditMandatoryFieldValuesGenerator newGenerator(final Stream<? extends EntityField<?, ?>> mandatoryFields) {
+        return new AuditMandatoryFieldValuesGenerator(mandatoryFields);
+    }
+}

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorImplForCreateTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorImplForCreateTest.java
@@ -1,10 +1,7 @@
 package com.kenshoo.pl.entity.internal.audit;
 
 import com.google.common.collect.ImmutableList;
-import com.kenshoo.pl.entity.CurrentEntityState;
-import com.kenshoo.pl.entity.EntityChange;
-import com.kenshoo.pl.entity.EntityFieldValue;
-import com.kenshoo.pl.entity.FinalEntityState;
+import com.kenshoo.pl.entity.*;
 import com.kenshoo.pl.entity.audit.AuditRecord;
 import com.kenshoo.pl.entity.audit.FieldAuditRecord;
 import com.kenshoo.pl.entity.internal.EntityIdExtractor;
@@ -50,7 +47,7 @@ public class AuditRecordGeneratorImplForCreateTest {
     private EntityIdExtractor entityIdExtractor;
 
     @Mock
-    private AuditRecordGeneratorImpl.FinalEntityStateCreator finalStateCreator;
+    private ChangeContext changeContext;
 
     @Mock
     private CurrentEntityState currentState;
@@ -68,8 +65,9 @@ public class AuditRecordGeneratorImplForCreateTest {
     public void setUp() {
         when(cmd.getEntityType()).thenReturn(AuditedType.INSTANCE);
         when(cmd.getChangeOperation()).thenReturn(CREATE);
+        when(changeContext.getEntity(cmd)).thenReturn(currentState);
+        when(changeContext.getFinalEntity(cmd)).thenReturn(finalState);
         when(entityIdExtractor.extract(cmd, currentState)).thenReturn(Optional.of(STRING_ID));
-        when(finalStateCreator.apply(currentState, cmd)).thenReturn(finalState);
     }
 
     @Test
@@ -78,7 +76,7 @@ public class AuditRecordGeneratorImplForCreateTest {
         when(fieldChangesGenerator.generate(currentState, finalState)).thenReturn(emptyList());
 
         final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
-            auditRecordGenerator.generate(cmd, currentState, emptyList());
+            auditRecordGenerator.generate(cmd, changeContext, emptyList());
 
         assertThat(actualOptionalAuditRecord,
                    isPresentAnd(allOf(hasEntityType(AuditedType.INSTANCE),
@@ -96,7 +94,7 @@ public class AuditRecordGeneratorImplForCreateTest {
         when(fieldChangesGenerator.generate(currentState, finalState)).thenReturn(emptyList());
 
         final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
-            auditRecordGenerator.generate(cmd, currentState, emptyList());
+            auditRecordGenerator.generate(cmd, changeContext, emptyList());
 
         assertThat(actualOptionalAuditRecord,
                    isPresentAnd(allOf(hasMandatoryFieldValue(NotAuditedAncestorType.NAME, ANCESTOR_NAME),
@@ -117,7 +115,7 @@ public class AuditRecordGeneratorImplForCreateTest {
         when(fieldChangesGenerator.generate(currentState, finalState)).thenReturn(expectedFieldChanges);
 
         final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
-            auditRecordGenerator.generate(cmd, currentState, emptyList());
+            auditRecordGenerator.generate(cmd, changeContext, emptyList());
 
         assertThat(actualOptionalAuditRecord,
                    isPresentAnd(allOf(hasCreatedFieldRecord(AuditedType.NAME, NAME),
@@ -132,7 +130,7 @@ public class AuditRecordGeneratorImplForCreateTest {
         final List<AuditRecord<?>> childRecords = ImmutableList.of(mockChildRecord(), mockChildRecord());
 
         final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
-            auditRecordGenerator.generate(cmd, currentState, childRecords);
+            auditRecordGenerator.generate(cmd, changeContext, childRecords);
 
         assertThat(actualOptionalAuditRecord,
                    isPresentAnd(allOf(hasSameChildRecord(childRecords.get(0)),
@@ -157,7 +155,7 @@ public class AuditRecordGeneratorImplForCreateTest {
         when(fieldChangesGenerator.generate(currentState, finalState)).thenReturn(expectedFieldChanges);
 
         final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
-            auditRecordGenerator.generate(cmd, currentState, emptyList());
+            auditRecordGenerator.generate(cmd, changeContext, emptyList());
 
         assertThat(actualOptionalAuditRecord,
                    isPresentAnd(allOf(hasMandatoryFieldValue(NotAuditedAncestorType.NAME, ANCESTOR_NAME),
@@ -186,7 +184,7 @@ public class AuditRecordGeneratorImplForCreateTest {
         final List<AuditRecord<?>> childRecords = ImmutableList.of(mockChildRecord(), mockChildRecord());
 
         final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
-            auditRecordGenerator.generate(cmd, currentState, childRecords);
+            auditRecordGenerator.generate(cmd, changeContext, childRecords);
 
         assertThat(actualOptionalAuditRecord,
                    isPresentAnd(allOf(hasMandatoryFieldValue(NotAuditedAncestorType.NAME, ANCESTOR_NAME),

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorImplForUpdateTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorImplForUpdateTest.java
@@ -1,14 +1,10 @@
 package com.kenshoo.pl.entity.internal.audit;
 
 import com.google.common.collect.ImmutableList;
-import com.kenshoo.pl.entity.CurrentEntityState;
-import com.kenshoo.pl.entity.EntityChange;
-import com.kenshoo.pl.entity.EntityFieldValue;
-import com.kenshoo.pl.entity.FinalEntityState;
+import com.kenshoo.pl.entity.*;
 import com.kenshoo.pl.entity.audit.AuditRecord;
 import com.kenshoo.pl.entity.audit.FieldAuditRecord;
 import com.kenshoo.pl.entity.internal.EntityIdExtractor;
-import com.kenshoo.pl.entity.internal.audit.AuditRecordGeneratorImpl.FinalEntityStateCreator;
 import com.kenshoo.pl.entity.internal.audit.entitytypes.AuditedType;
 import com.kenshoo.pl.entity.internal.audit.entitytypes.NotAuditedAncestorType;
 import org.junit.Before;
@@ -54,7 +50,7 @@ public class AuditRecordGeneratorImplForUpdateTest {
     private EntityIdExtractor entityIdExtractor;
 
     @Mock
-    private FinalEntityStateCreator finalStateCreator;
+    private ChangeContext changeContext;
 
     @Mock
     private CurrentEntityState currentState;
@@ -72,8 +68,9 @@ public class AuditRecordGeneratorImplForUpdateTest {
     public void setUp() {
         when(cmd.getEntityType()).thenReturn(AuditedType.INSTANCE);
         when(cmd.getChangeOperation()).thenReturn(UPDATE);
+        when(changeContext.getEntity(cmd)).thenReturn(currentState);
+        when(changeContext.getFinalEntity(cmd)).thenReturn(finalState);
         when(entityIdExtractor.extract(cmd, currentState)).thenReturn(Optional.of(STRING_ID));
-        when(finalStateCreator.apply(currentState, cmd)).thenReturn(finalState);
     }
 
     @Test
@@ -82,7 +79,7 @@ public class AuditRecordGeneratorImplForUpdateTest {
         when(fieldChangesGenerator.generate(currentState, finalState)).thenReturn(emptyList());
 
         final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
-            auditRecordGenerator.generate(cmd, currentState, emptyList());
+            auditRecordGenerator.generate(cmd, changeContext, emptyList());
 
         assertThat(actualOptionalAuditRecord, isEmpty());
     }
@@ -97,7 +94,7 @@ public class AuditRecordGeneratorImplForUpdateTest {
         when(fieldChangesGenerator.generate(currentState, finalState)).thenReturn(emptyList());
 
         final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
-            auditRecordGenerator.generate(cmd, currentState, emptyList());
+            auditRecordGenerator.generate(cmd, changeContext, emptyList());
 
         assertThat(actualOptionalAuditRecord, isEmpty());
     }
@@ -118,7 +115,7 @@ public class AuditRecordGeneratorImplForUpdateTest {
         when(fieldChangesGenerator.generate(currentState, finalState)).thenReturn(expectedFieldChanges);
 
         final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
-            auditRecordGenerator.generate(cmd, currentState, emptyList());
+            auditRecordGenerator.generate(cmd, changeContext, emptyList());
 
         assertThat(actualOptionalAuditRecord,
                    isPresentAnd(allOf(hasEntityId(STRING_ID),
@@ -140,7 +137,7 @@ public class AuditRecordGeneratorImplForUpdateTest {
         final List<AuditRecord<?>> childRecords = ImmutableList.of(mockChildRecord(), mockChildRecord());
 
         final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
-            auditRecordGenerator.generate(cmd, currentState, childRecords);
+            auditRecordGenerator.generate(cmd, changeContext, childRecords);
 
         assertThat(actualOptionalAuditRecord,
                    isPresentAnd(allOf(hasEntityId(STRING_ID),
@@ -172,7 +169,7 @@ public class AuditRecordGeneratorImplForUpdateTest {
         final List<AuditRecord<?>> childRecords = ImmutableList.of(mockChildRecord(), mockChildRecord());
 
         final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
-            auditRecordGenerator.generate(cmd, currentState, childRecords);
+            auditRecordGenerator.generate(cmd, changeContext, childRecords);
 
         //noinspection unchecked
         assertThat(actualOptionalAuditRecord,

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorImplForUpdateTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorImplForUpdateTest.java
@@ -1,31 +1,36 @@
 package com.kenshoo.pl.entity.internal.audit;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.kenshoo.pl.entity.CurrentEntityMutableState;
+import com.kenshoo.pl.entity.CurrentEntityState;
+import com.kenshoo.pl.entity.EntityChange;
+import com.kenshoo.pl.entity.EntityFieldValue;
+import com.kenshoo.pl.entity.FinalEntityState;
 import com.kenshoo.pl.entity.audit.AuditRecord;
+import com.kenshoo.pl.entity.audit.FieldAuditRecord;
 import com.kenshoo.pl.entity.internal.EntityIdExtractor;
+import com.kenshoo.pl.entity.internal.audit.AuditRecordGeneratorImpl.FinalEntityStateCreator;
 import com.kenshoo.pl.entity.internal.audit.entitytypes.AuditedType;
 import com.kenshoo.pl.entity.internal.audit.entitytypes.NotAuditedAncestorType;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
 import static com.github.npathai.hamcrestopt.OptionalMatchers.isEmpty;
 import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresentAnd;
 import static com.kenshoo.pl.entity.ChangeOperation.UPDATE;
-import static com.kenshoo.pl.entity.audit.AuditTrigger.*;
 import static com.kenshoo.pl.entity.matchers.audit.AuditRecordMatchers.*;
 import static java.util.Collections.emptyList;
 import static org.hamcrest.CoreMatchers.allOf;
-import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AuditRecordGeneratorImplForUpdateTest {
@@ -38,23 +43,43 @@ public class AuditRecordGeneratorImplForUpdateTest {
     private static final String OLD_NAME = "oldName";
     private static final String NEW_DESC = "newDesc";
     private static final String OLD_DESC = "oldDesc";
-    private static final String NEW_DESC2 = "newDesc2";
-    private static final String OLD_DESC2 = "oldDesc2";
+
+    @Mock
+    private AuditMandatoryFieldValuesGenerator mandatoryFieldValuesGenerator;
+
+    @Mock
+    private AuditFieldChangesGenerator<AuditedType> fieldChangesGenerator;
 
     @Mock
     private EntityIdExtractor entityIdExtractor;
 
+    @Mock
+    private FinalEntityStateCreator finalStateCreator;
+
+    @Mock
+    private CurrentEntityState currentState;
+
+    @Mock
+    private EntityChange<AuditedType> cmd;
+
+    @Mock
+    private FinalEntityState finalState;
+
+    @InjectMocks
+    private AuditRecordGeneratorImpl<AuditedType> auditRecordGenerator;
+
+    @Before
+    public void setUp() {
+        when(cmd.getEntityType()).thenReturn(AuditedType.INSTANCE);
+        when(cmd.getChangeOperation()).thenReturn(UPDATE);
+        when(entityIdExtractor.extract(cmd, currentState)).thenReturn(Optional.of(STRING_ID));
+        when(finalStateCreator.apply(currentState, cmd)).thenReturn(finalState);
+    }
+
     @Test
     public void generate_WithIdOnly_ShouldReturnEmpty() {
-        final AuditedCommand cmd = new AuditedCommand(ID, UPDATE);
-
-        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
-        currentState.set(AuditedType.ID, ID);
-
-        final AuditedFieldSet<AuditedType> auditedFieldSet = AuditedFieldSet.builder(AuditedType.ID).build();
-        final AuditRecordGeneratorImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
-
-        doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
+        when(mandatoryFieldValuesGenerator.generate(finalState)).thenReturn(emptyList());
+        when(fieldChangesGenerator.generate(currentState, finalState)).thenReturn(emptyList());
 
         final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
             auditRecordGenerator.generate(cmd, currentState, emptyList());
@@ -63,21 +88,13 @@ public class AuditRecordGeneratorImplForUpdateTest {
     }
 
     @Test
-    public void generate_WithExternalMandatoryOnly_ShouldReturnEmpty() {
-        final AuditedCommand cmd = new AuditedCommand(ID, UPDATE);
+    public void generate_WithMandatoryOnly_ShouldReturnEmpty() {
+        final Collection<EntityFieldValue> expectedMandatoryFieldValues =
+            ImmutableList.of(new EntityFieldValue(NotAuditedAncestorType.NAME, ANCESTOR_NAME),
+                             new EntityFieldValue(NotAuditedAncestorType.DESC, ANCESTOR_DESC));
 
-        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
-        currentState.set(AuditedType.ID, ID);
-        currentState.set(NotAuditedAncestorType.NAME, ANCESTOR_NAME);
-        currentState.set(NotAuditedAncestorType.DESC, ANCESTOR_DESC);
-
-        final AuditedFieldSet<AuditedType> auditedFieldSet =
-            AuditedFieldSet.builder(AuditedType.ID)
-                           .withExternalFields(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC)
-                           .build();
-        final AuditRecordGeneratorImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
-
-        doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
+        when(mandatoryFieldValuesGenerator.generate(finalState)).thenReturn(expectedMandatoryFieldValues);
+        when(fieldChangesGenerator.generate(currentState, finalState)).thenReturn(emptyList());
 
         final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
             auditRecordGenerator.generate(cmd, currentState, emptyList());
@@ -86,641 +103,39 @@ public class AuditRecordGeneratorImplForUpdateTest {
     }
 
     @Test
-    public void generate_WithInternalMandatoryOnly_AllIntersect_AllChanged_ShouldCreateMandatoryFieldValuesAndFieldRecordsForAll() {
-        final AuditedCommand cmd = new AuditedCommand(ID, UPDATE)
-            .with(AuditedType.NAME, NEW_NAME)
-            .with(AuditedType.DESC, NEW_DESC);
+    public void generate_WithFieldChangesOnly_ShouldReturnBasicDataAndFieldChanges() {
+        final Collection<FieldAuditRecord<AuditedType>> expectedFieldChanges =
+            ImmutableList.of(FieldAuditRecord.builder(AuditedType.NAME)
+                                             .oldValue(OLD_NAME)
+                                             .newValue(NEW_NAME)
+                                             .build(),
+                             FieldAuditRecord.builder(AuditedType.DESC)
+                                             .oldValue(OLD_DESC)
+                                             .newValue(NEW_DESC)
+                                             .build());
 
-        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
-        currentState.set(AuditedType.ID, ID);
-        currentState.set(AuditedType.NAME, OLD_NAME);
-        currentState.set(AuditedType.DESC, OLD_DESC);
-
-        final AuditedFieldSet<AuditedType> auditedFieldSet =
-            AuditedFieldSet.builder(AuditedType.ID)
-                           .withInternalFields(ALWAYS, AuditedType.NAME, AuditedType.DESC)
-                           .build();
-        final AuditRecordGeneratorImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
-
-        doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
+        when(mandatoryFieldValuesGenerator.generate(finalState)).thenReturn(emptyList());
+        when(fieldChangesGenerator.generate(currentState, finalState)).thenReturn(expectedFieldChanges);
 
         final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
             auditRecordGenerator.generate(cmd, currentState, emptyList());
 
         assertThat(actualOptionalAuditRecord,
-                   isPresentAnd(allOf(hasMandatoryFieldValue(AuditedType.NAME, NEW_NAME),
-                                      hasMandatoryFieldValue(AuditedType.DESC, NEW_DESC),
-                                      hasChangedFieldRecord(AuditedType.NAME, OLD_NAME, NEW_NAME),
-                                      hasChangedFieldRecord(AuditedType.DESC, OLD_DESC, NEW_DESC))));
-    }
-
-    @Test
-    public void generate_WithInternalMandatoryOnly_AllIntersect_SomeChanged_ShouldCreateFieldRecordsForChangedOnly() {
-        final AuditedCommand cmd = new AuditedCommand(ID, UPDATE)
-            .with(AuditedType.NAME, NEW_NAME)
-            .with(AuditedType.DESC, OLD_DESC);
-
-        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
-        currentState.set(AuditedType.ID, ID);
-        currentState.set(AuditedType.NAME, OLD_NAME);
-        currentState.set(AuditedType.DESC, OLD_DESC);
-
-        final AuditedFieldSet<AuditedType> auditedFieldSet =
-            AuditedFieldSet.builder(AuditedType.ID)
-                           .withInternalFields(ALWAYS, AuditedType.NAME, AuditedType.DESC)
-                           .build();
-        final AuditRecordGeneratorImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
-
-        doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
-
-        final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
-            auditRecordGenerator.generate(cmd, currentState, emptyList());
-
-        assertThat(actualOptionalAuditRecord,
-                   isPresentAnd(allOf(hasChangedFieldRecord(AuditedType.NAME, OLD_NAME, NEW_NAME),
-                                      not(hasFieldRecordFor(AuditedType.DESC)))));
-    }
-
-    @Test
-    public void generate_WithInternalMandatoryOnly_AllIntersect_NoneChanged_ShouldReturnEmpty() {
-        final AuditedCommand cmd = new AuditedCommand(ID, UPDATE)
-            .with(AuditedType.NAME, OLD_NAME)
-            .with(AuditedType.DESC, OLD_DESC);
-
-        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
-        currentState.set(AuditedType.ID, ID);
-        currentState.set(AuditedType.NAME, OLD_NAME);
-        currentState.set(AuditedType.DESC, OLD_DESC);
-
-        final AuditedFieldSet<AuditedType> auditedFieldSet =
-            AuditedFieldSet.builder(AuditedType.ID)
-                           .withInternalFields(ALWAYS, AuditedType.NAME, AuditedType.DESC)
-                           .build();
-        final AuditRecordGeneratorImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
-
-        doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
-
-        final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
-            auditRecordGenerator.generate(cmd, currentState, emptyList());
-
-        assertThat(actualOptionalAuditRecord, isEmpty());
-    }
-
-    @Test
-    public void generate_WithInternalMandatoryOnly_SomeIntersect_AllChanged_ShouldCreateFieldRecordsForIntersectionOnly() {
-        final AuditedCommand cmd = new AuditedCommand(ID, UPDATE)
-            .with(AuditedType.NAME, NEW_NAME)
-            .with(AuditedType.DESC, NEW_DESC);
-
-        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
-        currentState.set(AuditedType.ID, ID);
-        currentState.set(AuditedType.NAME, OLD_NAME);
-        currentState.set(AuditedType.DESC, OLD_DESC);
-
-        final AuditedFieldSet<AuditedType> auditedFieldSet =
-            AuditedFieldSet.builder(AuditedType.ID)
-                           .withInternalFields(ALWAYS, AuditedType.NAME)
-                           .build();
-        final AuditRecordGeneratorImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
-
-        doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
-
-        final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
-            auditRecordGenerator.generate(cmd, currentState, emptyList());
-
-        assertThat(actualOptionalAuditRecord,
-                   isPresentAnd(allOf(hasChangedFieldRecord(AuditedType.NAME, OLD_NAME, NEW_NAME),
-                                      not(hasFieldRecordFor(AuditedType.DESC)))));
-    }
-
-    @Test
-    public void generate_WithInternalMandatoryOnly_SomeIntersect_SomeChanged_ShouldCreateFieldRecordsForBothChangedAndIntersectedOnly() {
-        final AuditedCommand cmd = new AuditedCommand(ID, UPDATE)
-            .with(AuditedType.NAME, NEW_NAME)
-            .with(AuditedType.DESC, OLD_DESC)
-            .with(AuditedType.DESC2, OLD_DESC2);
-
-        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
-        currentState.set(AuditedType.ID, ID);
-        currentState.set(AuditedType.NAME, OLD_NAME);
-        currentState.set(AuditedType.DESC, OLD_DESC);
-
-        final AuditedFieldSet<AuditedType> auditedFieldSet =
-            AuditedFieldSet.builder(AuditedType.ID)
-                           .withInternalFields(ALWAYS, AuditedType.NAME, AuditedType.DESC)
-                           .build();
-        final AuditRecordGeneratorImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
-
-        doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
-
-        final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
-            auditRecordGenerator.generate(cmd, currentState, emptyList());
-
-        assertThat(actualOptionalAuditRecord,
-                   isPresentAnd(allOf(hasChangedFieldRecord(AuditedType.NAME, OLD_NAME, NEW_NAME),
-                                      not(hasFieldRecordFor(AuditedType.DESC)),
-                                      not(hasFieldRecordFor(AuditedType.DESC2)))));
-    }
-
-    @Test
-    public void generate_WithInternalMandatoryOnly_NoneIntersect_SomeChanged_ShouldReturnEmpty() {
-        final AuditedCommand cmd = new AuditedCommand(ID, UPDATE)
-            .with(AuditedType.DESC, NEW_DESC)
-            .with(AuditedType.DESC2, NEW_DESC2);
-
-        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
-        currentState.set(AuditedType.ID, ID);
-        currentState.set(AuditedType.NAME, OLD_NAME);
-        currentState.set(AuditedType.DESC, OLD_DESC);
-        currentState.set(AuditedType.DESC2, OLD_DESC2);
-
-        final AuditedFieldSet<AuditedType> auditedFieldSet =
-            AuditedFieldSet.builder(AuditedType.ID)
-                           .withInternalFields(ALWAYS, AuditedType.NAME)
-                           .build();
-        final AuditRecordGeneratorImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
-
-        doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
-
-        final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
-            auditRecordGenerator.generate(cmd, currentState, emptyList());
-
-        assertThat(actualOptionalAuditRecord, isEmpty());
-    }
-
-    @Test
-    public void generate_WithOnCreateOrUpdate_AllIntersect_AllChanged_ShouldGenerateBasicDataAndFieldRecordsForAll() {
-        final AuditedCommand cmd = new AuditedCommand(ID, UPDATE)
-            .with(AuditedType.NAME, NEW_NAME)
-            .with(AuditedType.DESC, NEW_DESC);
-
-        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
-        currentState.set(AuditedType.NAME, OLD_NAME);
-        currentState.set(AuditedType.DESC, OLD_DESC);
-
-        final AuditedFieldSet<AuditedType> auditedFieldSet =
-            AuditedFieldSet.builder(AuditedType.ID)
-                           .withInternalFields(ON_CREATE_OR_UPDATE, ImmutableSet.of(AuditedType.NAME, AuditedType.DESC))
-                           .build();
-        final AuditRecordGeneratorImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
-
-        doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
-
-        final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
-            auditRecordGenerator.generate(cmd, currentState, emptyList());
-
-        assertThat(actualOptionalAuditRecord,
-                   isPresentAnd(allOf(hasEntityType(AuditedType.INSTANCE),
-                                      hasEntityId(STRING_ID),
+                   isPresentAnd(allOf(hasEntityId(STRING_ID),
+                                      hasEntityType(AuditedType.INSTANCE),
                                       hasOperator(UPDATE),
                                       hasChangedFieldRecord(AuditedType.NAME, OLD_NAME, NEW_NAME),
                                       hasChangedFieldRecord(AuditedType.DESC, OLD_DESC, NEW_DESC))));
     }
 
     @Test
-    public void generate_WithOnCreateOrUpdate_AllIntersect_SomeChanged_ShouldGenerateFieldRecordsForChanged() {
-        final AuditedCommand cmd = new AuditedCommand(ID, UPDATE)
-            .with(AuditedType.NAME, NEW_NAME)
-            .with(AuditedType.DESC, NEW_DESC)
-            .with(AuditedType.DESC2, OLD_DESC2);
-
-        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
-        currentState.set(AuditedType.NAME, OLD_NAME);
-        currentState.set(AuditedType.DESC, OLD_DESC);
-        currentState.set(AuditedType.DESC2, OLD_DESC2);
-
-        final AuditedFieldSet<AuditedType> auditedFieldSet =
-            AuditedFieldSet.builder(AuditedType.ID)
-                           .withInternalFields(ON_CREATE_OR_UPDATE,
-                                               AuditedType.NAME, AuditedType.DESC, AuditedType.DESC2)
-                           .build();
-        final AuditRecordGeneratorImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
-
-        doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
-
-        final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
-            auditRecordGenerator.generate(cmd, currentState, emptyList());
-
-        assertThat(actualOptionalAuditRecord,
-                   isPresentAnd(allOf(hasChangedFieldRecord(AuditedType.NAME, OLD_NAME, NEW_NAME),
-                                      hasChangedFieldRecord(AuditedType.DESC, OLD_DESC, NEW_DESC),
-                                      not(hasFieldRecordFor(AuditedType.DESC2)))));
-    }
-
-    @Test
-    public void generate_WithOnCreateOrUpdate_AllIntersect_NoneChanged_ShouldReturnEmpty() {
-        final AuditedCommand cmd = new AuditedCommand(ID, UPDATE)
-            .with(AuditedType.NAME, OLD_NAME)
-            .with(AuditedType.DESC, OLD_DESC)
-            .with(AuditedType.DESC2, OLD_DESC2);
-
-        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
-        currentState.set(AuditedType.NAME, OLD_NAME);
-        currentState.set(AuditedType.DESC, OLD_DESC);
-        currentState.set(AuditedType.DESC2, OLD_DESC2);
-
-        final AuditedFieldSet<AuditedType> auditedFieldSet =
-            AuditedFieldSet.builder(AuditedType.ID)
-                           .withInternalFields(ON_CREATE_OR_UPDATE,
-                                               AuditedType.NAME, AuditedType.DESC, AuditedType.DESC2)
-                           .build();
-        final AuditRecordGeneratorImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
-
-        doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
-
-        final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
-            auditRecordGenerator.generate(cmd, currentState, emptyList());
-
-        assertThat(actualOptionalAuditRecord, isEmpty());
-    }
-
-    @Test
-    public void generate_WithOnCreateOrUpdate_SomeIntersect_AllChanged_ShouldGenerateRecordsForIntersectedOnly() {
-        final AuditedCommand cmd = new AuditedCommand(ID, UPDATE)
-            .with(AuditedType.NAME, NEW_NAME)
-            .with(AuditedType.DESC, NEW_DESC)
-            .with(AuditedType.DESC2, NEW_DESC2);
-
-        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
-        currentState.set(AuditedType.NAME, OLD_NAME);
-        currentState.set(AuditedType.DESC, OLD_DESC);
-        currentState.set(AuditedType.DESC2, OLD_DESC2);
-
-        final AuditedFieldSet<AuditedType> auditedFieldSet =
-            AuditedFieldSet.builder(AuditedType.ID)
-                           .withInternalFields(ON_CREATE_OR_UPDATE, AuditedType.NAME, AuditedType.DESC)
-                           .build();
-        final AuditRecordGeneratorImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
-
-        doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
-
-        final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
-            auditRecordGenerator.generate(cmd, currentState, emptyList());
-
-        assertThat(actualOptionalAuditRecord,
-                   isPresentAnd(allOf(hasChangedFieldRecord(AuditedType.NAME, OLD_NAME, NEW_NAME),
-                                      hasChangedFieldRecord(AuditedType.DESC, OLD_DESC, NEW_DESC),
-                                      not(hasFieldRecordFor(AuditedType.DESC2)))));
-    }
-
-    @Test
-    public void generate_WithOnCreateOrUpdate_SomeIntersect_SomeChanged_ShouldGenerateRecordsForIntersectedAndChangedOnly() {
-        final AuditedCommand cmd = new AuditedCommand(ID, UPDATE)
-            .with(AuditedType.NAME, NEW_NAME)
-            .with(AuditedType.DESC, OLD_DESC)
-            .with(AuditedType.DESC2, OLD_DESC2);
-
-        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
-        currentState.set(AuditedType.NAME, OLD_NAME);
-        currentState.set(AuditedType.DESC, OLD_DESC);
-        currentState.set(AuditedType.DESC2, OLD_DESC2);
-
-        final AuditedFieldSet<AuditedType> auditedFieldSet =
-            AuditedFieldSet.builder(AuditedType.ID)
-                           .withInternalFields(ON_CREATE_OR_UPDATE, AuditedType.NAME, AuditedType.DESC)
-                           .build();
-        final AuditRecordGeneratorImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
-
-        doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
-
-        final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
-            auditRecordGenerator.generate(cmd, currentState, emptyList());
-
-        assertThat(actualOptionalAuditRecord,
-                   isPresentAnd(allOf(hasChangedFieldRecord(AuditedType.NAME, OLD_NAME, NEW_NAME),
-                                      not(hasFieldRecordFor(AuditedType.DESC)),
-                                      not(hasFieldRecordFor(AuditedType.DESC2)))));
-    }
-
-    @Test
-    public void generate_WithOnCreateOrUpdate_SomeIntersect_NoneChanged_ShouldReturnEmpty() {
-        final AuditedCommand cmd = new AuditedCommand(ID, UPDATE)
-            .with(AuditedType.NAME, OLD_NAME)
-            .with(AuditedType.DESC, OLD_DESC)
-            .with(AuditedType.DESC2, OLD_DESC2);
-
-        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
-        currentState.set(AuditedType.NAME, OLD_NAME);
-        currentState.set(AuditedType.DESC, OLD_DESC);
-        currentState.set(AuditedType.DESC2, OLD_DESC2);
-
-        final AuditedFieldSet<AuditedType> auditedFieldSet =
-            AuditedFieldSet.builder(AuditedType.ID)
-                           .withInternalFields(ON_CREATE_OR_UPDATE, AuditedType.NAME, AuditedType.DESC)
-                           .build();
-        final AuditRecordGeneratorImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
-
-        doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
-
-        final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
-            auditRecordGenerator.generate(cmd, currentState, emptyList());
-
-        assertThat(actualOptionalAuditRecord, isEmpty());
-    }
-
-    @Test
-    public void generate_WithOnCreateOrUpdate_NoneIntersect_AllChanged_ShouldReturnEmpty() {
-        final AuditedCommand cmd = new AuditedCommand(ID, UPDATE)
-            .with(AuditedType.NAME, NEW_NAME)
-            .with(AuditedType.DESC, NEW_DESC);
-
-        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
-        currentState.set(AuditedType.NAME, OLD_NAME);
-        currentState.set(AuditedType.DESC, OLD_DESC);
-
-        final AuditedFieldSet<AuditedType> auditedFieldSet = AuditedFieldSet.builder(AuditedType.ID).build();
-        final AuditRecordGeneratorImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
-
-        doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
-
-        final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
-            auditRecordGenerator.generate(cmd, currentState, emptyList());
-
-        assertThat(actualOptionalAuditRecord, isEmpty());
-    }
-
-    @Test
-    public void generate_WithOnUpdate_AllIntersect_AllChanged_ShouldGenerateBasicDataAndFieldRecordsForAll() {
-        final AuditedCommand cmd = new AuditedCommand(ID, UPDATE)
-            .with(AuditedType.NAME, NEW_NAME)
-            .with(AuditedType.DESC, NEW_DESC);
-
-        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
-        currentState.set(AuditedType.NAME, OLD_NAME);
-        currentState.set(AuditedType.DESC, OLD_DESC);
-
-        final AuditedFieldSet<AuditedType> auditedFieldSet =
-            AuditedFieldSet.builder(AuditedType.ID)
-                           .withInternalFields(ON_UPDATE, AuditedType.NAME, AuditedType.DESC)
-                           .build();
-        final AuditRecordGeneratorImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
-
-        doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
-
-        final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
-            auditRecordGenerator.generate(cmd, currentState, emptyList());
-
-        assertThat(actualOptionalAuditRecord,
-                   isPresentAnd(allOf(hasEntityType(AuditedType.INSTANCE),
-                                      hasEntityId(STRING_ID),
-                                      hasOperator(UPDATE),
-                                      hasChangedFieldRecord(AuditedType.NAME, OLD_NAME, NEW_NAME),
-                                      hasChangedFieldRecord(AuditedType.DESC, OLD_DESC, NEW_DESC))));
-    }
-
-    @Test
-    public void generate_WithOnUpdate_AllIntersect_SomeChanged_ShouldGenerateFieldRecordsForChanged() {
-        final AuditedCommand cmd = new AuditedCommand(ID, UPDATE)
-            .with(AuditedType.NAME, NEW_NAME)
-            .with(AuditedType.DESC, NEW_DESC)
-            .with(AuditedType.DESC2, OLD_DESC2);
-
-        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
-        currentState.set(AuditedType.NAME, OLD_NAME);
-        currentState.set(AuditedType.DESC, OLD_DESC);
-        currentState.set(AuditedType.DESC2, OLD_DESC2);
-
-        final AuditedFieldSet<AuditedType> auditedFieldSet =
-            AuditedFieldSet.builder(AuditedType.ID)
-                           .withInternalFields(ON_UPDATE,
-                                               AuditedType.NAME, AuditedType.DESC, AuditedType.DESC2)
-                           .build();
-        final AuditRecordGeneratorImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
-
-        doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
-
-        final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
-            auditRecordGenerator.generate(cmd, currentState, emptyList());
-
-        assertThat(actualOptionalAuditRecord,
-                   isPresentAnd(allOf(hasChangedFieldRecord(AuditedType.NAME, OLD_NAME, NEW_NAME),
-                                      hasChangedFieldRecord(AuditedType.DESC, OLD_DESC, NEW_DESC),
-                                      not(hasFieldRecordFor(AuditedType.DESC2)))));
-    }
-
-    @Test
-    public void generate_WithOnUpdate_AllIntersect_NoneChanged_ShouldReturnEmpty() {
-        final AuditedCommand cmd = new AuditedCommand(ID, UPDATE)
-            .with(AuditedType.NAME, OLD_NAME)
-            .with(AuditedType.DESC, OLD_DESC)
-            .with(AuditedType.DESC2, OLD_DESC2);
-
-        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
-        currentState.set(AuditedType.NAME, OLD_NAME);
-        currentState.set(AuditedType.DESC, OLD_DESC);
-        currentState.set(AuditedType.DESC2, OLD_DESC2);
-
-        final AuditedFieldSet<AuditedType> auditedFieldSet =
-            AuditedFieldSet.builder(AuditedType.ID)
-                           .withInternalFields(ON_UPDATE,
-                                               AuditedType.NAME, AuditedType.DESC, AuditedType.DESC2)
-                           .build();
-        final AuditRecordGeneratorImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
-
-        doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
-
-        final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
-            auditRecordGenerator.generate(cmd, currentState, emptyList());
-
-        assertThat(actualOptionalAuditRecord, isEmpty());
-    }
-
-    @Test
-    public void generate_WithOnUpdate_SomeIntersect_AllChanged_ShouldGenerateRecordsForIntersectedOnly() {
-        final AuditedCommand cmd = new AuditedCommand(ID, UPDATE)
-            .with(AuditedType.NAME, NEW_NAME)
-            .with(AuditedType.DESC, NEW_DESC)
-            .with(AuditedType.DESC2, NEW_DESC2);
-
-        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
-        currentState.set(AuditedType.NAME, OLD_NAME);
-        currentState.set(AuditedType.DESC, OLD_DESC);
-        currentState.set(AuditedType.DESC2, OLD_DESC2);
-
-        final AuditedFieldSet<AuditedType> auditedFieldSet =
-            AuditedFieldSet.builder(AuditedType.ID)
-                           .withInternalFields(ON_UPDATE, AuditedType.NAME, AuditedType.DESC)
-                           .build();
-        final AuditRecordGeneratorImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
-
-        doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
-
-        final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
-            auditRecordGenerator.generate(cmd, currentState, emptyList());
-
-        assertThat(actualOptionalAuditRecord,
-                   isPresentAnd(allOf(hasChangedFieldRecord(AuditedType.NAME, OLD_NAME, NEW_NAME),
-                                      hasChangedFieldRecord(AuditedType.DESC, OLD_DESC, NEW_DESC),
-                                      not(hasFieldRecordFor(AuditedType.DESC2)))));
-    }
-
-    @Test
-    public void generate_WithOnUpdate_SomeIntersect_SomeChanged_ShouldGenerateRecordsForIntersectedAndChangedOnly() {
-        final AuditedCommand cmd = new AuditedCommand(ID, UPDATE)
-            .with(AuditedType.NAME, NEW_NAME)
-            .with(AuditedType.DESC, OLD_DESC)
-            .with(AuditedType.DESC2, OLD_DESC2);
-
-        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
-        currentState.set(AuditedType.NAME, OLD_NAME);
-        currentState.set(AuditedType.DESC, OLD_DESC);
-        currentState.set(AuditedType.DESC2, OLD_DESC2);
-
-        final AuditedFieldSet<AuditedType> auditedFieldSet =
-            AuditedFieldSet.builder(AuditedType.ID)
-                           .withInternalFields(ON_UPDATE, AuditedType.NAME, AuditedType.DESC)
-                           .build();
-        final AuditRecordGeneratorImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
-
-        doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
-
-        final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
-            auditRecordGenerator.generate(cmd, currentState, emptyList());
-
-        assertThat(actualOptionalAuditRecord,
-                   isPresentAnd(allOf(hasChangedFieldRecord(AuditedType.NAME, OLD_NAME, NEW_NAME),
-                                      not(hasFieldRecordFor(AuditedType.DESC)),
-                                      not(hasFieldRecordFor(AuditedType.DESC2)))));
-    }
-
-    @Test
-    public void generate_WithOnUpdate_SomeIntersect_NoneChanged_ShouldReturnEmpty() {
-        final AuditedCommand cmd = new AuditedCommand(ID, UPDATE)
-            .with(AuditedType.NAME, OLD_NAME)
-            .with(AuditedType.DESC, OLD_DESC)
-            .with(AuditedType.DESC2, OLD_DESC2);
-
-        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
-        currentState.set(AuditedType.NAME, OLD_NAME);
-        currentState.set(AuditedType.DESC, OLD_DESC);
-        currentState.set(AuditedType.DESC2, OLD_DESC2);
-
-        final AuditedFieldSet<AuditedType> auditedFieldSet =
-            AuditedFieldSet.builder(AuditedType.ID)
-                           .withInternalFields(ON_UPDATE, AuditedType.NAME, AuditedType.DESC)
-                           .build();
-        final AuditRecordGeneratorImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
-
-        doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
-
-        final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
-            auditRecordGenerator.generate(cmd, currentState, emptyList());
-
-        assertThat(actualOptionalAuditRecord, isEmpty());
-    }
-
-    @Test
-    public void generate_WithOnUpdate_NoneIntersect_AllChanged_ShouldReturnEmpty() {
-        final AuditedCommand cmd = new AuditedCommand(ID, UPDATE)
-            .with(AuditedType.NAME, NEW_NAME)
-            .with(AuditedType.DESC, NEW_DESC);
-
-        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
-        currentState.set(AuditedType.NAME, OLD_NAME);
-        currentState.set(AuditedType.DESC, OLD_DESC);
-
-        final AuditedFieldSet<AuditedType> auditedFieldSet = AuditedFieldSet.builder(AuditedType.ID).build();
-        final AuditRecordGeneratorImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
-
-        doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
-
-        final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
-            auditRecordGenerator.generate(cmd, currentState, emptyList());
-
-        assertThat(actualOptionalAuditRecord, isEmpty());
-    }
-
-    @Test
-    public void generate_WhenFieldChangedFromNull_ShouldGenerateCreatedFieldRecord() {
-        final AuditedCommand cmd = new AuditedCommand(ID, UPDATE)
-            .with(AuditedType.NAME, NEW_NAME);
-
-        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
-        currentState.set(AuditedType.NAME, null);
-
-        final AuditedFieldSet<AuditedType> auditedFieldSet =
-            AuditedFieldSet.builder(AuditedType.ID)
-                           .withInternalFields(ON_UPDATE, AuditedType.NAME)
-                           .build();
-        final AuditRecordGeneratorImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
-
-        doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
-
-        final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
-            auditRecordGenerator.generate(cmd, currentState, emptyList());
-
-        assertThat(actualOptionalAuditRecord,
-                   isPresentAnd(hasCreatedFieldRecord(AuditedType.NAME, NEW_NAME)));
-    }
-
-    @Test
-    public void generate_WhenFieldChangedToNull_ShouldGenerateDeletedFieldRecord() {
-        final AuditedCommand cmd = new AuditedCommand(ID, UPDATE)
-            .with(AuditedType.NAME, null);
-
-        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
-        currentState.set(AuditedType.NAME, OLD_NAME);
-
-        final AuditedFieldSet<AuditedType> auditedFieldSet =
-            AuditedFieldSet.builder(AuditedType.ID)
-                           .withInternalFields(ON_CREATE_OR_UPDATE, AuditedType.NAME)
-                           .build();
-        final AuditRecordGeneratorImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
-
-        doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
-
-        final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
-            auditRecordGenerator.generate(cmd, currentState, emptyList());
-
-        assertThat(actualOptionalAuditRecord,
-                   isPresentAnd(hasDeletedFieldRecord(AuditedType.NAME, OLD_NAME)));
-    }
-
-    @Test
-    public void generate_WithOnCreateOrUpdate_AndChildRecords_ShouldGenerateFieldRecordsAndChildRecords() {
-        final AuditedCommand cmd = new AuditedCommand(ID, UPDATE)
-            .with(AuditedType.NAME, NEW_NAME)
-            .with(AuditedType.DESC, NEW_DESC);
-
-        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
-        currentState.set(AuditedType.NAME, OLD_NAME);
-        currentState.set(AuditedType.DESC, OLD_DESC);
-
-        doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
-
-        final AuditedFieldSet<AuditedType> auditedFieldSet =
-            AuditedFieldSet.builder(AuditedType.ID)
-                           .withInternalFields(ON_CREATE_OR_UPDATE, AuditedType.NAME, AuditedType.DESC)
-                           .build();
-        final AuditRecordGeneratorImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
-
-        final List<AuditRecord<?>> childRecords = ImmutableList.of(mockChildRecord(), mockChildRecord());
-
-        final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
-            auditRecordGenerator.generate(cmd, currentState, childRecords);
-
-        //noinspection unchecked
-        assertThat(actualOptionalAuditRecord,
-                   isPresentAnd(allOf(hasEntityType(AuditedType.INSTANCE),
-                                      hasEntityId(STRING_ID),
-                                      hasOperator(UPDATE),
-                                      hasChangedFieldRecord(AuditedType.NAME, OLD_NAME, NEW_NAME),
-                                      hasChangedFieldRecord(AuditedType.DESC, OLD_DESC, NEW_DESC),
-                                      hasSameChildRecord(childRecords.get(0)),
-                                      hasSameChildRecord(childRecords.get(1)))));
-    }
-
-    @Test
-    public void generate_WithIdAndChildRecordsOnly_ShouldGenerateBasicDataAndChildRecords() {
-        final AuditedCommand cmd = new AuditedCommand(ID, UPDATE);
-
-        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
-        currentState.set(AuditedType.ID, ID);
-
-        doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
-
-        final AuditedFieldSet<AuditedType> auditedFieldSet = AuditedFieldSet.builder(AuditedType.ID).build();
-        final AuditRecordGeneratorImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
+    public void generate_WithChildRecordsOnly_ShouldReturnBasicDataAndChildRecords() {
+        final Collection<EntityFieldValue> expectedMandatoryFieldValues =
+            ImmutableList.of(new EntityFieldValue(NotAuditedAncestorType.NAME, ANCESTOR_NAME),
+                             new EntityFieldValue(NotAuditedAncestorType.DESC, ANCESTOR_DESC));
+
+        when(mandatoryFieldValuesGenerator.generate(finalState)).thenReturn(expectedMandatoryFieldValues);
+        when(fieldChangesGenerator.generate(currentState, finalState)).thenReturn(emptyList());
 
         final List<AuditRecord<?>> childRecords = ImmutableList.of(mockChildRecord(), mockChildRecord());
 
@@ -728,65 +143,31 @@ public class AuditRecordGeneratorImplForUpdateTest {
             auditRecordGenerator.generate(cmd, currentState, childRecords);
 
         assertThat(actualOptionalAuditRecord,
-                   isPresentAnd(allOf(hasEntityType(AuditedType.INSTANCE),
-                                      hasEntityId(STRING_ID),
+                   isPresentAnd(allOf(hasEntityId(STRING_ID),
+                                      hasEntityType(AuditedType.INSTANCE),
                                       hasOperator(UPDATE),
-                                      hasSameChildRecord(childRecords.get(0)),
-                                      hasSameChildRecord(childRecords.get(1)))));
-    }
-
-    @Test
-    public void generate_WithExternalMandatoryAndChildRecordsOnly_ShouldGenerateBasicAndMandatoryFieldsAndChildRecords() {
-        final AuditedCommand cmd = new AuditedCommand(ID, UPDATE);
-
-        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
-        currentState.set(AuditedType.ID, ID);
-        currentState.set(NotAuditedAncestorType.NAME, ANCESTOR_NAME);
-        currentState.set(NotAuditedAncestorType.DESC, ANCESTOR_DESC);
-
-        doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
-        final AuditedFieldSet<AuditedType> auditedFieldSet = AuditedFieldSet.builder(AuditedType.ID)
-                                                                            .withExternalFields(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC)
-                                                                            .build();
-        final AuditRecordGeneratorImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
-
-        final List<AuditRecord<?>> childRecords = ImmutableList.of(mockChildRecord(), mockChildRecord());
-
-        final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
-            auditRecordGenerator.generate(cmd, currentState, childRecords);
-
-        assertThat(actualOptionalAuditRecord,
-                   isPresentAnd(allOf(hasMandatoryFieldValue(NotAuditedAncestorType.NAME, ANCESTOR_NAME),
-                                      hasMandatoryFieldValue(NotAuditedAncestorType.DESC, ANCESTOR_DESC),
                                       hasSameChildRecord(childRecords.get(0)),
                                       hasSameChildRecord(childRecords.get(1)))));
     }
 
     @Test
     public void generate_WithEverything_ShouldGenerateEverything() {
-        final AuditedCommand cmd = new AuditedCommand(ID, UPDATE)
-            .with(AuditedType.NAME, NEW_NAME)
-            .with(AuditedType.DESC, NEW_DESC)
-            .with(AuditedType.DESC2, NEW_DESC2);
+        final Collection<EntityFieldValue> expectedMandatoryFieldValues =
+            ImmutableList.of(new EntityFieldValue(NotAuditedAncestorType.NAME, ANCESTOR_NAME),
+                             new EntityFieldValue(NotAuditedAncestorType.DESC, ANCESTOR_DESC));
 
-        final CurrentEntityMutableState currentState = new CurrentEntityMutableState();
-        currentState.set(AuditedType.ID, ID);
-        currentState.set(AuditedType.NAME, OLD_NAME);
-        currentState.set(AuditedType.DESC, OLD_DESC);
-        currentState.set(AuditedType.DESC2, OLD_DESC2);
-        currentState.set(NotAuditedAncestorType.NAME, ANCESTOR_NAME);
-        currentState.set(NotAuditedAncestorType.DESC, ANCESTOR_DESC);
+        final Collection<FieldAuditRecord<AuditedType>> expectedFieldChanges =
+            ImmutableList.of(FieldAuditRecord.builder(AuditedType.NAME)
+                                             .oldValue(OLD_NAME)
+                                             .newValue(NEW_NAME)
+                                             .build(),
+                             FieldAuditRecord.builder(AuditedType.DESC)
+                                             .oldValue(OLD_DESC)
+                                             .newValue(NEW_DESC)
+                                             .build());
 
-        final AuditedFieldSet<AuditedType> auditedFieldSet =
-            AuditedFieldSet.builder(AuditedType.ID)
-                           .withExternalFields(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC)
-                           .withInternalFields(ALWAYS, AuditedType.NAME)
-                           .withInternalFields(ON_CREATE_OR_UPDATE, AuditedType.DESC)
-                           .withInternalFields(ON_UPDATE, AuditedType.DESC2)
-                           .build();
-        final AuditRecordGeneratorImpl<AuditedType> auditRecordGenerator = newAuditRecordGenerator(auditedFieldSet);
-
-        doReturn(Optional.of(STRING_ID)).when(entityIdExtractor).extract(cmd, currentState);
+        when(mandatoryFieldValuesGenerator.generate(finalState)).thenReturn(expectedMandatoryFieldValues);
+        when(fieldChangesGenerator.generate(currentState, finalState)).thenReturn(expectedFieldChanges);
 
         final List<AuditRecord<?>> childRecords = ImmutableList.of(mockChildRecord(), mockChildRecord());
 
@@ -795,21 +176,18 @@ public class AuditRecordGeneratorImplForUpdateTest {
 
         //noinspection unchecked
         assertThat(actualOptionalAuditRecord,
-                   isPresentAnd(allOf(hasMandatoryFieldValue(NotAuditedAncestorType.NAME, ANCESTOR_NAME),
+                   isPresentAnd(allOf(hasEntityId(STRING_ID),
+                                      hasEntityType(AuditedType.INSTANCE),
+                                      hasOperator(UPDATE),
+                                      hasMandatoryFieldValue(NotAuditedAncestorType.NAME, ANCESTOR_NAME),
                                       hasMandatoryFieldValue(NotAuditedAncestorType.DESC, ANCESTOR_DESC),
-                                      hasMandatoryFieldValue(AuditedType.NAME, NEW_NAME),
                                       hasChangedFieldRecord(AuditedType.NAME, OLD_NAME, NEW_NAME),
                                       hasChangedFieldRecord(AuditedType.DESC, OLD_DESC, NEW_DESC),
-                                      hasChangedFieldRecord(AuditedType.DESC2, OLD_DESC2, NEW_DESC2),
                                       hasSameChildRecord(childRecords.get(0)),
                                       hasSameChildRecord(childRecords.get(1)))));
     }
 
     private AuditRecord<?> mockChildRecord() {
         return mock(AuditRecord.class);
-    }
-
-    private AuditRecordGeneratorImpl<AuditedType> newAuditRecordGenerator(final AuditedFieldSet<AuditedType> fieldSet) {
-        return new AuditRecordGeneratorImpl<>(fieldSet, entityIdExtractor);
     }
 }

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditedFieldsResolverTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditedFieldsResolverTest.java
@@ -37,7 +37,7 @@ public class AuditedFieldsResolverTest {
         final AuditedFieldSet<AuditedType> expectedFieldSet =
             AuditedFieldSet.builder(AuditedType.ID)
                            .withInternalFields(ON_CREATE_OR_UPDATE,
-                                               AuditedType.NAME, AuditedType.DESC, AuditedType.DESC2)
+                                               AuditedType.NAME, AuditedType.DESC, AuditedType.DESC2, AuditedType.AMOUNT)
                            .build();
 
         assertThat(fieldsResolver.resolve(AuditedType.INSTANCE),

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/MainTable.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/MainTable.java
@@ -13,6 +13,7 @@ public class MainTable extends AbstractDataTable<MainTable> {
     public final TableField<Record, String> name = createField("name", SQLDataType.VARCHAR(50));
     public final TableField<Record, String> desc = createField("desc", SQLDataType.VARCHAR(50));
     public final TableField<Record, String> desc2 = createField("desc2", SQLDataType.VARCHAR(50));
+    public final TableField<Record, Double> amount = createField("amount", SQLDataType.DOUBLE);
 
     private MainTable(final String name) {
         super(name);

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/RecursiveAuditRecordGeneratorTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/RecursiveAuditRecordGeneratorTest.java
@@ -56,11 +56,9 @@ public class RecursiveAuditRecordGeneratorTest {
     public void generateMany_OneAuditedEntity_WithChanges_ShouldGenerateRecord() {
         final ChangeEntityCommand<AuditedType> cmd = mockCommand();
         final AuditRecord<AuditedType> auditRecord = mockAuditRecord();
-        final CurrentEntityState currentState = mock(CurrentEntityState.class);
 
         when(flowConfig.auditRecordGenerator()).thenReturn(Optional.of(auditRecordGenerator));
-        when(changeContext.getEntity(cmd)).thenReturn(currentState);
-        doReturn(Optional.of(auditRecord)).when(auditRecordGenerator).generate(cmd, currentState, emptyList());
+        doReturn(Optional.of(auditRecord)).when(auditRecordGenerator).generate(cmd, changeContext, emptyList());
 
         final Stream<? extends AuditRecord<AuditedType>> actualAuditRecords =
             recursiveAuditRecordGenerator.generateMany(flowConfig, Stream.of(cmd), changeContext);
@@ -71,11 +69,9 @@ public class RecursiveAuditRecordGeneratorTest {
     @Test
     public void generateMany_OneAuditedEntity_WithoutChanges_ShouldReturnEmpty() {
         final ChangeEntityCommand<AuditedType> cmd = mockCommand();
-        final CurrentEntityState currentState = mock(CurrentEntityState.class);
 
         when(flowConfig.auditRecordGenerator()).thenReturn(Optional.of(auditRecordGenerator));
-        when(changeContext.getEntity(cmd)).thenReturn(currentState);
-        doReturn(Optional.empty()).when(auditRecordGenerator).generate(cmd, currentState, emptyList());
+        doReturn(Optional.empty()).when(auditRecordGenerator).generate(cmd, changeContext, emptyList());
 
         final Stream<? extends AuditRecord<AuditedType>> actualAuditRecords =
             recursiveAuditRecordGenerator.generateMany(flowConfig, Stream.of(cmd), changeContext);
@@ -100,19 +96,13 @@ public class RecursiveAuditRecordGeneratorTest {
         final ChangeEntityCommand<AuditedType> cmd1 = mockCommand();
         final ChangeEntityCommand<AuditedType> cmd2 = mockCommand();
 
-        final CurrentEntityState entity1 = mock(CurrentEntityState.class);
-        final CurrentEntityState entity2 = mock(CurrentEntityState.class);
-
         final AuditRecord<AuditedType> auditRecord1 = mockAuditRecord();
         final AuditRecord<AuditedType> auditRecord2 = mockAuditRecord();
 
         when(flowConfig.auditRecordGenerator()).thenReturn(Optional.of(auditRecordGenerator));
 
-        when(changeContext.getEntity(cmd1)).thenReturn(entity1);
-        when(changeContext.getEntity(cmd2)).thenReturn(entity2);
-
-        doReturn(Optional.of(auditRecord1)).when(auditRecordGenerator).generate(cmd1, entity1, emptyList());
-        doReturn(Optional.of(auditRecord2)).when(auditRecordGenerator).generate(cmd2, entity2, emptyList());
+        doReturn(Optional.of(auditRecord1)).when(auditRecordGenerator).generate(cmd1, changeContext, emptyList());
+        doReturn(Optional.of(auditRecord2)).when(auditRecordGenerator).generate(cmd2, changeContext, emptyList());
 
         final Set<AuditRecord<AuditedType>> expectedAuditRecords =
             ImmutableSet.of(auditRecord1, auditRecord2);
@@ -128,18 +118,12 @@ public class RecursiveAuditRecordGeneratorTest {
         final ChangeEntityCommand<AuditedType> cmd1 = mockCommand();
         final ChangeEntityCommand<AuditedType> cmd2 = mockCommand();
 
-        final CurrentEntityState entity1 = mock(CurrentEntityState.class);
-        final CurrentEntityState entity2 = mock(CurrentEntityState.class);
-
         final AuditRecord<AuditedType> auditRecord1 = mockAuditRecord();
 
         when(flowConfig.auditRecordGenerator()).thenReturn(Optional.of(auditRecordGenerator));
 
-        when(changeContext.getEntity(cmd1)).thenReturn(entity1);
-        when(changeContext.getEntity(cmd2)).thenReturn(entity2);
-
-        doReturn(Optional.of(auditRecord1)).when(auditRecordGenerator).generate(cmd1, entity1, emptyList());
-        doReturn(Optional.empty()).when(auditRecordGenerator).generate(cmd2, entity2, emptyList());
+        doReturn(Optional.of(auditRecord1)).when(auditRecordGenerator).generate(cmd1, changeContext, emptyList());
+        doReturn(Optional.empty()).when(auditRecordGenerator).generate(cmd2, changeContext, emptyList());
 
         final Stream<? extends AuditRecord<AuditedType>> actualAuditRecords =
             recursiveAuditRecordGenerator.generateMany(flowConfig, Stream.of(cmd1, cmd2), changeContext);
@@ -158,10 +142,6 @@ public class RecursiveAuditRecordGeneratorTest {
         final AuditRecord<TestChild1EntityType> childAuditRecord1B = mockAuditRecord();
         final List<AuditRecord<TestChild1EntityType>> childAuditRecords = ImmutableList.of(childAuditRecord1A, childAuditRecord1B);
 
-        final CurrentEntityState currentState = mock(CurrentEntityState.class);
-        final CurrentEntityState childEntity1A = mock(CurrentEntityState.class);
-        final CurrentEntityState childEntity1B = mock(CurrentEntityState.class);
-
         when(flowConfig.auditRecordGenerator()).thenReturn(Optional.of(auditRecordGenerator));
         when(flowConfig.childFlows()).thenReturn(singletonList(child1FlowConfig));
 
@@ -171,13 +151,9 @@ public class RecursiveAuditRecordGeneratorTest {
 
         when(cmd.getChildren(TestChild1EntityType.INSTANCE)).thenReturn(Stream.of(childCmd1A, childCmd1B));
 
-        when(changeContext.getEntity(cmd)).thenReturn(currentState);
-        when(changeContext.getEntity(childCmd1A)).thenReturn(childEntity1A);
-        when(changeContext.getEntity(childCmd1B)).thenReturn(childEntity1B);
-
-        doReturn(Optional.of(childAuditRecord1A)).when(child1AuditRecordGenerator).generate(childCmd1A, childEntity1A, emptyList());
-        doReturn(Optional.of(childAuditRecord1B)).when(child1AuditRecordGenerator).generate(childCmd1B, childEntity1B, emptyList());
-        doReturn(Optional.of(expectedAuditRecord)).when(auditRecordGenerator).generate(cmd, currentState, childAuditRecords);
+        doReturn(Optional.of(childAuditRecord1A)).when(child1AuditRecordGenerator).generate(childCmd1A, changeContext, emptyList());
+        doReturn(Optional.of(childAuditRecord1B)).when(child1AuditRecordGenerator).generate(childCmd1B, changeContext, emptyList());
+        doReturn(Optional.of(expectedAuditRecord)).when(auditRecordGenerator).generate(cmd, changeContext, childAuditRecords);
 
         final Stream<? extends AuditRecord<AuditedType>> actualAuditRecords =
             recursiveAuditRecordGenerator.generateMany(flowConfig, Stream.of(cmd), changeContext);
@@ -195,10 +171,6 @@ public class RecursiveAuditRecordGeneratorTest {
         final AuditRecord<AuditedType> expectedAuditRecord = mockAuditRecord();
         final AuditRecord<TestChild1EntityType> childAuditRecord1A = mockAuditRecord();
 
-        final CurrentEntityState currentState = mock(CurrentEntityState.class);
-        final CurrentEntityState childEntity1A = mock(CurrentEntityState.class);
-        final CurrentEntityState childEntity1B = mock(CurrentEntityState.class);
-
         when(flowConfig.auditRecordGenerator()).thenReturn(Optional.of(auditRecordGenerator));
         when(flowConfig.childFlows()).thenReturn(singletonList(child1FlowConfig));
 
@@ -208,13 +180,9 @@ public class RecursiveAuditRecordGeneratorTest {
 
         when(cmd.getChildren(TestChild1EntityType.INSTANCE)).thenReturn(Stream.of(childCmd1A, childCmd1B));
 
-        when(changeContext.getEntity(cmd)).thenReturn(currentState);
-        when(changeContext.getEntity(childCmd1A)).thenReturn(childEntity1A);
-        when(changeContext.getEntity(childCmd1B)).thenReturn(childEntity1B);
-
-        doReturn(Optional.of(childAuditRecord1A)).when(child1AuditRecordGenerator).generate(childCmd1A, childEntity1A, emptyList());
-        doReturn(Optional.empty()).when(child1AuditRecordGenerator).generate(childCmd1B, childEntity1B, emptyList());
-        doReturn(Optional.of(expectedAuditRecord)).when(auditRecordGenerator).generate(cmd, currentState, singletonList(childAuditRecord1A));
+        doReturn(Optional.of(childAuditRecord1A)).when(child1AuditRecordGenerator).generate(childCmd1A, changeContext, emptyList());
+        doReturn(Optional.empty()).when(child1AuditRecordGenerator).generate(childCmd1B, changeContext, emptyList());
+        doReturn(Optional.of(expectedAuditRecord)).when(auditRecordGenerator).generate(cmd, changeContext, singletonList(childAuditRecord1A));
 
         final Stream<? extends AuditRecord<AuditedType>> actualAuditRecords =
             recursiveAuditRecordGenerator.generateMany(flowConfig, Stream.of(cmd), changeContext);
@@ -232,9 +200,6 @@ public class RecursiveAuditRecordGeneratorTest {
         final AuditRecord<AuditedType> expectedAuditRecord = mockAuditRecord();
         final AuditRecord<TestChild1EntityType> auditedChildRecord = mockAuditRecord();
 
-        final CurrentEntityState currentState = mock(CurrentEntityState.class);
-        final CurrentEntityState auditedChildEntity = mock(CurrentEntityState.class);
-
         when(flowConfig.auditRecordGenerator()).thenReturn(Optional.of(auditRecordGenerator));
         when(flowConfig.childFlows()).thenReturn(ImmutableList.of(child1FlowConfig, child2FlowConfig));
 
@@ -248,11 +213,8 @@ public class RecursiveAuditRecordGeneratorTest {
         when(cmd.getChildren(TestChild1EntityType.INSTANCE)).thenReturn(Stream.of(auditedChildCmd));
         when(cmd.getChildren(TestChild2EntityType.INSTANCE)).thenReturn(Stream.of(notAuditedChildCmd));
 
-        when(changeContext.getEntity(cmd)).thenReturn(currentState);
-        when(changeContext.getEntity(auditedChildCmd)).thenReturn(auditedChildEntity);
-
-        doReturn(Optional.of(auditedChildRecord)).when(child1AuditRecordGenerator).generate(auditedChildCmd, auditedChildEntity, emptyList());
-        doReturn(Optional.of(expectedAuditRecord)).when(auditRecordGenerator).generate(cmd, currentState, singletonList(auditedChildRecord));
+        doReturn(Optional.of(auditedChildRecord)).when(child1AuditRecordGenerator).generate(auditedChildCmd, changeContext, emptyList());
+        doReturn(Optional.of(expectedAuditRecord)).when(auditRecordGenerator).generate(cmd, changeContext, singletonList(auditedChildRecord));
 
         final Stream<? extends AuditRecord<AuditedType>> actualAuditRecords =
             recursiveAuditRecordGenerator.generateMany(flowConfig, Stream.of(cmd), changeContext);
@@ -278,12 +240,6 @@ public class RecursiveAuditRecordGeneratorTest {
                                                                            childAuditRecord2A,
                                                                            childAuditRecord2B);
 
-        final CurrentEntityState currentState = mock(CurrentEntityState.class);
-        final CurrentEntityState childEntity1A = mock(CurrentEntityState.class);
-        final CurrentEntityState childEntity1B = mock(CurrentEntityState.class);
-        final CurrentEntityState childEntity2A = mock(CurrentEntityState.class);
-        final CurrentEntityState childEntity2B = mock(CurrentEntityState.class);
-
         when(flowConfig.auditRecordGenerator()).thenReturn(Optional.of(auditRecordGenerator));
         when(flowConfig.childFlows()).thenReturn(ImmutableList.of(child1FlowConfig, child2FlowConfig));
 
@@ -298,17 +254,11 @@ public class RecursiveAuditRecordGeneratorTest {
         when(cmd.getChildren(TestChild1EntityType.INSTANCE)).thenReturn(Stream.of(childCmd1A, childCmd1B));
         when(cmd.getChildren(TestChild2EntityType.INSTANCE)).thenReturn(Stream.of(childCmd2A, childCmd2B));
 
-        when(changeContext.getEntity(cmd)).thenReturn(currentState);
-        when(changeContext.getEntity(childCmd1A)).thenReturn(childEntity1A);
-        when(changeContext.getEntity(childCmd1B)).thenReturn(childEntity1B);
-        when(changeContext.getEntity(childCmd2A)).thenReturn(childEntity2A);
-        when(changeContext.getEntity(childCmd2B)).thenReturn(childEntity2B);
-
-        doReturn(Optional.of(childAuditRecord1A)).when(child1AuditRecordGenerator).generate(childCmd1A, childEntity1A, emptyList());
-        doReturn(Optional.of(childAuditRecord1B)).when(child1AuditRecordGenerator).generate(childCmd1B, childEntity1B, emptyList());
-        doReturn(Optional.of(childAuditRecord2A)).when(child2AuditRecordGenerator).generate(childCmd2A, childEntity2A, emptyList());
-        doReturn(Optional.of(childAuditRecord2B)).when(child2AuditRecordGenerator).generate(childCmd2B, childEntity2B, emptyList());
-        doReturn(Optional.of(expectedAuditRecord)).when(auditRecordGenerator).generate(cmd, currentState, allChildAuditRecords);
+        doReturn(Optional.of(childAuditRecord1A)).when(child1AuditRecordGenerator).generate(childCmd1A, changeContext, emptyList());
+        doReturn(Optional.of(childAuditRecord1B)).when(child1AuditRecordGenerator).generate(childCmd1B, changeContext, emptyList());
+        doReturn(Optional.of(childAuditRecord2A)).when(child2AuditRecordGenerator).generate(childCmd2A, changeContext, emptyList());
+        doReturn(Optional.of(childAuditRecord2B)).when(child2AuditRecordGenerator).generate(childCmd2B, changeContext, emptyList());
+        doReturn(Optional.of(expectedAuditRecord)).when(auditRecordGenerator).generate(cmd, changeContext, allChildAuditRecords);
 
         final Stream<? extends AuditRecord<AuditedType>> actualAuditRecords =
             recursiveAuditRecordGenerator.generateMany(flowConfig, Stream.of(cmd), changeContext);
@@ -327,10 +277,6 @@ public class RecursiveAuditRecordGeneratorTest {
         final AuditRecord<TestChild1EntityType> childAuditRecord = mockAuditRecord();
         final AuditRecord<TestGrandchildEntityType> grandchildAuditRecord = mockAuditRecord();
 
-        final CurrentEntityState currentState = mock(CurrentEntityState.class);
-        final CurrentEntityState childEntity = mock(CurrentEntityState.class);
-        final CurrentEntityState grandchildEntity = mock(CurrentEntityState.class);
-
         when(flowConfig.auditRecordGenerator()).thenReturn(Optional.of(auditRecordGenerator));
         when(flowConfig.childFlows()).thenReturn(singletonList(child1FlowConfig));
 
@@ -345,16 +291,12 @@ public class RecursiveAuditRecordGeneratorTest {
         when(cmd.getChildren(TestChild1EntityType.INSTANCE)).thenReturn(Stream.of(childCmd));
         when(childCmd.getChildren(TestGrandchildEntityType.INSTANCE)).thenReturn(Stream.of(grandchildCmd));
 
-        when(changeContext.getEntity(cmd)).thenReturn(currentState);
-        when(changeContext.getEntity(childCmd)).thenReturn(childEntity);
-        when(changeContext.getEntity(grandchildCmd)).thenReturn(grandchildEntity);
-
         doReturn(Optional.of(grandchildAuditRecord))
-            .when(grandchildAuditRecordGenerator).generate(grandchildCmd, grandchildEntity, emptyList());
+            .when(grandchildAuditRecordGenerator).generate(grandchildCmd, changeContext, emptyList());
         doReturn(Optional.of(childAuditRecord))
-            .when(child1AuditRecordGenerator).generate(childCmd, childEntity, singletonList(grandchildAuditRecord));
+            .when(child1AuditRecordGenerator).generate(childCmd, changeContext, singletonList(grandchildAuditRecord));
         doReturn(Optional.of(expectedAuditRecord))
-            .when(auditRecordGenerator).generate(cmd, currentState, singletonList(childAuditRecord));
+            .when(auditRecordGenerator).generate(cmd, changeContext, singletonList(childAuditRecord));
 
         final Stream<? extends AuditRecord<AuditedType>> actualAuditRecords =
             recursiveAuditRecordGenerator.generateMany(flowConfig, Stream.of(cmd), changeContext);

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/entitytypes/AuditedType.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/entitytypes/AuditedType.java
@@ -5,6 +5,8 @@ import com.kenshoo.pl.entity.annotation.Id;
 import com.kenshoo.pl.entity.annotation.audit.Audited;
 import com.kenshoo.pl.entity.internal.audit.MainTable;
 
+import static java.lang.Math.abs;
+
 @Audited
 public class AuditedType extends AbstractType<AuditedType> {
 
@@ -15,6 +17,7 @@ public class AuditedType extends AbstractType<AuditedType> {
     public static final EntityField<AuditedType, String> NAME = INSTANCE.field(MainTable.INSTANCE.name);
     public static final EntityField<AuditedType, String> DESC = INSTANCE.field(MainTable.INSTANCE.desc);
     public static final EntityField<AuditedType, String> DESC2 = INSTANCE.field(MainTable.INSTANCE.desc2);
+    public static final EntityField<AuditedType, Double> AMOUNT = INSTANCE.field(MainTable.INSTANCE.amount, (a1, a2) -> abs(a1 - a2) < 0.01);
 
     private AuditedType() {
         super("Audited");


### PR DESCRIPTION
Splitting `AuditRecordGeneratorImpl` into smaller classes handling specific groups of fields.
The motivation for doing this is:
1) Following the single-responsibility principle :)
2) Reduce and simplify the unit tests of each class so they are easier to understand and maintain
3) Prepare for the next refactoring which will implement the trigger of auditing "on update" only

See diagrams:

**BEFORE:**

![image](https://user-images.githubusercontent.com/6349062/89768034-ba960480-db03-11ea-8d5a-80d5ff0db329.png)

**AFTER:**

![image](https://user-images.githubusercontent.com/6349062/89777695-d655d680-db14-11ea-9819-9612b63be95d.png)
