### PR TITLE
Failing test for creating multiple entity types in transaction

### DIFF
--- a/integration-tests/src/test/java/com/kenshoo/pl/transaction/Entity1.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/transaction/Entity1.java
@@ -1,0 +1,39 @@
+package com.kenshoo.pl.transaction;
+
+import com.kenshoo.jooq.DataTable;
+import com.kenshoo.pl.entity.*;
+import com.kenshoo.pl.entity.annotation.Id;
+import com.kenshoo.pl.one2many.relatedByPK.ParentEntity;
+import com.kenshoo.pl.one2many.relatedByPK.ParentTable;
+
+
+public class Entity1 extends AbstractEntityType<Entity1> {
+
+    public static final Entity1 INSTANCE = new Entity1();
+
+    @Id
+    public static final EntityField<Entity1, Integer> ID = INSTANCE.field(Table1.INSTANCE.id);
+
+    public static final EntityField<Entity1, String> NAME = INSTANCE.field(Table1.INSTANCE.name);
+
+    private Entity1() {
+        super("entity1");
+    }
+
+    @Override
+    public DataTable getPrimaryTable() {
+        return Table1.INSTANCE;
+    }
+
+    @Override
+    public SupportedChangeOperation getSupportedOperation() {
+        return SupportedChangeOperation.CREATE_UPDATE_AND_DELETE;
+    }
+
+    public static class Key extends SingleUniqueKey<Entity1, Integer> {
+        public Key() {
+            super(Entity1.ID);
+        }
+    }
+
+}

--- a/integration-tests/src/test/java/com/kenshoo/pl/transaction/Entity2.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/transaction/Entity2.java
@@ -1,0 +1,37 @@
+package com.kenshoo.pl.transaction;
+
+import com.kenshoo.jooq.DataTable;
+import com.kenshoo.pl.entity.*;
+import com.kenshoo.pl.entity.annotation.Id;
+import com.kenshoo.pl.one2many.relatedByPK.ParentTable;
+
+
+public class Entity2 extends AbstractEntityType<Entity2> {
+
+    public static final Entity2 INSTANCE = new Entity2();
+
+    @Id
+    public static final EntityField<Entity2, Integer> ID = INSTANCE.field(Table2.INSTANCE.id);
+
+    public static final EntityField<Entity2, String> NAME = INSTANCE.field(Table2.INSTANCE.name);
+
+    private Entity2() {
+        super("entity2");
+    }
+
+    @Override
+    public DataTable getPrimaryTable() {
+        return Table2.INSTANCE;
+    }
+
+    @Override
+    public SupportedChangeOperation getSupportedOperation() {
+        return SupportedChangeOperation.CREATE_UPDATE_AND_DELETE;
+    }
+
+    public static class Key extends SingleUniqueKey<Entity2, Integer> {
+        public Key() {
+            super(Entity2.ID);
+        }
+    }
+}

