### PR TITLE
add condition fields to requiredFields

### DIFF
--- a/main/src/main/java/com/kenshoo/pl/entity/spi/helpers/UniquenessValidator.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/spi/helpers/UniquenessValidator.java
@@ -93,7 +93,8 @@ public class UniquenessValidator<E extends EntityType<E>> implements ChangesVali
 
     @Override
     public Stream<? extends EntityField<?, ?>> requiredFields(Collection<? extends EntityField<E, ?>> fieldsToUpdate, ChangeOperation op) {
-        return Stream.concat(Stream.of(uniqueKey.getFields()), Stream.of(uniqueKey.getEntityType().getPrimaryKey().getFields()));
+        return Stream.of(condition.getFields().stream(), Stream.of(uniqueKey.getFields()), Stream.of(uniqueKey.getEntityType().getPrimaryKey().getFields()))
+                .flatMap(fields -> fields);
     }
 
     public static class Builder<E extends EntityType<E>> {

--- a/main/src/main/java/com/kenshoo/pl/entity/spi/helpers/UniquenessValidator.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/spi/helpers/UniquenessValidator.java
@@ -93,8 +93,7 @@ public class UniquenessValidator<E extends EntityType<E>> implements ChangesVali
 
     @Override
     public Stream<? extends EntityField<?, ?>> requiredFields(Collection<? extends EntityField<E, ?>> fieldsToUpdate, ChangeOperation op) {
-        return Stream.of(condition.getFields().stream(), Stream.of(uniqueKey.getFields()), Stream.of(uniqueKey.getEntityType().getPrimaryKey().getFields()))
-                .flatMap(fields -> fields);
+        return Seq.concat(condition.getFields().stream(), Stream.of(uniqueKey.getFields()), Stream.of(uniqueKey.getEntityType().getPrimaryKey().getFields()));
     }
 
     public static class Builder<E extends EntityType<E>> {


### PR DESCRIPTION
SEARCH-95928
part of [this PR ](https://github.com/kenshoo/persistence-layer/pull/11) the uniquenessValidator check the condition on the bulk commands.
This PR add the condition fields to the requiredFields because when checking the condition on the bulk commands by the finalEntity these fields are necessary .
@galkoren 