### PR TITLE
PL-103: Support private entity fields for Scala

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+.settings/
+.classpath
+.project
+workspace/
+*.iml
+*.ipr
+*.iws
+build/
+target/
+out/
+.gradle/
+venv/
+.idea
+.env

--- a/main/src/main/java/com/kenshoo/pl/entity/AbstractEntityType.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/AbstractEntityType.java
@@ -32,7 +32,7 @@ public abstract class AbstractEntityType<E extends EntityType<E>> implements Ent
     private Collection<EntityField<E, ?>> fields = new ArrayList<>();
     private Collection<PrototypedEntityField<E, ?>> prototypedFields = new ArrayList<>();
 
-    private final Supplier<BiMap<String, EntityField<E, ?>>> fieldNameMappingSupplier = memoize(() -> EntityTypeReflectionUtil.getFieldToNameBiMap(AbstractEntityType.this.getClass()));
+    private final Supplier<BiMap<String, EntityField<E, ?>>> fieldNameMappingSupplier = memoize(() -> EntityTypeReflectionUtil.getFieldToNameBiMap(AbstractEntityType.this));
 
     protected AbstractEntityType(String name) {
         this.name = name;

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/EntityTypeReflectionUtil.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/EntityTypeReflectionUtil.java
@@ -8,6 +8,7 @@ import com.kenshoo.pl.entity.*;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
@@ -93,7 +94,9 @@ public abstract class EntityTypeReflectionUtil {
 
     private static <E extends EntityType<E>, T> EntityField<E, T> getEntityFieldInstance(final Field field, final EntityType<E> entityType) {
         try {
-            field.setAccessible(true);
+            if (!Modifier.isPublic(field.getModifiers())) {
+                field.setAccessible(true);
+            }
             //noinspection unchecked
             return (EntityField<E, T>) field.get(entityType);
         } catch (IllegalAccessException e) {

--- a/main/src/test/java/com/kenshoo/pl/entity/EntityFieldToNameTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/EntityFieldToNameTest.java
@@ -19,6 +19,14 @@ public class EntityFieldToNameTest {
     }
 
     @Test
+    public void privateFieldToName() {
+        final var entity = TestPrivateFieldsEntity.INSTANCE;
+        String fieldName = entity.toFieldName(entity.getFIELD_1());
+
+        assertThat(fieldName, is("FIELD_1"));
+    }
+
+    @Test
     public void badInput() {
         String fieldName = TestEntity.INSTANCE.toFieldName(null);
 

--- a/main/src/test/java/com/kenshoo/pl/entity/EntityNameToFieldTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/EntityNameToFieldTest.java
@@ -18,6 +18,14 @@ public class EntityNameToFieldTest {
     }
 
     @Test
+    public void privateFieldFromName() {
+        final var entity = TestPrivateFieldsEntity.INSTANCE;
+        final var entityField = entity.getFieldByName("FIELD_1");
+
+        assertThat(entityField, is(entity.getFIELD_1()));
+    }
+
+    @Test
     public void prototypeFieldFromName() {
         EntityField<TestEntity, ?> fieldByName = TestEntity.INSTANCE.getFieldByName("FIELD_1");
 

--- a/main/src/test/java/com/kenshoo/pl/entity/TestPrivateFieldsEntity.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/TestPrivateFieldsEntity.java
@@ -1,0 +1,38 @@
+package com.kenshoo.pl.entity;
+
+import com.kenshoo.jooq.DataTable;
+import com.kenshoo.pl.entity.annotation.Id;
+
+/**
+ * An entity simulating the Scala use-case where fields are private under the hood with synthetic getters
+  */
+public class TestPrivateFieldsEntity extends AbstractEntityType<TestPrivateFieldsEntity> {
+
+    public static final TestPrivateFieldsEntity INSTANCE = new TestPrivateFieldsEntity();
+
+    @Id
+    private final EntityField<TestPrivateFieldsEntity, Integer> ID = field(TestEntityTable.TABLE.id);
+    private final EntityField<TestPrivateFieldsEntity, String> FIELD_1 = field(TestEntityTable.TABLE.field_1);
+    private final EntityField<TestPrivateFieldsEntity, String> SECONDARY_FIELD_1 = field(SecondaryTable.TABLE.secondary_field_1);
+
+    private TestPrivateFieldsEntity() {
+        super("test");
+    }
+
+    public EntityField<TestPrivateFieldsEntity, Integer> getID() {
+        return ID;
+    }
+
+    public EntityField<TestPrivateFieldsEntity, String> getFIELD_1() {
+        return FIELD_1;
+    }
+
+    public EntityField<TestPrivateFieldsEntity, String> getSECONDARY_FIELD_1() {
+        return SECONDARY_FIELD_1;
+    }
+
+    @Override
+    public DataTable getPrimaryTable() {
+        return TestEntityTable.TABLE;
+    }
+}

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/EntityTypeReflectionUtilTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/EntityTypeReflectionUtilTest.java
@@ -1,0 +1,19 @@
+package com.kenshoo.pl.entity.internal;
+
+import com.kenshoo.pl.entity.TestPrivateFieldsEntity;
+import com.kenshoo.pl.entity.annotation.Id;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+public class EntityTypeReflectionUtilTest {
+
+    @Test
+    public void getFieldAnnotationOfPrivateFieldReturnsNonNull() {
+        final var entity = TestPrivateFieldsEntity.INSTANCE;
+        final var actualAnnotation = EntityTypeReflectionUtil.getFieldAnnotation(entity, entity.getID(), Id.class);
+
+        assertThat(actualAnnotation, notNullValue());
+    }
+}


### PR DESCRIPTION
PL uses reflection to resolve annotations on the entity fields, and also to give names to the entity fields for logging (plus another usage for fetching partial entities which is less important and may be deprecated soon).
This reflection uses  `getField(...)` and `field.get(null)`  which together assume that the fields are `public static`. This sets a requirement for how the fields must be defined, and it makes sense since the `EntityType` should be a singleton.

However Scala does not have an explicit `public` **nor** `static` for fields. Instead:
1) Fields are defined as `val` (by the best practice) which makes them immutable, and they are also `public` by default. However under the hood they are compiled as `private final` Java members and the `public` getters are generated synthetically.
2) Scala does not use `static`. The equivalent is a member inside a singleton, and this can be achieved either by placing it inside an `object` or using a private constructor like Java.

Due to the above, PL `EntityType`-s cannot be defined in Scala with the current reflection logic.
After thinking about this, my conclusion is that the simplest solution is to relax the requirement of `public static` for the fields and support `private` and non-`static` as well by using the `getDeclaredField(...)` reflection method.
The drawbacks as far as I see are:
1) PL no longer enforces a singleton `EntityType` in Java, since the fields could be defined as non-static and the `EntityType` instantiated multiple times. I think it's a minor risk and we can enforce it as a best practice with the Wiki and through the plugin.
2) The fields could be defined in Java as `private` with additional getters/setters that will not be scanned or recognized by the framework, and the user might try to place annotations on them which will not be recognized. Again this can be enforced with the Wiki/plugin.
3) `getField(..)` can also fetch `public` fields recursively up the hierarchy - which means we will no longer support inheritance of `EntityType`-s, but as far as I can tell nobody uses it (and I'm not sure it would work in all scenarios anyway).
