### PR TITLE
Entity change composite validator refactoring

### DIFF
--- a/main/src/main/java/com/kenshoo/pl/entity/internal/validators/AnyFieldsTrigger.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/validators/AnyFieldsTrigger.java
@@ -18,6 +18,6 @@ public class AnyFieldsTrigger <E extends EntityType<E>> implements ValidationTri
 
     @Override
     public boolean triggeredByFields(Collection<? extends EntityField<E, ?>> entityFields) {
-        return entityFields.stream().anyMatch(field -> triggerFields.contains(field));
+        return entityFields.stream().anyMatch(triggerFields::contains);
     }
 }

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/validators/AnyFieldsTrigger.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/validators/AnyFieldsTrigger.java
@@ -1,0 +1,23 @@
+package com.kenshoo.pl.entity.internal.validators;
+
+import com.kenshoo.pl.entity.EntityField;
+import com.kenshoo.pl.entity.EntityType;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class AnyFieldsTrigger <E extends EntityType<E>> implements ValidationTrigger<E>{
+
+    private final Set<EntityField<E, ?>> triggerFields;
+
+    public AnyFieldsTrigger(Stream<EntityField<E, ?>> triggerFields) {
+        this.triggerFields = triggerFields.collect(Collectors.toSet());
+    }
+
+    @Override
+    public boolean triggeredByFields(Collection<? extends EntityField<E, ?>> entityFields) {
+        return entityFields.stream().anyMatch(field -> triggerFields.contains(field));
+    }
+}

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/validators/FieldTrigger.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/validators/FieldTrigger.java
@@ -17,6 +17,6 @@ public class FieldTrigger<E extends EntityType<E>> implements ValidationTrigger<
 
     @Override
     public boolean triggeredByFields(Collection<? extends EntityField<E, ?>> entityFields) {
-        return entityFields.stream().anyMatch(field -> triggerField.equals(field));
+        return entityFields.stream().anyMatch(triggerField::equals);
     }
 }

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/validators/FieldTrigger.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/validators/FieldTrigger.java
@@ -3,7 +3,9 @@ package com.kenshoo.pl.entity.internal.validators;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.EntityType;
 
+import java.util.Collection;
 import java.util.Objects;
+import java.util.stream.Stream;
 
 public class FieldTrigger<E extends EntityType<E>> implements ValidationTrigger<E> {
 
@@ -14,20 +16,7 @@ public class FieldTrigger<E extends EntityType<E>> implements ValidationTrigger<
     }
 
     @Override
-    public boolean triggeredByField(EntityField<E, ?> entityField) {
-        return triggerField.equals(entityField);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        FieldTrigger<?> that = (FieldTrigger<?>) o;
-        return Objects.equals(triggerField, that.triggerField);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(triggerField);
+    public boolean triggeredByFields(Collection<? extends EntityField<E, ?>> entityFields) {
+        return entityFields.stream().anyMatch(field -> triggerField.equals(field));
     }
 }

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/validators/ValidationTrigger.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/validators/ValidationTrigger.java
@@ -3,7 +3,10 @@ package com.kenshoo.pl.entity.internal.validators;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.EntityType;
 
+import java.util.Collection;
+
+
 public interface ValidationTrigger<E extends EntityType<E>> {
 
-    boolean triggeredByField(EntityField<E, ?> entityField);
+    boolean triggeredByFields(Collection<? extends EntityField<E, ?>> entityFields);
 }

--- a/main/src/main/java/com/kenshoo/pl/entity/spi/helpers/EntityChangeCompositeValidator.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/spi/helpers/EntityChangeCompositeValidator.java
@@ -119,7 +119,6 @@ public class EntityChangeCompositeValidator<E extends EntityType<E>> implements 
             CurrentEntityState currentState = changeContext.getEntity(entityChange);
             Collection<? extends EntityField<E, ?>> fieldsToUpdate = entityChange.getChangedFields().collect(Collectors.toList());
             findValidatorsTriggeredByFields(fieldsToUpdate, changeOperation)