--- a/integration-tests/src/test/java/com/kenshoo/pl/transaction/MultipleEntityTypeTransactionTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/transaction/MultipleEntityTypeTransactionTest.java
@@ -1,0 +1,130 @@
+package com.kenshoo.pl.transaction;
+
+import com.kenshoo.jooq.DataTable;
+import com.kenshoo.jooq.DataTableUtils;
+import com.kenshoo.jooq.TestJooqConfig;
+import com.kenshoo.pl.TypedFluidPersistenceCmdBuilder;
+import com.kenshoo.pl.entity.*;
+import com.kenshoo.pl.one2many.relatedByPK.IdGenerator;
+import com.kenshoo.pl.one2many.relatedByPK.IntegerIdGeneratorEnricher;
+import org.jooq.DSLContext;
+import org.jooq.Query;
+import org.jooq.impl.DSL;
+import org.jooq.lambda.Seq;
+import org.junit.*;
+
+import java.util.List;
+
+import static com.kenshoo.pl.TypedFluidPersistenceCmdBuilder.fluid;
+
+public class MultipleEntityTypeTransactionTest {
+
+    private static final TablesSetup tablesSetup = new TablesSetup();
+
+    private static final Table1 TABLE_1 = Table1.INSTANCE;
+    private static final Table2 TABLE_2 = Table2.INSTANCE;
+    private static final List<DataTable> ALL_TABLES = List.of(TABLE_1, TABLE_2);
+
+    private final IdGenerator idGenerator = new IdGenerator();
+
+    private final DSLContext jooq = TestJooqConfig.create();
+
+    private PLContext plContext;
+
+    private PersistenceLayer<Entity1> persistenceLayer1;
+    private PersistenceLayer<Entity2> persistenceLayer2;
+
+    @Before
+    public void setupTables() {
+        persistenceLayer1 = new PersistenceLayer<>(jooq);
+        persistenceLayer2 = new PersistenceLayer<>(jooq);
+        plContext = new PLContext.Builder(jooq).build();
+
+        if (tablesSetup.alreadyCreated) {
+            return;
+        }
+        tablesSetup.alreadyCreated = true;
+        tablesSetup.staticDSLContext = jooq;
+
+        ALL_TABLES.forEach(table -> DataTableUtils.createTable(jooq, table));
+        jooq.alterTable(TABLE_1).add(DSL.constraint("unique_id_1").unique(TABLE_1.id)).execute();
+        jooq.alterTable(TABLE_2).add(DSL.constraint("unique_id_2").unique(TABLE_2.id)).execute();
+    }
+
+    @Ignore
+    @Test
+    public void createTwoUnrelatedTypesInTransaction() {
+
+        jooq.transactionResult(configuration -> {
+            final var result1 = insertEntity1(newEntity1().with(Entity1.NAME, "name1"));
+            final var result2 = insertEntity2(newEntity2().with(Entity2.NAME, "name2"));
+            return Seq.of(result1, result2) ;
+        });
+    }
+
+    @After
+    public void clearTables() {
+        ALL_TABLES.stream()
+                  .map(jooq::deleteFrom)
+                  .forEach(Query::execute);
+    }
+
+    @AfterClass
+    public static void dropTables() {
+        ALL_TABLES.stream()
+                  .map(tablesSetup.staticDSLContext::dropTableIfExists)
+                  .forEach(Query::execute);
+    }
+
+    @SafeVarargs
+    private CreateResult<Entity1, Identifier<Entity1>> insertEntity1(TypedFluidPersistenceCmdBuilder<Entity1, CreateEntityCommand<Entity1>>... cmds) {
+        return insert(persistenceLayer1, Entity1.INSTANCE, Entity1.ID, cmds);
+    }
+
+    @SafeVarargs
+    private CreateResult<Entity2, Identifier<Entity2>> insertEntity2(TypedFluidPersistenceCmdBuilder<Entity2, CreateEntityCommand<Entity2>>... cmds) {
+        return insert(persistenceLayer2, Entity2.INSTANCE, Entity2.ID, cmds);
+    }
+
+    @SafeVarargs
+    private <E extends EntityType<E>> CreateResult<E, Identifier<E>> insert(PersistenceLayer<E> persistenceLayer,
+                                                                            E entityType,
+                                                                            EntityField<E, Integer> idField,
+                                                                            TypedFluidPersistenceCmdBuilder<E, CreateEntityCommand<E>>... cmds) {
+        return insert(persistenceLayer, flow(entityType, idField), cmds);
+    }
+
+    @SafeVarargs
+    private <E extends EntityType<E>> CreateResult<E, Identifier<E>> insert(PersistenceLayer<E> persistenceLayer,
+                                                                            ChangeFlowConfig.Builder<E> flow,
+                                                                            TypedFluidPersistenceCmdBuilder<E, CreateEntityCommand<E>>... cmdBuilders) {
+        final List<CreateEntityCommand<E>> createCmds = Seq.of(cmdBuilders)
+                                                           .map(TypedFluidPersistenceCmdBuilder::get)
+                                                           .toList();
+
+        return persistenceLayer.create(createCmds, flow.build());
+    }
+
+    private <E extends EntityType<E>> ChangeFlowConfig.Builder<E> flow(E entityType, EntityField<E, Integer> idField) {
+        final IntegerIdGeneratorEnricher<E> idEnricher = new IntegerIdGeneratorEnricher<>(idGenerator, idField);
+        return ChangeFlowConfigBuilderFactory.newInstance(plContext, entityType)
+                                             .withPostFetchCommandEnricher(idEnricher);
+    }
+
+    private TypedFluidPersistenceCmdBuilder<Entity1, CreateEntityCommand<Entity1>> newEntity1() {
+        return newEntity(Entity1.INSTANCE);
+    }
+
+    private TypedFluidPersistenceCmdBuilder<Entity2, CreateEntityCommand<Entity2>> newEntity2() {
+        return newEntity(Entity2.INSTANCE);
+    }
+
+    private <E extends EntityType<E>> TypedFluidPersistenceCmdBuilder<E, CreateEntityCommand<E>> newEntity(E entityType) {
+        return fluid(new CreateEntityCommand<>(entityType));
+    }
+
+    private static class TablesSetup {
+        DSLContext staticDSLContext;
+        boolean alreadyCreated = false;
+    }
+}

