### PR TITLE
add postFetchCondition to PlCondition

### DIFF
--- a/integration-tests/src/test/java/com/kenshoo/pl/entity/spi/helpers/UniquenessValidatorTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/entity/spi/helpers/UniquenessValidatorTest.java
@@ -216,6 +216,28 @@ public class UniquenessValidatorTest {
     }
 
     @Test
+    public void testDontFailWhenAllCommandsUnmatchedCondition() {
+        final var validator = new UniquenessValidator
+                .Builder<>(entitiesFetcher, new UniqueKey<>(List.of(ParentEntity.NAME)))
+                .setCondition(PLCondition.not(ParentEntity.ID_IN_TARGET.isNull()))
+                .build();
+
+        final var entity1 = new CreateParent()
+                .with(ParentEntity.ID, 99)
+                .with(ParentEntity.NAME, "moshe")
+                .with(ParentEntity.ID_IN_TARGET, null);
+
+        final var entity2 = new CreateParent()
+                .with(ParentEntity.ID, 1)
+                .with(ParentEntity.NAME, "moshe")
+                .with(ParentEntity.ID_IN_TARGET, null);
+
+        final var results = parentPersistence.create(List.of(entity1, entity2), parentFlow(validator).build());
+
+        assertThat(results.hasErrors(), is(false));
+    }
+
+    @Test
     public void testDontFailCommandWhenSameUniqueKeyInDBButConditionIsUnmatched() {
         UniqueKey<ParentEntity> uniqueness = new UniqueKey<>(asList(ParentEntity.NAME));
 

--- a/integration-tests/src/test/java/com/kenshoo/pl/entity/spi/helpers/UniquenessValidatorTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/entity/spi/helpers/UniquenessValidatorTest.java
@@ -172,7 +172,7 @@ public class UniquenessValidatorTest {
     }
 
     @Test
-    public void testDontFailBulkCommandsWhenConditionIsUnmatched() {
+    public void testDontFailCommandWhenSameUniqueKeyInBulkButConditionIsUnmatched() {
         final var validator = new UniquenessValidator
                 .Builder<>(entitiesFetcher, new UniqueKey<>(List.of(ParentEntity.NAME)))
                 .setCondition(PLCondition.not(ParentEntity.ID_IN_TARGET.isNull()))
@@ -194,7 +194,7 @@ public class UniquenessValidatorTest {
     }
 
     @Test
-    public void testFailBulkCommandsWhenConditionIsMatched() {
+    public void testFailCommandWhenSameUniqueKeyInBulkAndConditionIsMatched() {
         final var validator = new UniquenessValidator
                 .Builder<>(entitiesFetcher, new UniqueKey<>(List.of(ParentEntity.NAME)))
                 .setCondition(PLCondition.not(ParentEntity.ID_IN_TARGET.isNull()))
@@ -216,7 +216,7 @@ public class UniquenessValidatorTest {
     }
 
     @Test
-    public void testDontFailCommandConditionIsUnmatched() {
+    public void testDontFailCommandWhenSameUniqueKeyInDBButConditionIsUnmatched() {
         UniqueKey<ParentEntity> uniqueness = new UniqueKey<>(asList(ParentEntity.NAME));
 
         UniquenessValidator<ParentEntity> validator = new UniquenessValidator

--- a/integration-tests/src/test/java/com/kenshoo/pl/entity/spi/helpers/UniquenessValidatorTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/entity/spi/helpers/UniquenessValidatorTest.java
@@ -221,13 +221,17 @@ public class UniquenessValidatorTest {
 
         UniquenessValidator<ParentEntity> validator = new UniquenessValidator
                 .Builder<>(entitiesFetcher, uniqueness)
-                .setCondition(PLCondition.not(ParentEntity.NAME.eq("moshe")))
+                .setCondition(PLCondition.not(ParentEntity.ID_IN_TARGET.isNull()))
                 .build();
 
-        create(new CreateParent().with(ParentEntity.ID, 99).with(ParentEntity.NAME, "moshe"));
+        create(new CreateParent().with(ParentEntity.ID, 99)
+                .with(ParentEntity.NAME, "moshe")
+                .with(ParentEntity.ID_IN_TARGET, null));
 
         List<CreateParent> commands = asList(
-                new CreateParent().with(ParentEntity.ID, 1).with(ParentEntity.NAME, "moshe")
+                new CreateParent().with(ParentEntity.ID, 1)
+                        .with(ParentEntity.NAME, "moshe")
+                        .with(ParentEntity.ID_IN_TARGET, 12345)
         );
 
         CreateResult<ParentEntity, Identifier<ParentEntity>> results = parentPersistence.create(commands, parentFlow(validator).build());

--- a/main/src/main/java/com/kenshoo/pl/entity/EntityField.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/EntityField.java
@@ -30,7 +30,7 @@ public interface EntityField<E extends EntityType<E>, T> {
         final Object tableValue = getDbAdapter().getFirstDbValue(value);
         @SuppressWarnings("unchecked")
         final TableField<Record, Object> tableField = (TableField<Record, Object>)getDbAdapter().getFirstTableField();
-        return new PLCondition(tableField.eq(tableValue), this);
+        return new PLCondition(tableField.eq(tableValue), entity -> entity.safeGet(this).equals(Triptional.of(value)), this);
     }
 
     default PLCondition in(T ...values) {
@@ -41,7 +41,7 @@ public interface EntityField<E extends EntityType<E>, T> {
         final Object[] tableValues = Arrays.stream(values).map(value -> getDbAdapter().getFirstDbValue(value)).toArray(Object[]::new);
         @SuppressWarnings("unchecked")
         final TableField<Record, Object> tableField = (TableField<Record, Object>)getDbAdapter().getFirstTableField();
-        return new PLCondition(tableField.in(tableValues), this);
+        return new PLCondition(tableField.in(tableValues), entity -> Arrays.stream(values).anyMatch(value -> entity.safeGet(this).equals(Triptional.of(value))), this);
     }
 
     default PLCondition isNull() {
@@ -50,6 +50,6 @@ public interface EntityField<E extends EntityType<E>, T> {
         }
         @SuppressWarnings("unchecked")
         final TableField<Record, Object> tableField = (TableField<Record, Object>)getDbAdapter().getFirstTableField();
-        return new PLCondition(tableField.isNull(), this);
+        return new PLCondition(tableField.isNull(), entity -> entity.safeGet(this).isNull(), this);
     }
 }

--- a/main/src/main/java/com/kenshoo/pl/entity/EntityField.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/EntityField.java
@@ -2,6 +2,7 @@ package com.kenshoo.pl.entity;
 
 import org.jooq.Record;
 import org.jooq.TableField;
+import org.jooq.lambda.Seq;
 
 import java.util.Arrays;
 
@@ -41,7 +42,9 @@ public interface EntityField<E extends EntityType<E>, T> {
         final Object[] tableValues = Arrays.stream(values).map(value -> getDbAdapter().getFirstDbValue(value)).toArray(Object[]::new);
         @SuppressWarnings("unchecked")
         final TableField<Record, Object> tableField = (TableField<Record, Object>)getDbAdapter().getFirstTableField();
-        return new PLCondition(tableField.in(tableValues), entity -> Arrays.stream(values).anyMatch(value -> entity.safeGet(this).equals(Triptional.of(value))), this);
+        final var setOfValues = Seq.of(values).toSet();
+        return new PLCondition(tableField.in(tableValues),
+                entity -> setOfValues.contains(entity.safeGet(this).asOptional().orElse(null)), this);
     }
 
     default PLCondition isNull() {

--- a/main/src/main/java/com/kenshoo/pl/entity/PLCondition.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/PLCondition.java
@@ -83,7 +83,7 @@ public class PLCondition {
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder(17, 37)//??
+        return new HashCodeBuilder(17, 37)
                 .append(jooqCondition)
                 .append(lambdaCondition)
                 .append(fields)

--- a/main/src/main/java/com/kenshoo/pl/entity/PLCondition.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/PLCondition.java
@@ -8,27 +8,33 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.jooq.Condition;
 import org.jooq.impl.DSL;
 
-import java.util.Collections;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import static java.util.Objects.requireNonNull;
 
 public class PLCondition {
 
     private final Condition jooqCondition;
+    private final Predicate<Entity> lambdaCondition;
     private final Set<? extends EntityField<?, ?>> fields;
 
-    public PLCondition(final Condition jooqCondition, final EntityField<?, ?>... fields) {
-        this(jooqCondition, ImmutableSet.copyOf(fields));
+    public PLCondition(final Condition jooqCondition, final Predicate<Entity> lambdaCondition, final EntityField<?, ?>... fields) {
+        this(jooqCondition, lambdaCondition, ImmutableSet.copyOf(fields));
     }
 
-    public PLCondition(final Condition jooqCondition, final Set<? extends EntityField<?, ?>> fields) {
+    public PLCondition(final Condition jooqCondition, final Predicate<Entity> lambdaCondition, final Set<? extends EntityField<?, ?>> fields) {
         this.jooqCondition = requireNonNull(jooqCondition, "a Jooq condition must be provided");
+        this.lambdaCondition = requireNonNull(lambdaCondition, "a Lambda condition must be provided");
         this.fields = requireNonNull(fields, "Fields must not be null (can be empty)");
     }
 
     public Condition getJooqCondition() {
         return jooqCondition;
+    }
+
+    public Predicate<Entity> getPostFetchCondition() {
+        return lambdaCondition;
     }
 
     public Set<? extends EntityField<?, ?>> getFields() {
@@ -38,23 +44,26 @@ public class PLCondition {
     public PLCondition and(final PLCondition other) {
         requireNonNull(other, "a condition must be provided");
         return new PLCondition(jooqCondition.and(other.jooqCondition),
+                               lambdaCondition.and(other.lambdaCondition),
                                Sets.union(this.fields, other.fields));
     }
 
     public PLCondition or(final PLCondition other) {
         requireNonNull(other, "a condition must be provided");
         return new PLCondition(jooqCondition.or(other.jooqCondition),
+                               lambdaCondition.or(other.lambdaCondition),
                                Sets.union(this.fields, other.fields));
     }
 
     public static PLCondition not(final PLCondition condition) {
         requireNonNull(condition, "a condition must be provided");
         return new PLCondition(condition.jooqCondition.not(),
+                               condition.lambdaCondition.negate(),
                                condition.fields);
     }
 
     public static PLCondition trueCondition() {
-        return  new PLCondition(DSL.trueCondition());
+        return  new PLCondition(DSL.trueCondition(),entity -> true);
     }
 
     @Override
@@ -66,24 +75,27 @@ public class PLCondition {
         PLCondition that = (PLCondition) o;
 
         return new EqualsBuilder()
-            .append(jooqCondition, that.jooqCondition)
-            .append(fields, that.fields)
-            .isEquals();
+                .append(jooqCondition, that.jooqCondition)
+                .append(lambdaCondition, that.lambdaCondition)
+                .append(fields, that.fields)
+                .isEquals();
     }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder(17, 37)
-            .append(jooqCondition)
-            .append(fields)
-            .toHashCode();
+        return new HashCodeBuilder(17, 37)//??
+                .append(jooqCondition)
+                .append(lambdaCondition)
+                .append(fields)
+                .toHashCode();
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-            .append("jooqCondition", jooqCondition)
-            .append("fields", fields)
-            .toString();
+                .append("jooqCondition", jooqCondition)
+                .append("lambdaCondition", lambdaCondition)
+                .append("fields", fields)
+                .toString();
     }
 }

--- a/main/src/main/java/com/kenshoo/pl/entity/PLCondition.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/PLCondition.java
@@ -16,16 +16,16 @@ import static java.util.Objects.requireNonNull;
 public class PLCondition {
 
     private final Condition jooqCondition;
-    private final Predicate<Entity> lambdaCondition;
+    private final Predicate<Entity> postFetchCondition;
     private final Set<? extends EntityField<?, ?>> fields;
 
-    public PLCondition(final Condition jooqCondition, final Predicate<Entity> lambdaCondition, final EntityField<?, ?>... fields) {
-        this(jooqCondition, lambdaCondition, ImmutableSet.copyOf(fields));
+    public PLCondition(final Condition jooqCondition, final Predicate<Entity> postFetchCondition, final EntityField<?, ?>... fields) {
+        this(jooqCondition, postFetchCondition, ImmutableSet.copyOf(fields));
     }
 
-    public PLCondition(final Condition jooqCondition, final Predicate<Entity> lambdaCondition, final Set<? extends EntityField<?, ?>> fields) {
+    public PLCondition(final Condition jooqCondition, final Predicate<Entity> postFetchCondition, final Set<? extends EntityField<?, ?>> fields) {
         this.jooqCondition = requireNonNull(jooqCondition, "a Jooq condition must be provided");
-        this.lambdaCondition = requireNonNull(lambdaCondition, "a Lambda condition must be provided");
+        this.postFetchCondition = requireNonNull(postFetchCondition, "a post fetch condition must be provided");
         this.fields = requireNonNull(fields, "Fields must not be null (can be empty)");
     }
 
@@ -34,7 +34,7 @@ public class PLCondition {
     }
 
     public Predicate<Entity> getPostFetchCondition() {
-        return lambdaCondition;
+        return postFetchCondition;
     }
 
     public Set<? extends EntityField<?, ?>> getFields() {
@@ -44,57 +44,33 @@ public class PLCondition {
     public PLCondition and(final PLCondition other) {
         requireNonNull(other, "a condition must be provided");
         return new PLCondition(jooqCondition.and(other.jooqCondition),
-                               lambdaCondition.and(other.lambdaCondition),
+                               postFetchCondition.and(other.postFetchCondition),
                                Sets.union(this.fields, other.fields));
     }
 
     public PLCondition or(final PLCondition other) {
         requireNonNull(other, "a condition must be provided");
         return new PLCondition(jooqCondition.or(other.jooqCondition),
-                               lambdaCondition.or(other.lambdaCondition),
+                               postFetchCondition.or(other.postFetchCondition),
                                Sets.union(this.fields, other.fields));
     }
 
     public static PLCondition not(final PLCondition condition) {
         requireNonNull(condition, "a condition must be provided");
         return new PLCondition(condition.jooqCondition.not(),
-                               condition.lambdaCondition.negate(),
+                               condition.postFetchCondition.negate(),
                                condition.fields);
     }
 
     public static PLCondition trueCondition() {
-        return  new PLCondition(DSL.trueCondition(),entity -> true);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-
-        if (o == null || getClass() != o.getClass()) return false;
-
-        PLCondition that = (PLCondition) o;
-
-        return new EqualsBuilder()
-                .append(jooqCondition, that.jooqCondition)
-                .append(lambdaCondition, that.lambdaCondition)
-                .append(fields, that.fields)
-                .isEquals();
-    }
-
-    @Override
-    public int hashCode() {
-        return new HashCodeBuilder(17, 37)
-                .append(jooqCondition)
-                .append(lambdaCondition)
-                .append(fields)
-                .toHashCode();
+        return new PLCondition(DSL.trueCondition(), entity -> true);
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
                 .append("jooqCondition", jooqCondition)
-                .append("lambdaCondition", lambdaCondition)
+                .append("postFetchCondition", postFetchCondition)
                 .append("fields", fields)
                 .toString();
     }

--- a/main/src/main/java/com/kenshoo/pl/entity/spi/helpers/UniquenessValidator.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/spi/helpers/UniquenessValidator.java
@@ -1,16 +1,6 @@
 package com.kenshoo.pl.entity.spi.helpers;
 
-import com.kenshoo.pl.entity.ChangeContext;
-import com.kenshoo.pl.entity.ChangeOperation;
-import com.kenshoo.pl.entity.CurrentEntityState;
-import com.kenshoo.pl.entity.EntityChange;
-import com.kenshoo.pl.entity.EntityField;
-import com.kenshoo.pl.entity.EntityType;
-import com.kenshoo.pl.entity.Identifier;
-import com.kenshoo.pl.entity.PLCondition;
-import com.kenshoo.pl.entity.SupportedChangeOperation;
-import com.kenshoo.pl.entity.UniqueKey;
-import com.kenshoo.pl.entity.ValidationError;
+import com.kenshoo.pl.entity.*;
 import com.kenshoo.pl.entity.internal.EntitiesFetcher;
 import com.kenshoo.pl.entity.spi.ChangesValidator;
 import org.apache.commons.lang3.ArrayUtils;
@@ -63,6 +53,7 @@ public class UniquenessValidator<E extends EntityType<E>> implements ChangesVali
     private Map<Identifier<E>, EntityChange<E>> markDuplicatesInCollectionWithErrors(Collection<? extends EntityChange<E>> commands, ChangeContext ctx) {
         return commands
                 .stream()
+                .filter(command -> condition.getPostFetchCondition().test(ctx.getFinalEntity(command)))
                 .collect(toMap(cmd -> createKeyValue(cmd, uniqueKey), identity(), fail2ndConflictingCommand(ctx)));
     }
 

--- a/main/src/main/java/com/kenshoo/pl/entity/spi/helpers/UniquenessValidator.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/spi/helpers/UniquenessValidator.java
@@ -41,13 +41,15 @@ public class UniquenessValidator<E extends EntityType<E>> implements ChangesVali
 
         Map<Identifier<E>, ? extends EntityChange<E>> commandsByIds = markDuplicatesInCollectionWithErrors(commands, ctx);
 
-        UniqueKey<E> pk = uniqueKey.getEntityType().getPrimaryKey();
-        EntityField<E, ?>[] uniqueKeyAndPK = ArrayUtils.addAll(uniqueKey.getFields(), pk.getFields());
+        if (!commandsByIds.isEmpty()) {
+            UniqueKey<E> pk = uniqueKey.getEntityType().getPrimaryKey();
+            EntityField<E, ?>[] uniqueKeyAndPK = ArrayUtils.addAll(uniqueKey.getFields(), pk.getFields());
 
-        Map<Identifier<E>, CurrentEntityState> duplicates = fetcher.fetch(uniqueKey.getEntityType(), commandsByIds.keySet(), condition, uniqueKeyAndPK)
-                .stream().collect(toMap(e -> createKeyValue(e, uniqueKey), identity()));
+            Map<Identifier<E>, CurrentEntityState> duplicates = fetcher.fetch(uniqueKey.getEntityType(), commandsByIds.keySet(), condition, uniqueKeyAndPK)
+                    .stream().collect(toMap(e -> createKeyValue(e, uniqueKey), identity()));
 
-        duplicates.forEach((dupKey, dupEntity) -> ctx.addValidationError(commandsByIds.get(dupKey), errorForDatabaseConflict(dupEntity, pk)));
+            duplicates.forEach((dupKey, dupEntity) -> ctx.addValidationError(commandsByIds.get(dupKey), errorForDatabaseConflict(dupEntity, pk)));
+        }
     }
 
     private Map<Identifier<E>, EntityChange<E>> markDuplicatesInCollectionWithErrors(Collection<? extends EntityChange<E>> commands, ChangeContext ctx) {

--- a/main/src/test/java/com/kenshoo/pl/entity/EntityFieldConditionsTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/EntityFieldConditionsTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import java.util.Objects;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 public class EntityFieldConditionsTest {
@@ -20,6 +21,37 @@ public class EntityFieldConditionsTest {
         final PLCondition plCondition = TestEntityType.NAME1.eq("abc");
 
         assertContainsFields(plCondition, TestEntityType.NAME1);
+    }
+
+    @Test
+    public void testFieldEqualInPostFetchCondition() {
+        final var entity = createEntityWith(TestEntityType.NAME1, "myName");
+
+        assertThat(TestEntityType.NAME1.eq("myName").getPostFetchCondition().test(entity), is(true));
+        assertThat(TestEntityType.NAME1.eq("abcd").getPostFetchCondition().test(entity), is(false));
+    }
+
+    @Test
+    public void testFieldInValuesInPostFetchCondition() {
+        final var entity = createEntityWith(TestEntityType.NAME1, "myName");
+
+        assertThat(TestEntityType.NAME1.in("abcd", "myName").getPostFetchCondition().test(entity), is(true));
+        assertThat(TestEntityType.NAME1.in("abcd", "aaaa").getPostFetchCondition().test(entity), is(false));
+    }
+
+    @Test
+    public void testFieldIsNullInPostFetchCondition() {
+        final var entityWithNullValue = createEntityWith(TestEntityType.NAME1, null);
+        final var entity = createEntityWith(TestEntityType.NAME1, "myName");
+
+        assertThat(TestEntityType.NAME1.isNull().getPostFetchCondition().test(entityWithNullValue), is(true));
+        assertThat(TestEntityType.NAME1.isNull().getPostFetchCondition().test(entity), is(false));
+    }
+
+    private FinalEntityState createEntityWith(EntityField<TestEntityType, String> field, String value) {
+        return new FinalEntityState(CurrentEntityState.EMPTY, new CreateEntityCommand<>(TestEntityType.INSTANCE) {{
+            set(field, value);
+        }});
     }
 
     @Test(expected = UnsupportedOperationException.class)

--- a/main/src/test/java/com/kenshoo/pl/entity/PLConditionTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/PLConditionTest.java
@@ -25,11 +25,11 @@ public class PLConditionTest {
     @Mock
     private Condition outputJooqCondition;
     @Mock
-    private Predicate<Entity> lambdaCondition1;
+    private Predicate<Entity> postFetchCondition1;
     @Mock
-    private Predicate<Entity> lambdaCondition2;
+    private Predicate<Entity> postFetchCondition2;
     @Mock
-    private Predicate<Entity> outputLambdaCondition;
+    private Predicate<Entity> outputPostFetchCondition;
     @Mock
     private EntityField<?, ?> entityField1;
     @Mock
@@ -44,9 +44,9 @@ public class PLConditionTest {
     public void setUp() {
         entityFields = ImmutableSet.of(entityField1, entityField2);
 
-        plCondition1 = new PLCondition(jooqCondition1, lambdaCondition1, entityField1);
-        plCondition2 = new PLCondition(jooqCondition2, lambdaCondition2, entityField2);
-        binaryPLCondition = new PLCondition(outputJooqCondition, outputLambdaCondition, entityFields);
+        plCondition1 = new PLCondition(jooqCondition1, postFetchCondition1, entityField1);
+        plCondition2 = new PLCondition(jooqCondition2, postFetchCondition2, entityField2);
+        binaryPLCondition = new PLCondition(outputJooqCondition, outputPostFetchCondition, entityFields);
     }
 
     @Test
@@ -55,38 +55,49 @@ public class PLConditionTest {
     }
 
     @Test
-    public void testGetLambdaCondition() {
-        assertThat(plCondition1.getPostFetchCondition(), equalTo(lambdaCondition1));
+    public void testGetPostFetchCondition() {
+        assertThat(plCondition1.getPostFetchCondition(), equalTo(postFetchCondition1));
     }
 
     @Test
     public void testGetFields() {
-        assertThat(new PLCondition(jooqCondition1, lambdaCondition1 ,entityFields).getFields(),
-                   equalTo(entityFields));
+        assertThat(new PLCondition(jooqCondition1, postFetchCondition1, entityFields).getFields(),
+                equalTo(entityFields));
     }
 
     @Test
     public void testAndProducesCorrectPLCondition() {
         when(jooqCondition1.and(jooqCondition2)).thenReturn(outputJooqCondition);
-        when(lambdaCondition1.and(lambdaCondition2)).thenReturn(outputLambdaCondition);
+        when(postFetchCondition1.and(postFetchCondition2)).thenReturn(outputPostFetchCondition);
 
-        assertThat(plCondition1.and(plCondition2), equalTo(binaryPLCondition));
+        final var outputPlCondition = plCondition1.and(plCondition2);
+
+        assertThat(outputPlCondition.getJooqCondition(), equalTo(binaryPLCondition.getJooqCondition()));
+        assertThat(outputPlCondition.getPostFetchCondition(), equalTo(binaryPLCondition.getPostFetchCondition()));
+        assertThat(outputPlCondition.getFields(), equalTo(binaryPLCondition.getFields()));
     }
 
     @Test
     public void testOrProducesCorrectPLCondition() {
         when(jooqCondition1.or(jooqCondition2)).thenReturn(outputJooqCondition);
-        when(lambdaCondition1.or(lambdaCondition2)).thenReturn(outputLambdaCondition);
+        when(postFetchCondition1.or(postFetchCondition2)).thenReturn(outputPostFetchCondition);
 
-        assertThat(plCondition1.or(plCondition2), equalTo(binaryPLCondition));
+        final var outputPlCondition = plCondition1.or(plCondition2);
+
+        assertThat(outputPlCondition.getJooqCondition(), equalTo(binaryPLCondition.getJooqCondition()));
+        assertThat(outputPlCondition.getPostFetchCondition(), equalTo(binaryPLCondition.getPostFetchCondition()));
+        assertThat(outputPlCondition.getFields(), equalTo(binaryPLCondition.getFields()));
     }
 
     @Test
     public void testNotProducesCorrectPLCondition() {
         when(jooqCondition1.not()).thenReturn(jooqCondition2);
-        when(lambdaCondition1.negate()).thenReturn(lambdaCondition2);
+        when(postFetchCondition1.negate()).thenReturn(postFetchCondition2);
 
-        assertThat(PLCondition.not(plCondition1),
-                equalTo(new PLCondition(jooqCondition2, lambdaCondition2, entityField1)));
+        final var outputPlCondition = PLCondition.not(plCondition1);
+
+        assertThat(outputPlCondition.getJooqCondition(), equalTo(jooqCondition2));
+        assertThat(outputPlCondition.getPostFetchCondition(), equalTo(postFetchCondition2));
+        assertThat(outputPlCondition.getFields(), equalTo(plCondition1.getFields()));
     }
 }


### PR DESCRIPTION
SEARCH-95928
The UniquenessValidator checks duplication in bulk command and DB by a unique key and condition.
the validator check the condition just in the DB entities and did not check the condition on the command entities.
This PR add a predicate condition to the PLCondition beside the jooq condition, and the UniquenessValidator use this predicate condition on the bulk commands.
@galkoren 