-                    .distinct()
                     .map(validator -> validator.validate(entityChange, currentState))
                     .filter(Objects::nonNull)
                     .forEach(validationError -> changeContext.addValidationError(entityChange, validationError));

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/validators/AnyFieldsTriggerTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/validators/AnyFieldsTriggerTest.java
@@ -16,17 +16,17 @@ public class AnyFieldsTriggerTest {
     private final AnyFieldsTrigger anyFieldTrigger = new AnyFieldsTrigger<>(Stream.of(TestEntity.FIELD_1, TestEntity.FIELD_2));
 
     @Test
-    public void triggered_by_one_of_fields() {
+    public void triggeredByOneOfFields() {
         assertTrue(anyFieldTrigger.triggeredByFields(List.of(TestEntity.FIELD_1)));
     }
 
     @Test
-    public void triggered_by_list_contains_field() {
+    public void triggeredByListContainsField() {
         assertTrue(anyFieldTrigger.triggeredByFields(List.of(TestEntity.ID, TestEntity.FIELD_1)));
     }
 
     @Test
-    public void do_not_triggered_by_list_not_contains_field() {
+    public void isNotTriggeredByListDoesNotContainField() {
         assertFalse(anyFieldTrigger.triggeredByFields(List.of(TestEntity.ID)));
     }
 }

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/validators/AnyFieldsTriggerTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/validators/AnyFieldsTriggerTest.java
@@ -1,0 +1,32 @@
+package com.kenshoo.pl.entity.internal.validators;
+
+import com.kenshoo.pl.entity.TestEntity;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.*;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class AnyFieldsTriggerTest {
+
+    private final AnyFieldsTrigger anyFieldTrigger = new AnyFieldsTrigger<>(Stream.of(TestEntity.FIELD_1, TestEntity.FIELD_2));
+
+    @Test
+    public void triggered_by_one_of_fields() {
+        assertTrue(anyFieldTrigger.triggeredByFields(List.of(TestEntity.FIELD_1)));
+    }
+
+    @Test
+    public void triggered_by_list_contains_field() {
+        assertTrue(anyFieldTrigger.triggeredByFields(List.of(TestEntity.ID, TestEntity.FIELD_1)));
+    }
+
+    @Test
+    public void do_not_triggered_by_list_not_contains_field() {
+        assertFalse(anyFieldTrigger.triggeredByFields(List.of(TestEntity.ID)));
+    }
+}

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/validators/FieldTriggerTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/validators/FieldTriggerTest.java
@@ -15,17 +15,17 @@ public class FieldTriggerTest {
     private final FieldTrigger fieldTrigger = new FieldTrigger<>(TestEntity.FIELD_1);
 
     @Test
-    public void triggered_exactly_by_field() {
+    public void triggeredExactlyByField() {
         assertTrue(fieldTrigger.triggeredByFields(List.of(TestEntity.FIELD_1)));
     }
 
     @Test
-    public void triggered_by_list_contains_field() {
+    public void triggeredByListContainsField() {
         assertTrue(fieldTrigger.triggeredByFields(List.of(TestEntity.FIELD_2, TestEntity.FIELD_1)));
     }
 
     @Test
-    public void do_not_triggered_by_list_not_contains_field() {
+    public void isNotTriggeredByListDoesNotContainField() {
         assertFalse(fieldTrigger.triggeredByFields(List.of(TestEntity.FIELD_2)));
     }
 }

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/validators/FieldTriggerTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/validators/FieldTriggerTest.java
@@ -1,0 +1,31 @@
+package com.kenshoo.pl.entity.internal.validators;
+
+import com.kenshoo.pl.entity.TestEntity;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class FieldTriggerTest {
+
+    private final FieldTrigger fieldTrigger = new FieldTrigger<>(TestEntity.FIELD_1);
+
+    @Test
+    public void triggered_exactly_by_field() {
+        assertTrue(fieldTrigger.triggeredByFields(List.of(TestEntity.FIELD_1)));
+    }
+
+    @Test
+    public void triggered_by_list_contains_field() {
+        assertTrue(fieldTrigger.triggeredByFields(List.of(TestEntity.FIELD_2, TestEntity.FIELD_1)));
+    }
+
+    @Test
+    public void do_not_triggered_by_list_not_contains_field() {
+        assertFalse(fieldTrigger.triggeredByFields(List.of(TestEntity.FIELD_2)));
+    }
+}

--- a/main/src/test/java/com/kenshoo/pl/entity/spi/helpers/EntityChangeCompositeValidatorTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/spi/helpers/EntityChangeCompositeValidatorTest.java
@@ -186,7 +186,7 @@ public class EntityChangeCompositeValidatorTest {
     }
 
     @Test
-    public void registerAncestorsValidatorForEmptyUpdateTest() {
+    public void registeredAncestorsValidatorShouldBeInvokedWhenNothingIsChangedTest() {
         when(entityChange.getChangedFields()).thenReturn(Stream.of());
         validator.register(ancestorsValidator);
         validator.validate(entityChanges, ChangeOperation.UPDATE, changeContext);
@@ -194,7 +194,7 @@ public class EntityChangeCompositeValidatorTest {
     }
 
     @Test
-    public void ancestorsRequiredFieldsForEmptyUpdateTest() {
+    public void registeredAncestorsValidatorShouldReturnFieldsWhenNothingIsChangedTest() {
         when(ancestorsValidator.ancestorsFields()).thenReturn(Stream.of(TestEntity.FIELD_1));
         validator.register(ancestorsValidator);
         List<? extends EntityField<?, ?>> fields = validator.requiredFields(Collections.emptyList(), ChangeOperation.UPDATE).collect(Collectors.toList());

--- a/main/src/test/java/com/kenshoo/pl/entity/spi/helpers/EntityChangeCompositeValidatorTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/spi/helpers/EntityChangeCompositeValidatorTest.java
@@ -198,7 +198,6 @@ public class EntityChangeCompositeValidatorTest {
         when(ancestorsValidator.ancestorsFields()).thenReturn(Stream.of(TestEntity.FIELD_1));
         validator.register(ancestorsValidator);
         List<? extends EntityField<?, ?>> fields = validator.requiredFields(Collections.emptyList(), ChangeOperation.UPDATE).collect(Collectors.toList());
-        ;
         assertThat(fields.size(), is(1));
         assertThat(fields, containsInAnyOrder(TestEntity.FIELD_1));
     }

--- a/main/src/test/java/com/kenshoo/pl/entity/spi/helpers/EntityChangeCompositeValidatorTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/spi/helpers/EntityChangeCompositeValidatorTest.java
@@ -13,6 +13,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -28,7 +29,6 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class EntityChangeCompositeValidatorTest {
 
-    private static final int ENTITY_ID = 10;
     private static final String FIELD_1_VALUE = "value1";
 
     @Mock
@@ -175,7 +175,7 @@ public class EntityChangeCompositeValidatorTest {
     public void registerAncestorsValidatorForCreateTest() {
         validator.register(ancestorsValidator);
         validator.validate(entityChanges, ChangeOperation.CREATE, changeContext);
-        verify(ancestorsValidator).validate(any(CurrentEntityState.class));
+        verify(ancestorsValidator).validate(currentState);
     }
 
     @Test
@@ -183,5 +183,23 @@ public class EntityChangeCompositeValidatorTest {
         validator.register(ancestorsValidator);
         validator.validate(entityChanges, ChangeOperation.UPDATE, changeContext);
         verify(ancestorsValidator).validate(any(CurrentEntityState.class));
+    }
+
+    @Test
+    public void registerAncestorsValidatorForEmptyUpdateTest() {
+        when(entityChange.getChangedFields()).thenReturn(Stream.of());
+        validator.register(ancestorsValidator);
+        validator.validate(entityChanges, ChangeOperation.UPDATE, changeContext);
+        verify(ancestorsValidator).validate(currentState);
+    }
+
+    @Test
+    public void ancestorsRequiredFieldsForEmptyUpdateTest() {
+        when(ancestorsValidator.ancestorsFields()).thenReturn(Stream.of(TestEntity.FIELD_1));
+        validator.register(ancestorsValidator);
+        List<? extends EntityField<?, ?>> fields = validator.requiredFields(Collections.emptyList(), ChangeOperation.UPDATE).collect(Collectors.toList());
+        ;
+        assertThat(fields.size(), is(1));
+        assertThat(fields, containsInAnyOrder(TestEntity.FIELD_1));
     }
 }


### PR DESCRIPTION
Entity change composite validator refactoring fix the bug of ancestor validator when the changed entity does not contain any changed fields.