### PR TITLE
PL-99: Add Triptional methods for examining the value

### DIFF
--- a/main/src/main/java/com/kenshoo/pl/entity/Triptional.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/Triptional.java
@@ -5,10 +5,7 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.BiFunction;
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.function.Supplier;
+import java.util.function.*;
 
 import static com.kenshoo.pl.entity.Triptional.State.*;
 import static java.util.Objects.requireNonNull;
@@ -312,6 +309,50 @@ public class Triptional<T> {
     public <U> Optional<U> mapToOptional(final Function<? super T, ? extends U> notNullMapper,
                                          final Supplier<? extends U> nullReplacer) {
         return map(notNullMapper, nullReplacer).asOptional();
+    }
+
+    /**
+     * Return {@code true} if there is a value present (possibly {@code null}), and it equals the input;
+     * otherwise {@code false}
+     *
+     * @param value a value to compare to this value
+     * @return {@code true} if there is a value present, and it equals the input; otherwise {@code false}
+     */
+    public boolean contains(final T value) {
+        return isPresent() && Objects.equals(this.value, value);
+    }
+
+    /**
+     * If a value is present, and the value matches the given predicate,
+     * returns an {@code Triptional} describing the value, otherwise returns an
+     * absent {@code Triptional}.
+     *
+     * @param predicate the predicate to apply to a value, if present
+     * @return an {@code Triptional} describing the value of this
+     *         {@code Triptional}, if a value is present and the value matches the
+     *         given predicate; otherwise an absent {@code Triptional}
+     * @throws NullPointerException if the predicate is {@code null}
+     */
+    public Triptional<T> filter(final Predicate<? super T> predicate) {
+        requireNonNull(predicate, "a predicate must be provided");
+        if (matches(predicate)) {
+            return this;
+        }
+        return absent();
+    }
+
+    /**
+     * Return {@code true} if there is a value is present, and it matches the given predicate;
+     * otherwise return {@code false}
+     *
+     * @param predicate the predicate to apply to a value, if present
+     * @return {@code true} if there is a value is present, and it matches the given predicate;
+     *         otherwise {@code false}
+     * @throws NullPointerException if the predicate is {@code null}
+     */
+    public boolean matches(final Predicate<? super T> predicate) {
+        requireNonNull(predicate, "a predicate must be provided");
+        return isPresent() && predicate.test(value);
     }
 
     /**

--- a/main/src/main/java/com/kenshoo/pl/entity/Triptional.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/Triptional.java
@@ -312,17 +312,6 @@ public class Triptional<T> {
     }
 
     /**
-     * Return {@code true} if there is a value present (possibly {@code null}), and it equals the input;
-     * otherwise {@code false}
-     *
-     * @param value a value to compare to this value
-     * @return {@code true} if there is a value present, and it equals the input; otherwise {@code false}
-     */
-    public boolean contains(final T value) {
-        return isPresent() && Objects.equals(this.value, value);
-    }
-
-    /**
      * If a value is present, and the value matches the given predicate,
      * returns an {@code Triptional} describing the value, otherwise returns an
      * absent {@code Triptional}.
@@ -389,6 +378,17 @@ public class Triptional<T> {
      */
     public boolean isNull() {
         return state == NULL;
+    }
+
+    /**
+     * Return {@code true} if there is a value present (possibly {@code null}), and it equals the input;
+     * otherwise {@code false}
+     *
+     * @param value a value to compare to this value
+     * @return {@code true} if there is a value present, and it equals the input; otherwise {@code false}
+     */
+    public boolean equalsValue(final T value) {
+        return isPresent() && Objects.equals(this.value, value);
     }
 
     /**

--- a/main/src/test/java/com/kenshoo/pl/entity/TriptionalTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/TriptionalTest.java
@@ -311,36 +311,6 @@ public class TriptionalTest {
     }
 
     @Test
-    public void contains_WhenBothNotNullAndEqual_ShouldReturnTrue() {
-        assertThat(Triptional.of(2).contains(2), is(true));
-    }
-
-    @Test
-    public void contains_WhenBothNotNullAndUnequal_ShouldReturnFalse() {
-        assertThat(Triptional.of(2).contains(3), is(false));
-    }
-
-    @Test
-    public void contains_WhenThisNullAndOtherNotNull_ShouldReturnFalse() {
-        assertThat(Triptional.nullInstance().contains(3), is(false));
-    }
-
-    @Test
-    public void contains_WhenThisNotNullAndOtherNull_ShouldReturnFalse() {
-        assertThat(Triptional.of(2).contains(null), is(false));
-    }
-
-    @Test
-    public void contains_WhenThisAbsentAndOtherNotNull_ShouldReturnFalse() {
-        assertThat(Triptional.absent().contains(3), is(false));
-    }
-
-    @Test
-    public void contains_WhenThisAbsentAndOtherNull_ShouldReturnFalse() {
-        assertThat(Triptional.absent().contains(null), is(false));
-    }
-
-    @Test
     public void filter_WhenNotNullAndMatchesPredicate_ShouldReturnThis_Scenario1() {
         assertThat(Triptional.of(2).filter(num -> num < 3), is(Triptional.of(2)));
     }
@@ -398,6 +368,41 @@ public class TriptionalTest {
     @Test
     public void matches_WhenAbsent_ShouldReturnFalse() {
         assertThat(Triptional.absent().matches("abc"::equals), is(false));
+    }
+
+    @Test
+    public void equalsValue_WhenBothNotNullAndEqual_ShouldReturnTrue() {
+        assertThat(Triptional.of(2).equalsValue(2), is(true));
+    }
+
+    @Test
+    public void equalsValue_WhenBothNotNullAndUnequal_ShouldReturnFalse() {
+        assertThat(Triptional.of(2).equalsValue(3), is(false));
+    }
+
+    @Test
+    public void equalsValue_WhenThisNullAndOtherNotNull_ShouldReturnFalse() {
+        assertThat(Triptional.nullInstance().equalsValue(3), is(false));
+    }
+
+    @Test
+    public void equalsValue_WhenThisNotNullAndOtherNull_ShouldReturnFalse() {
+        assertThat(Triptional.of(2).equalsValue(null), is(false));
+    }
+
+    @Test
+    public void equalsValue_WhenBothNull_ShouldReturnTrue() {
+        assertThat(Triptional.nullInstance().equalsValue(null), is(true));
+    }
+
+    @Test
+    public void equalsValue_WhenThisAbsentAndOtherNotNull_ShouldReturnFalse() {
+        assertThat(Triptional.absent().equalsValue(3), is(false));
+    }
+
+    @Test
+    public void equalsValue_WhenThisAbsentAndOtherNull_ShouldReturnFalse() {
+        assertThat(Triptional.absent().equalsValue(null), is(false));
     }
 
     @Test

--- a/main/src/test/java/com/kenshoo/pl/entity/TriptionalTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/TriptionalTest.java
@@ -311,6 +311,96 @@ public class TriptionalTest {
     }
 
     @Test
+    public void contains_WhenBothNotNullAndEqual_ShouldReturnTrue() {
+        assertThat(Triptional.of(2).contains(2), is(true));
+    }
+
+    @Test
+    public void contains_WhenBothNotNullAndUnequal_ShouldReturnFalse() {
+        assertThat(Triptional.of(2).contains(3), is(false));
+    }
+
+    @Test
+    public void contains_WhenThisNullAndOtherNotNull_ShouldReturnFalse() {
+        assertThat(Triptional.nullInstance().contains(3), is(false));
+    }
+
+    @Test
+    public void contains_WhenThisNotNullAndOtherNull_ShouldReturnFalse() {
+        assertThat(Triptional.of(2).contains(null), is(false));
+    }
+
+    @Test
+    public void contains_WhenThisAbsentAndOtherNotNull_ShouldReturnFalse() {
+        assertThat(Triptional.absent().contains(3), is(false));
+    }
+
+    @Test
+    public void contains_WhenThisAbsentAndOtherNull_ShouldReturnFalse() {
+        assertThat(Triptional.absent().contains(null), is(false));
+    }
+
+    @Test
+    public void filter_WhenNotNullAndMatchesPredicate_ShouldReturnThis_Scenario1() {
+        assertThat(Triptional.of(2).filter(num -> num < 3), is(Triptional.of(2)));
+    }
+
+    @Test
+    public void filter_WhenNotNullAndMatchesPredicate_ShouldReturnThis_Scenario2() {
+        assertThat(Triptional.of(2).filter(num -> num > 1), is(Triptional.of(2)));
+    }
+
+    @Test
+    public void filter_WhenNotNullAndDoesntMatchPredicate_ShouldReturnAbsent() {
+        assertThat(Triptional.of(2).filter(num -> num < 2), is(Triptional.absent()));
+    }
+
+    @Test
+    public void filter_WhenNullAndMatchesPredicate_ShouldReturnThis() {
+        assertThat(Triptional.nullInstance().filter(Objects::isNull), is(Triptional.nullInstance()));
+    }
+
+    @Test
+    public void filter_WhenNullAndDoesntMatchPredicate_ShouldReturnAbsent() {
+        assertThat(Triptional.nullInstance().filter("abc"::equals), is(Triptional.absent()));
+    }
+
+    @Test
+    public void filter_WhenAbsent_ShouldReturnAbsent() {
+        assertThat(Triptional.absent().filter("abc"::equals), is(Triptional.absent()));
+    }
+
+    @Test
+    public void matches_WhenNotNullAndMatchesPredicate_ShouldReturnTrue_Scenario1() {
+        assertThat(Triptional.of(2).matches(num -> num < 3), is(true));
+    }
+
+    @Test
+    public void matches_WhenNotNullAndMatchesPredicate_ShouldReturnTrue_Scenario2() {
+        assertThat(Triptional.of(2).matches(num -> num > 1), is(true));
+    }
+
+    @Test
+    public void matches_WhenNotNullAndDoesntMatchPredicate_ShouldReturnFalse() {
+        assertThat(Triptional.of(2).matches(num -> num < 2), is(false));
+    }
+
+    @Test
+    public void matches_WhenNullAndMatchesPredicate_ShouldReturnTrue() {
+        assertThat(Triptional.nullInstance().matches(Objects::isNull), is(true));
+    }
+
+    @Test
+    public void matches_WhenNullAndDoesntMatchPredicate_ShouldReturnFalse() {
+        assertThat(Triptional.nullInstance().matches("abc"::equals), is(false));
+    }
+
+    @Test
+    public void matches_WhenAbsent_ShouldReturnFalse() {
+        assertThat(Triptional.absent().matches("abc"::equals), is(false));
+    }
+
+    @Test
     public void equalsOneArg_WhenBothNotNullWithSameValue_ShouldReturnTrue() {
         assertThat(Triptional.of(2).equals(Triptional.of(1 + 1)), is(true));
     }


### PR DESCRIPTION
To support a use-case that has already come up in Kenshoo search - adding three methods for checking the value of a `Triptional`.
`filter()` already exists in `Optional`.
The other two exist in the Scala `Option`. We chose different names:
- `equalsValue()` instead of `contains()`
- `matches()` instead of `exists()`