--- a/integration-tests/src/test/java/com/kenshoo/pl/transaction/MultipleEntityTypeTransactionTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/transaction/MultipleEntityTypeTransactionTest.java
@@ -12,10 +12,12 @@ import org.jooq.Query;
 import org.jooq.impl.DSL;
 import org.jooq.lambda.Seq;
 import org.junit.*;
+import static org.hamcrest.CoreMatchers.is;
 
 import java.util.List;
 
 import static com.kenshoo.pl.TypedFluidPersistenceCmdBuilder.fluid;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class MultipleEntityTypeTransactionTest {
 
@@ -53,14 +55,48 @@ public class MultipleEntityTypeTransactionTest {
 
     @Ignore
     @Test
-    public void createTwoUnrelatedTypesInTransaction() {
+    public void commitTwoUnrelatedTypesInTransaction() {
 
-        jooq.transactionResult(configuration -> {
+        var results = jooq.transactionResult(configuration -> {
             final var result1 = insertEntity1(newEntity1().with(Entity1.NAME, "name1"));
             final var result2 = insertEntity2(newEntity2().with(Entity2.NAME, "name2"));
-            return Seq.of(result1, result2) ;
+            return List.of(result1.getChangeResults().iterator().next().getCommand().get(Entity1.ID),
+                           result2.getChangeResults().iterator().next().getCommand().get(Entity2.ID));
         });
+
+        List<CurrentEntityState> fetch1 = plContext.select(Entity1.NAME).from(Entity1.INSTANCE).where(Entity1.ID.eq(results.get(0))).fetch();
+        List<CurrentEntityState> fetch2 = plContext.select(Entity2.NAME).from(Entity2.INSTANCE).where(Entity2.ID.eq(results.get(1))).fetch();
+        assertThat(fetch1.get(0).get(Entity1.NAME), is("name1"));
+        assertThat(fetch2.get(0).get(Entity2.NAME), is("name2"));
     }
+
+    @Ignore
+    @Test
+    public void rollbackTwoUnrelatedTypesInTransaction() {
+
+        var results = jooq.transactionResult(configuration -> {
+            final var result1 = insertEntity1(newEntity1().with(Entity1.NAME, "name1"));
+            final var result2 = insertEntity2(newEntity2().with(Entity2.NAME, "name2"));
+            return List.of(result1.getChangeResults().iterator().next().getCommand().get(Entity1.ID),
+                    result2.getChangeResults().iterator().next().getCommand().get(Entity2.ID));
+        });
+
+        try {
+            jooq.transaction(configuration -> {
+                updateEntity1(updateEntity1(IdentifierType.uniqueKey(Entity1.ID).createIdentifier(results.get(0))).with(Entity1.NAME, "name1_update"));
+                updateEntity2(updateEntity2(IdentifierType.uniqueKey(Entity2.ID).createIdentifier(results.get(1))).with(Entity2.NAME, "name2_update"));
+                throw new RuntimeException("Rollback transaction");
+            });
+        } catch (Exception e){
+        }
+
+
+        List<CurrentEntityState> fetch1 = plContext.select(Entity1.NAME).from(Entity1.INSTANCE).where(Entity1.ID.eq(results.get(0))).fetch();
+        List<CurrentEntityState> fetch2 = plContext.select(Entity2.NAME).from(Entity2.INSTANCE).where(Entity2.ID.eq(results.get(1))).fetch();
+        assertThat(fetch1.get(0).get(Entity1.NAME), is("name1"));
+        assertThat(fetch2.get(0).get(Entity2.NAME), is("name2"));
+    }
+
 
     @After
     public void clearTables() {
@@ -105,6 +141,35 @@ public class MultipleEntityTypeTransactionTest {
         return persistenceLayer.create(createCmds, flow.build());
     }
 
+    @SafeVarargs
+    private UpdateResult<Entity1, Identifier<Entity1>> updateEntity1(TypedFluidPersistenceCmdBuilder<Entity1, UpdateEntityCommand<Entity1, Identifier<Entity1>>>... cmds) {
+        return update(persistenceLayer1, Entity1.INSTANCE, Entity1.ID, cmds);
+    }
+
+    @SafeVarargs
+    private UpdateResult<Entity2, Identifier<Entity2>> updateEntity2(TypedFluidPersistenceCmdBuilder<Entity2, UpdateEntityCommand<Entity2, Identifier<Entity2>>>... cmds) {
+        return update(persistenceLayer2, Entity2.INSTANCE, Entity2.ID, cmds);
+    }
+
+    @SafeVarargs
+    private <E extends EntityType<E>> UpdateResult<E, Identifier<E>> update(PersistenceLayer<E> persistenceLayer,
+                                                                            E entityType,
+                                                                            EntityField<E, Integer> idField,
+                                                                            TypedFluidPersistenceCmdBuilder<E, UpdateEntityCommand<E, Identifier<E>>>... cmds) {
+        return update(persistenceLayer, flow(entityType, idField), cmds);
+    }
+
+    @SafeVarargs
+    private <ID extends Identifier<E>, E extends EntityType<E>> UpdateResult<E, ID> update(PersistenceLayer<E> persistenceLayer,
+                                                                            ChangeFlowConfig.Builder<E> flow,
+                                                                            TypedFluidPersistenceCmdBuilder<E, UpdateEntityCommand<E, ID>>... cmdBuilders) {
+        final List<UpdateEntityCommand<E, ID>> createCmds = Seq.of(cmdBuilders)
+                .map(TypedFluidPersistenceCmdBuilder::get)
+                .toList();
+
+        return persistenceLayer.update(createCmds, flow.build());
+    }
+
     private <E extends EntityType<E>> ChangeFlowConfig.Builder<E> flow(E entityType, EntityField<E, Integer> idField) {
         final IntegerIdGeneratorEnricher<E> idEnricher = new IntegerIdGeneratorEnricher<>(idGenerator, idField);
         return ChangeFlowConfigBuilderFactory.newInstance(plContext, entityType)
@@ -119,9 +184,22 @@ public class MultipleEntityTypeTransactionTest {
         return newEntity(Entity2.INSTANCE);
     }
 
+    private  <ID extends Identifier<Entity1>>TypedFluidPersistenceCmdBuilder<Entity1, UpdateEntityCommand<Entity1, ID>> updateEntity1(ID key) {
+        return updateEntity(Entity1.INSTANCE, key);
+    }
+
+    private  <ID extends Identifier<Entity2>>TypedFluidPersistenceCmdBuilder<Entity2, UpdateEntityCommand<Entity2, ID>> updateEntity2(ID key) {
+        return updateEntity(Entity2.INSTANCE, key);
+    }
+
     private <E extends EntityType<E>> TypedFluidPersistenceCmdBuilder<E, CreateEntityCommand<E>> newEntity(E entityType) {
         return fluid(new CreateEntityCommand<>(entityType));
     }
+
+    private <E extends EntityType<E>, ID extends Identifier<E>> TypedFluidPersistenceCmdBuilder<E, UpdateEntityCommand<E, ID>> updateEntity(E entityType, ID key) {
+        return fluid(new UpdateEntityCommand<>(entityType, key));
+    }
+
 
     private static class TablesSetup {
         DSLContext staticDSLContext;

--- a/integration-tests/src/test/java/com/kenshoo/pl/transaction/MultipleEntityTypeTransactionTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/transaction/MultipleEntityTypeTransactionTest.java
@@ -3,12 +3,15 @@ package com.kenshoo.pl.transaction;
 import com.kenshoo.jooq.DataTable;
 import com.kenshoo.jooq.DataTableUtils;
 import com.kenshoo.jooq.TestJooqConfig;
+import com.kenshoo.jooq.TransactionContextImpl;
 import com.kenshoo.pl.TypedFluidPersistenceCmdBuilder;
 import com.kenshoo.pl.entity.*;
 import com.kenshoo.pl.one2many.relatedByPK.IdGenerator;
 import com.kenshoo.pl.one2many.relatedByPK.IntegerIdGeneratorEnricher;
 import org.jooq.DSLContext;
 import org.jooq.Query;
+import org.jooq.TransactionContext;
+import org.jooq.TransactionProvider;
 import org.jooq.impl.DSL;
 import org.jooq.lambda.Seq;
 import org.junit.*;
@@ -53,16 +56,20 @@ public class MultipleEntityTypeTransactionTest {
         jooq.alterTable(TABLE_2).add(DSL.constraint("unique_id_2").unique(TABLE_2.id)).execute();
     }
 
-    @Ignore
     @Test
     public void commitTwoUnrelatedTypesInTransaction() {
 
-        var results = jooq.transactionResult(configuration -> {
-            final var result1 = insertEntity1(newEntity1().with(Entity1.NAME, "name1"));
-            final var result2 = insertEntity2(newEntity2().with(Entity2.NAME, "name2"));
-            return List.of(result1.getChangeResults().iterator().next().getCommand().get(Entity1.ID),
-                           result2.getChangeResults().iterator().next().getCommand().get(Entity2.ID));
-        });
+        final TransactionProvider txProvider = jooq.configuration().transactionProvider();
+        TransactionContext trx = new TransactionContextImpl(jooq.configuration(), jooq);
+        txProvider.begin(trx);
+
+
+        final var result1 = insertEntity1(newEntity1().with(Entity1.NAME, "name1"));
+        final var result2 = insertEntity2(newEntity2().with(Entity2.NAME, "name2"));
+        final var results =  List.of(result1.getChangeResults().iterator().next().getCommand().get(Entity1.ID),
+                    result2.getChangeResults().iterator().next().getCommand().get(Entity2.ID));
+
+        txProvider.commit(trx);
 
         List<CurrentEntityState> fetch1 = plContext.select(Entity1.NAME).from(Entity1.INSTANCE).where(Entity1.ID.eq(results.get(0))).fetch();
         List<CurrentEntityState> fetch2 = plContext.select(Entity2.NAME).from(Entity2.INSTANCE).where(Entity2.ID.eq(results.get(1))).fetch();
@@ -70,25 +77,23 @@ public class MultipleEntityTypeTransactionTest {
         assertThat(fetch2.get(0).get(Entity2.NAME), is("name2"));
     }
 
-    @Ignore
     @Test
     public void rollbackTwoUnrelatedTypesInTransaction() {
 
-        var results = jooq.transactionResult(configuration -> {
-            final var result1 = insertEntity1(newEntity1().with(Entity1.NAME, "name1"));
-            final var result2 = insertEntity2(newEntity2().with(Entity2.NAME, "name2"));
-            return List.of(result1.getChangeResults().iterator().next().getCommand().get(Entity1.ID),
-                    result2.getChangeResults().iterator().next().getCommand().get(Entity2.ID));
-        });
 
-        try {
-            jooq.transaction(configuration -> {
-                updateEntity1(updateEntity1(IdentifierType.uniqueKey(Entity1.ID).createIdentifier(results.get(0))).with(Entity1.NAME, "name1_update"));
-                updateEntity2(updateEntity2(IdentifierType.uniqueKey(Entity2.ID).createIdentifier(results.get(1))).with(Entity2.NAME, "name2_update"));
-                throw new RuntimeException("Rollback transaction");
-            });
-        } catch (Exception e){
-        }
+        final var result1 = insertEntity1(newEntity1().with(Entity1.NAME, "name1"));
+        final var result2 = insertEntity2(newEntity2().with(Entity2.NAME, "name2"));
+        final var results =  List.of(result1.getChangeResults().iterator().next().getCommand().get(Entity1.ID),
+                result2.getChangeResults().iterator().next().getCommand().get(Entity2.ID));
+
+        final TransactionProvider txProvider = jooq.configuration().transactionProvider();
+        TransactionContext trx = new TransactionContextImpl(jooq.configuration(), jooq);
+        txProvider.begin(trx);
+
+        updateEntity1(updateEntity1(IdentifierType.uniqueKey(Entity1.ID).createIdentifier(results.get(0))).with(Entity1.NAME, "name1_update"));
+        updateEntity2(updateEntity2(IdentifierType.uniqueKey(Entity2.ID).createIdentifier(results.get(1))).with(Entity2.NAME, "name2_update"));
+
+        txProvider.rollback(trx);
 
 
         List<CurrentEntityState> fetch1 = plContext.select(Entity1.NAME).from(Entity1.INSTANCE).where(Entity1.ID.eq(results.get(0))).fetch();

--- a/integration-tests/src/test/java/com/kenshoo/pl/transaction/Table1.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/transaction/Table1.java
@@ -1,0 +1,26 @@
+package com.kenshoo.pl.transaction;
+
+import com.kenshoo.jooq.AbstractDataTable;
+import org.jooq.Record;
+import org.jooq.TableField;
+import org.jooq.impl.SQLDataType;
+
+public class Table1 extends AbstractDataTable<Table1> {
+
+    public static final Table1 INSTANCE = new Table1("Table1");
+
+    public final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER);
+    public final TableField<Record, String> name = createField("name", SQLDataType.VARCHAR(40));
+
+    public Table1(String name) {
+        super(name);
+    }
+    public Table1(Table1 aliased, String alias) {
+        super(aliased, alias);
+    }
+
+    @Override
+    public Table1 as(String alias) {
+        return new Table1(this, alias);
+    }
+}

--- a/integration-tests/src/test/java/com/kenshoo/pl/transaction/Table2.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/transaction/Table2.java
@@ -1,0 +1,26 @@
+package com.kenshoo.pl.transaction;
+
+import com.kenshoo.jooq.AbstractDataTable;
+import org.jooq.Record;
+import org.jooq.TableField;
+import org.jooq.impl.SQLDataType;
+
+public class Table2 extends AbstractDataTable<Table2> {
+
+    public static final Table2 INSTANCE = new Table2("Table2");
+
+    public final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER);
+    public final TableField<Record, String> name = createField("name", SQLDataType.VARCHAR(40));
+
+    public Table2(String name) {
+        super(name);
+    }
+    public Table2(Table2 aliased, String alias) {
+        super(aliased, alias);
+    }
+
+    @Override
+    public Table2 as(String alias) {
+        return new Table2(this, alias);
+    }
+}

--- a/main/src/main/java/com/kenshoo/pl/TypedFluidPersistenceCmdBuilder.java
+++ b/main/src/main/java/com/kenshoo/pl/TypedFluidPersistenceCmdBuilder.java
@@ -1,0 +1,51 @@
+package com.kenshoo.pl;
+
+
+import com.kenshoo.pl.entity.ChangeEntityCommand;
+import com.kenshoo.pl.entity.EntityField;
+import com.kenshoo.pl.entity.EntityType;
+import com.kenshoo.pl.entity.internal.MissingChildrenSupplier;
+import com.kenshoo.pl.entity.spi.FieldValueSupplier;
+
+public class TypedFluidPersistenceCmdBuilder<E extends EntityType<E>, CMD extends ChangeEntityCommand<E>> {
+
+    public CMD get() {
+        return cmd;
+    }
+
+    private final CMD cmd;
+
+    public TypedFluidPersistenceCmdBuilder(CMD cmd) {
+        this.cmd = cmd;
+    }
+
+    public static <E extends EntityType<E>, C extends ChangeEntityCommand<E>> TypedFluidPersistenceCmdBuilder<E, C> fluid(C cmd) {
+        return new TypedFluidPersistenceCmdBuilder<>(cmd);
+    }
+
+    public <T> TypedFluidPersistenceCmdBuilder<E, CMD> with(EntityField<E, T> field, T value) {
+        cmd.set(field, value);
+        return this;
+    }
+
+    public <T> TypedFluidPersistenceCmdBuilder<E, CMD> with(EntityField<E, T> field, FieldValueSupplier<T> valueSupplier) {
+        cmd.set(field, valueSupplier);
+        return this;
+    }
+
+    public <CHILD extends EntityType<CHILD>, CHILDCMD extends ChangeEntityCommand<CHILD>> TypedFluidPersistenceCmdBuilder<E, CMD> withChild(CHILDCMD childCmd) {
+        cmd.addChild(childCmd);
+        return this;
+    }
+
+    public <CHILD extends EntityType<CHILD>, CHILDCMD extends ChangeEntityCommand<CHILD>> TypedFluidPersistenceCmdBuilder<E, CMD> withChild(TypedFluidPersistenceCmdBuilder<CHILD, CHILDCMD> childCmd) {
+        cmd.addChild(childCmd.get());
+        return this;
+    }
+
+    public <CHILD extends EntityType<CHILD>> TypedFluidPersistenceCmdBuilder<E, CMD> with(MissingChildrenSupplier<CHILD> s) {
+        cmd.add(s);
+        return this;
+    }
+
+}


### PR DESCRIPTION
Added a failing (ignored) test for the scenario of creating two different entity types in two bulks, in the same transaction.
The test generates the following error:

```
Cannot commit transaction
org.jooq.exception.DataAccessException: Cannot commit transaction
	at org.jooq.impl.DefaultConnectionProvider.commit(DefaultConnectionProvider.java:113)
	at org.jooq.impl.DefaultTransactionProvider.commit(DefaultTransactionProvider.java:192)
	at org.jooq.impl.ThreadLocalTransactionProvider.commit(ThreadLocalTransactionProvider.java:102)
	at org.jooq.impl.DefaultDSLContext.lambda$transactionResult0$0(DefaultDSLContext.java:526)
	at org.jooq.impl.Tools$10$1.block(Tools.java:4509)
	at java.base/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3128)
	at org.jooq.impl.Tools$10.get(Tools.java:4506)
	at org.jooq.impl.DefaultDSLContext.transactionResult0(DefaultDSLContext.java:574)
	at org.jooq.impl.DefaultDSLContext.transactionResult(DefaultDSLContext.java:491)
	at com.kenshoo.pl.transaction.MultipleEntityTypeTransactionTest.createTwoDifferentTypesInTransaction(MultipleEntityTypeTransactionTest.java:60)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.runTestClass(JUnitTestClassExecutor.java:110)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:58)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:38)
	at org.gradle.api.internal.tasks.testing.junit.AbstractJUnitTestClassProcessor.processTestClass(AbstractJUnitTestClassProcessor.java:62)
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.processTestClass(SuiteTestClassProcessor.java:51)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:35)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:32)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:93)
	at com.sun.proxy.$Proxy2.processTestClass(Unknown Source)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.processTestClass(TestWorker.java:118)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:35)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:175)
	at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:157)
	at org.gradle.internal.remote.internal.hub.MessageHub$Handler.run(MessageHub.java:404)
	at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:63)
	at org.gradle.internal.concurrent.ManagedExecutorImpl$1.run(ManagedExecutorImpl.java:46)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at org.gradle.internal.concurrent.ThreadFactoryImpl$ManagedThreadRunnable.run(ThreadFactoryImpl.java:55)
	at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: com.mysql.jdbc.exceptions.jdbc4.MySQLNonTransientConnectionException: No operations allowed after connection closed.
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)
	at com.mysql.jdbc.Util.handleNewInstance(Util.java:389)
	at com.mysql.jdbc.Util.getInstance(Util.java:372)
	at com.mysql.jdbc.SQLError.createSQLException(SQLError.java:958)
	at com.mysql.jdbc.SQLError.createSQLException(SQLError.java:937)
	at com.mysql.jdbc.SQLError.createSQLException(SQLError.java:926)
	at com.mysql.jdbc.SQLError.createSQLException(SQLError.java:872)
	at com.mysql.jdbc.ConnectionImpl.throwConnectionClosedException(ConnectionImpl.java:1236)
	at com.mysql.jdbc.ConnectionImpl.checkClosed(ConnectionImpl.java:1231)
	at com.mysql.jdbc.ConnectionImpl.commit(ConnectionImpl.java:1581)
	at org.jooq.impl.DefaultConnectionProvider.commit(DefaultConnectionProvider.java:110)
```