### PR TITLE
don't share state on CREATE because it doesn't work when populating c…

### DIFF
--- a/main/src/main/java/com/kenshoo/pl/entity/CurrentEntityMutableState.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/CurrentEntityMutableState.java
@@ -9,7 +9,7 @@ import static java.util.Collections.emptyList;
 
 public class CurrentEntityMutableState implements CurrentEntityState {
 
-    private final Map<EntityField<?, ?>, Object> fields = new HashMap<>();
+    private final Map<EntityField<?, ?>, Object> fields = new HashMap<>(1);
     private Map<EntityType, List<FieldsValueMap>> manyByType;
 
     public boolean containsField(EntityField<?, ?> field) {

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/EntitiesToContextFetcher.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/EntitiesToContextFetcher.java
@@ -106,8 +106,7 @@ public class EntitiesToContextFetcher {
         E entityType = flowConfig.getEntityType();
         Collection<EntityField<E, ?>> foreignKeys = entityType.determineForeignKeys(flowConfig.getRequiredRelationFields()).filter(not(new IsFieldReferringToParent<>(context.getHierarchy(), entityType))).collect(toList());
         if (foreignKeys.isEmpty()) {
-            CurrentEntityState sharedEntity = new CurrentEntityMutableState();
-            commands.forEach(cmd -> context.addEntity(cmd, sharedEntity));
+            commands.forEach(cmd -> context.addEntity(cmd, new CurrentEntityMutableState()));
         } else {
             final UniqueKey<E> foreignUniqueKey = new ForeignUniqueKey<>(foreignKeys);
             Map<? extends ChangeEntityCommand<E>, Identifier<E>> keysByCommand = commands.stream().collect(toMap(identity(), foreignUniqueKey::createValue));


### PR DESCRIPTION
The bug
---
Children of CREATE operator share the same CurrentState.
When different children of different parents require fields from their parents, it doesn't work.
EntitiesToContextFetcher populates the parent values into the children, but since they all share the same state, the values override each other.

Test that fails before the fix:
```java
    @Test
    public void create_child_with_supplier_from_parent() {

        insert(newParent().with(NAME, "moshe"));
        insert(newParent().with(NAME, "david"));

        var supplier = fromOldValue(ParentEntity.NAME, parentName -> "I'm the child of " + parentName);

        update(
            existingParentWithId(generatedId(0)).with(insertChild().with(ORDINAL, 0).with(FIELD_1, supplier)),
            existingParentWithId(generatedId(1)).with(insertChild().with(ORDINAL, 0).with(FIELD_1, supplier))
        );
```

Expecting "child of moshe" and "child of david", but actual results are "child of david" and "child of david".

The fix is simple: each child command shall have it's own state.
