### PR TITLE
PL-108: Refactor AuditRecord.entityType to be the name of the EntityType

### DIFF
--- a/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForCreateOneLevelTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForCreateOneLevelTest.java
@@ -91,7 +91,7 @@ public class AuditForCreateOneLevelTest {
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
         final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
-        assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE),
+        assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(id)),
                                       hasOperator(CREATE),
                                       hasCreatedFieldRecord(AuditedType.NAME, "name"),
@@ -142,7 +142,7 @@ public class AuditForCreateOneLevelTest {
                    auditRecords, hasSize(2));
 
         final AuditRecord<AuditedType> auditRecord1 = typed(auditRecords.get(0));
-        assertThat(auditRecord1, allOf(hasEntityType(AuditedType.INSTANCE),
+        assertThat(auditRecord1, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                        hasEntityId(String.valueOf(ids.get(0))),
                                        hasOperator(CREATE),
                                        hasCreatedFieldRecord(AuditedType.NAME, "nameA"),
@@ -150,7 +150,7 @@ public class AuditForCreateOneLevelTest {
                                        hasCreatedFieldRecord(AuditedType.DESC2, "desc2A")));
 
         final AuditRecord<AuditedType> auditRecord2 = typed(auditRecords.get(1));
-        assertThat(auditRecord2, allOf(hasEntityType(AuditedType.INSTANCE),
+        assertThat(auditRecord2, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                        hasEntityId(String.valueOf(ids.get(1))),
                                        hasOperator(CREATE),
                                        hasCreatedFieldRecord(AuditedType.NAME, "nameB"),
@@ -223,7 +223,7 @@ public class AuditForCreateOneLevelTest {
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
         final AuditRecord<InclusiveAuditedType> auditRecord = typed(auditRecords.get(0));
-        assertThat(auditRecord, allOf(hasEntityType(InclusiveAuditedType.INSTANCE),
+        assertThat(auditRecord, allOf(hasEntityType(InclusiveAuditedType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(id)),
                                       hasOperator(CREATE),
                                       hasNoFieldRecords()));
@@ -257,7 +257,7 @@ public class AuditForCreateOneLevelTest {
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
         final AuditRecord<AuditedWithoutDataFieldsType> auditRecord = typed(auditRecords.get(0));
-        assertThat(auditRecord, allOf(hasEntityType(AuditedWithoutDataFieldsType.INSTANCE),
+        assertThat(auditRecord, allOf(hasEntityType(AuditedWithoutDataFieldsType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(ID)),
                                       hasOperator(CREATE)));
     }

--- a/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForCreateTwoLevelsTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForCreateTwoLevelsTest.java
@@ -86,12 +86,12 @@ public class AuditForCreateTwoLevelsTest {
                    auditRecords, hasSize(1));
         final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
 
-        assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE),
+        assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(parentId)),
                                       hasOperator(CREATE),
                                       hasCreatedFieldRecord(AuditedType.NAME, "name")));
 
-        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE),
+        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(childId)),
                                                          hasOperator(CREATE),
                                                          hasCreatedFieldRecord(AuditedChild1Type.NAME, "childName"))));
@@ -124,11 +124,11 @@ public class AuditForCreateTwoLevelsTest {
                    auditRecords, hasSize(1));
         final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
 
-        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE),
+        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(child1AId)),
                                                          hasOperator(CREATE),
                                                          hasCreatedFieldRecord(AuditedChild1Type.NAME, "child1AName"))));
-        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE),
+        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(child1BId)),
                                                          hasOperator(CREATE),
                                                          hasCreatedFieldRecord(AuditedChild1Type.NAME, "child1BName"))));
@@ -162,11 +162,11 @@ public class AuditForCreateTwoLevelsTest {
                    auditRecords, hasSize(1));
         final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
 
-        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE),
+        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(child1Id)),
                                                          hasOperator(CREATE),
                                                          hasCreatedFieldRecord(AuditedChild1Type.NAME, "child1Name"))));
-        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild2Type.INSTANCE),
+        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild2Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(child2Id)),
                                                          hasOperator(CREATE),
                                                          hasCreatedFieldRecord(AuditedChild2Type.NAME, "child2Name"))));
@@ -199,11 +199,11 @@ public class AuditForCreateTwoLevelsTest {
                    auditRecords, hasSize(1));
         final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
 
-        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE),
+        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(auditedChildId)),
                                                          hasOperator(CREATE),
                                                          hasCreatedFieldRecord(AuditedChild1Type.NAME, "auditedChildName"))));
-        assertThat(auditRecord, not(hasChildRecordThat(hasEntityType(NotAuditedChildType.INSTANCE))));
+        assertThat(auditRecord, not(hasChildRecordThat(hasEntityType(NotAuditedChildType.INSTANCE.getName()))));
     }
 
     @Test
@@ -250,11 +250,11 @@ public class AuditForCreateTwoLevelsTest {
                    auditRecords, hasSize(1));
         final AuditRecord<AuditedWithoutDataFieldsType> auditRecord = typed(auditRecords.get(0));
 
-        assertThat(auditRecord, allOf(hasEntityType(AuditedWithoutDataFieldsType.INSTANCE),
+        assertThat(auditRecord, allOf(hasEntityType(AuditedWithoutDataFieldsType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(parentId)),
                                       hasOperator(CREATE)));
 
-        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE),
+        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(childId)),
                                                          hasOperator(CREATE),
                                                          hasCreatedFieldRecord(AuditedChild1Type.NAME, "childName"))));
@@ -292,11 +292,11 @@ public class AuditForCreateTwoLevelsTest {
         final AuditRecord<AuditedType> auditRecord1 = typed(auditRecords.get(0));
         final AuditRecord<AuditedType> auditRecord2 = typed(auditRecords.get(1));
 
-        assertThat(auditRecord1, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE),
+        assertThat(auditRecord1, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                           hasEntityId(String.valueOf(child1Id)),
                                                           hasOperator(CREATE),
                                                           hasCreatedFieldRecord(AuditedChild1Type.NAME, "child1Name"))));
-        assertThat(auditRecord2, hasChildRecordThat(allOf(hasEntityType(AuditedChild2Type.INSTANCE),
+        assertThat(auditRecord2, hasChildRecordThat(allOf(hasEntityType(AuditedChild2Type.INSTANCE.getName()),
                                                           hasEntityId(String.valueOf(child2Id)),
                                                           hasOperator(CREATE),
                                                           hasCreatedFieldRecord(AuditedChild2Type.NAME, "child2Name"))));

--- a/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForDeleteOneLevelTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForDeleteOneLevelTest.java
@@ -90,7 +90,7 @@ public class AuditForDeleteOneLevelTest {
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
         final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
-        assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE),
+        assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(ID_1)),
                                       hasOperator(DELETE)));
     }
@@ -119,12 +119,12 @@ public class AuditForDeleteOneLevelTest {
                    auditRecords, hasSize(2));
 
         final AuditRecord<AuditedType> auditRecord1 = typed(auditRecords.get(0));
-        assertThat(auditRecord1, allOf(hasEntityType(AuditedType.INSTANCE),
+        assertThat(auditRecord1, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                        hasEntityId(String.valueOf(ID_1)),
                                        hasOperator(DELETE)));
 
         final AuditRecord<AuditedType> auditRecord2 = typed(auditRecords.get(1));
-        assertThat(auditRecord2, allOf(hasEntityType(AuditedType.INSTANCE),
+        assertThat(auditRecord2, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                        hasEntityId(String.valueOf(ID_2)),
                                        hasOperator(DELETE)));
     }
@@ -143,7 +143,7 @@ public class AuditForDeleteOneLevelTest {
                    auditRecords, hasSize(1));
 
         final AuditRecord<AuditedType> auditRecord1 = typed(auditRecords.get(0));
-        assertThat(auditRecord1, allOf(hasEntityType(AuditedType.INSTANCE),
+        assertThat(auditRecord1, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                        hasEntityId(String.valueOf(ID_1)),
                                        hasOperator(DELETE)));
     }
@@ -158,7 +158,7 @@ public class AuditForDeleteOneLevelTest {
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
         final AuditRecord<AuditedWithoutDataFieldsType> auditRecord = typed(auditRecords.get(0));
-        assertThat(auditRecord, allOf(hasEntityType(AuditedWithoutDataFieldsType.INSTANCE),
+        assertThat(auditRecord, allOf(hasEntityType(AuditedWithoutDataFieldsType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(ID_1)),
                                       hasOperator(DELETE)));
     }

--- a/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForDeleteTwoLevelsTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForDeleteTwoLevelsTest.java
@@ -99,10 +99,10 @@ public class AuditForDeleteTwoLevelsTest {
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
         final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
-        assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE),
+        assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(PARENT_ID_1)),
                                       hasOperator(DELETE)));
-        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE),
+        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(CHILD_ID_11)),
                                                          hasOperator(DELETE))));
     }
@@ -127,10 +127,10 @@ public class AuditForDeleteTwoLevelsTest {
                    auditRecords, hasSize(1));
         final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
 
-        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE),
+        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(CHILD_ID_11)),
                                                          hasOperator(DELETE))));
-        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE),
+        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(CHILD_ID_12)),
                                                          hasOperator(DELETE))));
     }
@@ -155,10 +155,10 @@ public class AuditForDeleteTwoLevelsTest {
                    auditRecords, hasSize(1));
         final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
 
-        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE),
+        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(CHILD_ID_11)),
                                                          hasOperator(DELETE))));
-        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild2Type.INSTANCE),
+        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild2Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(CHILD_ID_12)),
                                                          hasOperator(DELETE))));
     }
@@ -183,10 +183,10 @@ public class AuditForDeleteTwoLevelsTest {
                    auditRecords, hasSize(1));
         final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
 
-        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE),
+        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(CHILD_ID_11)),
                                                          hasOperator(DELETE))));
-        assertThat(auditRecord, not(hasChildRecordThat(hasEntityType(NotAuditedChildType.INSTANCE))));
+        assertThat(auditRecord, not(hasChildRecordThat(hasEntityType(NotAuditedChildType.INSTANCE.getName()))));
     }
 
     @Test
@@ -208,10 +208,10 @@ public class AuditForDeleteTwoLevelsTest {
                    auditRecords, hasSize(1));
         final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
 
-        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE),
+        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(CHILD_ID_11)),
                                                          hasOperator(DELETE))));
-        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE),
+        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(CHILD_ID_12)),
                                                          hasOperator(DELETE))));
     }
@@ -270,10 +270,10 @@ public class AuditForDeleteTwoLevelsTest {
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
         final AuditRecord<AuditedWithoutDataFieldsType> auditRecord = typed(auditRecords.get(0));
-        assertThat(auditRecord, allOf(hasEntityType(AuditedWithoutDataFieldsType.INSTANCE),
+        assertThat(auditRecord, allOf(hasEntityType(AuditedWithoutDataFieldsType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(PARENT_ID_1)),
                                       hasOperator(DELETE)));
-        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE),
+        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(CHILD_ID_11)),
                                                          hasOperator(DELETE))));
     }
@@ -300,12 +300,12 @@ public class AuditForDeleteTwoLevelsTest {
                    auditRecords, hasSize(2));
 
         final AuditRecord<AuditedType> auditRecord1 = typed(auditRecords.get(0));
-        assertThat(auditRecord1, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE),
+        assertThat(auditRecord1, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                           hasEntityId(String.valueOf(CHILD_ID_11)),
                                                           hasOperator(DELETE))));
 
         final AuditRecord<AuditedType> auditRecord2 = typed(auditRecords.get(1));
-        assertThat(auditRecord2, hasChildRecordThat(allOf(hasEntityType(AuditedChild2Type.INSTANCE),
+        assertThat(auditRecord2, hasChildRecordThat(allOf(hasEntityType(AuditedChild2Type.INSTANCE.getName()),
                                                           hasEntityId(String.valueOf(CHILD_ID_21)),
                                                           hasOperator(DELETE))));
     }

--- a/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForUpdateOneLevelTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForUpdateOneLevelTest.java
@@ -103,7 +103,7 @@ public class AuditForUpdateOneLevelTest {
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
         final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
-        assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE),
+        assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(ID_1)),
                                       hasOperator(UPDATE),
                                       hasChangedFieldRecord(AuditedType.NAME, "nameA", "newNameA"),
@@ -124,7 +124,7 @@ public class AuditForUpdateOneLevelTest {
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
         final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
-        assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE),
+        assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(ID_1)),
                                       hasOperator(UPDATE),
                                       hasChangedFieldRecord(AuditedType.NAME, "nameA", "newNameA"),
@@ -157,7 +157,7 @@ public class AuditForUpdateOneLevelTest {
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
         final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
-        assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE),
+        assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(ID_1)),
                                       hasOperator(UPDATE),
                                       hasChangedFieldRecord(AuditedType.NAME, "nameA", "newNameA"),
@@ -195,7 +195,7 @@ public class AuditForUpdateOneLevelTest {
                    auditRecords, hasSize(2));
 
         final AuditRecord<AuditedType> auditRecord1 = typed(auditRecords.get(0));
-        assertThat(auditRecord1, allOf(hasEntityType(AuditedType.INSTANCE),
+        assertThat(auditRecord1, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                        hasEntityId(String.valueOf(ID_1)),
                                        hasOperator(UPDATE),
                                        hasChangedFieldRecord(AuditedType.NAME, "nameA", "newNameA"),
@@ -203,7 +203,7 @@ public class AuditForUpdateOneLevelTest {
                                        hasChangedFieldRecord(AuditedType.DESC2, "desc2A", "newDesc2A")));
 
         final AuditRecord<AuditedType> auditRecord2 = typed(auditRecords.get(1));
-        assertThat(auditRecord2, allOf(hasEntityType(AuditedType.INSTANCE),
+        assertThat(auditRecord2, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                        hasEntityId(String.valueOf(ID_2)),
                                        hasOperator(UPDATE),
                                        hasChangedFieldRecord(AuditedType.NAME, "nameB", "newNameB"),
@@ -227,7 +227,7 @@ public class AuditForUpdateOneLevelTest {
                    auditRecords, hasSize(1));
 
         final AuditRecord<AuditedType> auditRecord1 = typed(auditRecords.get(0));
-        assertThat(auditRecord1, allOf(hasEntityType(AuditedType.INSTANCE),
+        assertThat(auditRecord1, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                        hasEntityId(String.valueOf(ID_1)),
                                        hasOperator(UPDATE)));
     }
@@ -245,7 +245,7 @@ public class AuditForUpdateOneLevelTest {
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
         final AuditRecord<InclusiveAuditedType> auditRecord = typed(auditRecords.get(0));
-        assertThat(auditRecord, allOf(hasEntityType(InclusiveAuditedType.INSTANCE),
+        assertThat(auditRecord, allOf(hasEntityType(InclusiveAuditedType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(ID_1)),
                                       hasOperator(UPDATE),
                                       hasChangedFieldRecord(InclusiveAuditedType.NAME, "nameA", "newNameA"),
@@ -264,7 +264,7 @@ public class AuditForUpdateOneLevelTest {
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
         final AuditRecord<InclusiveAuditedType> auditRecord = typed(auditRecords.get(0));
-        assertThat(auditRecord, allOf(hasEntityType(InclusiveAuditedType.INSTANCE),
+        assertThat(auditRecord, allOf(hasEntityType(InclusiveAuditedType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(ID_1)),
                                       hasOperator(UPDATE),
                                       not(hasFieldRecordFor(InclusiveAuditedType.NAME)),

--- a/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForUpdateTwoLevelsTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForUpdateTwoLevelsTest.java
@@ -117,11 +117,11 @@ public class AuditForUpdateTwoLevelsTest {
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
         final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
-        assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE),
+        assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(PARENT_ID_1)),
                                       hasOperator(UPDATE),
                                       hasChangedFieldRecord(AuditedType.NAME, PARENT_NAME_1, NEW_PARENT_NAME_1)));
-        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE),
+        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(CHILD_ID_11)),
                                                          hasOperator(UPDATE),
                                                          hasChangedFieldRecord(AuditedChild1Type.NAME,
@@ -156,13 +156,13 @@ public class AuditForUpdateTwoLevelsTest {
                    auditRecords, hasSize(1));
         final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
 
-        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE),
+        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(CHILD_ID_11)),
                                                          hasOperator(UPDATE),
                                                          hasChangedFieldRecord(AuditedChild1Type.NAME,
                                                                                CHILD_NAME_11,
                                                                                NEW_CHILD_NAME_11))));
-        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE),
+        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(CHILD_ID_12)),
                                                          hasOperator(UPDATE),
                                                          hasChangedFieldRecord(AuditedChild1Type.NAME,
@@ -198,13 +198,13 @@ public class AuditForUpdateTwoLevelsTest {
                    auditRecords, hasSize(1));
         final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
 
-        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE),
+        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(CHILD_ID_11)),
                                                          hasOperator(UPDATE),
                                                          hasChangedFieldRecord(AuditedChild1Type.NAME,
                                                                                CHILD_NAME_11,
                                                                                NEW_CHILD_NAME_11))));
-        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild2Type.INSTANCE),
+        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild2Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(CHILD_ID_12)),
                                                          hasOperator(UPDATE),
                                                          hasChangedFieldRecord(AuditedChild2Type.NAME,
@@ -240,10 +240,10 @@ public class AuditForUpdateTwoLevelsTest {
                    auditRecords, hasSize(1));
         final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
 
-        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE),
+        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(CHILD_ID_11)),
                                                          hasOperator(UPDATE))));
-        assertThat(auditRecord, not(hasChildRecordThat(hasEntityType(NotAuditedChildType.INSTANCE))));
+        assertThat(auditRecord, not(hasChildRecordThat(hasEntityType(NotAuditedChildType.INSTANCE.getName()))));
     }
 
     @Test
@@ -269,7 +269,7 @@ public class AuditForUpdateTwoLevelsTest {
                    auditRecords, hasSize(1));
         final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
 
-        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE),
+        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(CHILD_ID_12)),
                                                          hasOperator(DELETE))));
     }
@@ -341,10 +341,10 @@ public class AuditForUpdateTwoLevelsTest {
                    auditRecords, hasSize(1));
         final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
 
-        assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE),
+        assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(PARENT_ID_1)),
                                       hasOperator(UPDATE),
-                                      not(hasChildRecordThat(hasEntityType(NotAuditedChildType.INSTANCE)))));
+                                      not(hasChildRecordThat(hasEntityType(NotAuditedChildType.INSTANCE.getName())))));
     }
 
     @Test
@@ -369,10 +369,10 @@ public class AuditForUpdateTwoLevelsTest {
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
         final AuditRecord<AuditedWithoutDataFieldsType> auditRecord = typed(auditRecords.get(0));
-        assertThat(auditRecord, allOf(hasEntityType(AuditedWithoutDataFieldsType.INSTANCE),
+        assertThat(auditRecord, allOf(hasEntityType(AuditedWithoutDataFieldsType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(PARENT_ID_1)),
                                       hasOperator(UPDATE)));
-        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE),
+        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(CHILD_ID_11)),
                                                          hasOperator(UPDATE))));
     }
@@ -400,10 +400,10 @@ public class AuditForUpdateTwoLevelsTest {
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
         final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
-        assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE),
+        assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(PARENT_ID_1)),
                                       hasOperator(UPDATE)));
-        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE),
+        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(CHILD_ID_11)),
                                                          hasOperator(UPDATE))));
     }
@@ -431,10 +431,10 @@ public class AuditForUpdateTwoLevelsTest {
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
         final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
-        assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE),
+        assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(PARENT_ID_1)),
                                       hasOperator(UPDATE),
-                                      not(hasChildRecordThat(hasEntityType(AuditedChild1Type.INSTANCE)))));
+                                      not(hasChildRecordThat(hasEntityType(AuditedChild1Type.INSTANCE.getName())))));
     }
 
     @Test
@@ -468,12 +468,12 @@ public class AuditForUpdateTwoLevelsTest {
                    auditRecords, hasSize(2));
 
         final AuditRecord<AuditedType> auditRecord1 = typed(auditRecords.get(0));
-        assertThat(auditRecord1, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE),
+        assertThat(auditRecord1, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                           hasEntityId(String.valueOf(CHILD_ID_11)),
                                                           hasOperator(UPDATE))));
 
         final AuditRecord<AuditedType> auditRecord2 = typed(auditRecords.get(1));
-        assertThat(auditRecord2, hasChildRecordThat(allOf(hasEntityType(AuditedChild2Type.INSTANCE),
+        assertThat(auditRecord2, hasChildRecordThat(allOf(hasEntityType(AuditedChild2Type.INSTANCE.getName()),
                                                           hasEntityId(String.valueOf(CHILD_ID_21)),
                                                           hasOperator(UPDATE))));
     }

--- a/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForUpsertOneLevelTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForUpsertOneLevelTest.java
@@ -97,7 +97,7 @@ public class AuditForUpsertOneLevelTest {
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
         final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
-        assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE),
+        assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(fetchIdByName(NEW_NAME_1))),
                                       hasOperator(CREATE),
                                       hasCreatedFieldRecord(AuditedType.NAME, NEW_NAME_1),
@@ -117,7 +117,7 @@ public class AuditForUpsertOneLevelTest {
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
         final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
-        assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE),
+        assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(EXISTING_ID_1)),
                                       hasOperator(UPDATE),
                                       not(hasFieldRecordFor(AuditedType.NAME)),
@@ -155,7 +155,7 @@ public class AuditForUpsertOneLevelTest {
                    auditRecords, hasSize(2));
 
         final AuditRecord<AuditedType> auditRecord1 = typed(auditRecords.get(0));
-        assertThat(auditRecord1, allOf(hasEntityType(AuditedType.INSTANCE),
+        assertThat(auditRecord1, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                        hasEntityId(String.valueOf(fetchIdByName(NEW_NAME_1))),
                                        hasOperator(CREATE),
                                        hasCreatedFieldRecord(AuditedType.NAME, NEW_NAME_1),
@@ -163,7 +163,7 @@ public class AuditForUpsertOneLevelTest {
                                        hasCreatedFieldRecord(AuditedType.DESC2, "newDesc2A")));
 
         final AuditRecord<AuditedType> auditRecord2 = typed(auditRecords.get(1));
-        assertThat(auditRecord2, allOf(hasEntityType(AuditedType.INSTANCE),
+        assertThat(auditRecord2, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                        hasEntityId(String.valueOf(fetchIdByName(NEW_NAME_2))),
                                        hasOperator(CREATE),
                                        hasCreatedFieldRecord(AuditedType.NAME, NEW_NAME_2),
@@ -189,7 +189,7 @@ public class AuditForUpsertOneLevelTest {
                    auditRecords, hasSize(2));
 
         final AuditRecord<AuditedType> auditRecord1 = typed(auditRecords.get(0));
-        assertThat(auditRecord1, allOf(hasEntityType(AuditedType.INSTANCE),
+        assertThat(auditRecord1, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                        hasEntityId(String.valueOf(EXISTING_ID_1)),
                                        hasOperator(UPDATE),
                                        not(hasFieldRecordFor(AuditedType.NAME)),
@@ -197,7 +197,7 @@ public class AuditForUpsertOneLevelTest {
                                        hasChangedFieldRecord(AuditedType.DESC2, "desc2A", "newDesc2A")));
 
         final AuditRecord<AuditedType> auditRecord2 = typed(auditRecords.get(1));
-        assertThat(auditRecord2, allOf(hasEntityType(AuditedType.INSTANCE),
+        assertThat(auditRecord2, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                        hasEntityId(String.valueOf(EXISTING_ID_2)),
                                        hasOperator(UPDATE),
                                        not(hasFieldRecordFor(AuditedType.NAME)),
@@ -223,7 +223,7 @@ public class AuditForUpsertOneLevelTest {
                    auditRecords, hasSize(2));
 
         final AuditRecord<AuditedType> auditRecord1 = typed(auditRecords.get(0));
-        assertThat(auditRecord1, allOf(hasEntityType(AuditedType.INSTANCE),
+        assertThat(auditRecord1, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                        hasEntityId(String.valueOf(fetchIdByName(NEW_NAME_1))),
                                        hasOperator(CREATE),
                                        hasCreatedFieldRecord(AuditedType.NAME, NEW_NAME_1),
@@ -231,7 +231,7 @@ public class AuditForUpsertOneLevelTest {
                                        hasCreatedFieldRecord(AuditedType.DESC2, "newDesc2A")));
 
         final AuditRecord<AuditedType> auditRecord2 = typed(auditRecords.get(1));
-        assertThat(auditRecord2, allOf(hasEntityType(AuditedType.INSTANCE),
+        assertThat(auditRecord2, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                        hasEntityId(String.valueOf(EXISTING_ID_2)),
                                        hasOperator(UPDATE),
                                        not(hasFieldRecordFor(AuditedType.NAME)),

--- a/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForUpsertTwoLevelsTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForUpsertTwoLevelsTest.java
@@ -128,12 +128,12 @@ public class AuditForUpsertTwoLevelsTest {
                    auditRecords, hasSize(1));
         final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
 
-        assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE),
+        assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(parentId)),
                                       hasOperator(CREATE),
                                       hasCreatedFieldRecord(AuditedType.NAME, NEW_PARENT_NAME_1)));
 
-        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE),
+        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(childId)),
                                                          hasOperator(CREATE),
                                                          hasCreatedFieldRecord(AuditedChild1Type.NAME, NEW_CHILD_NAME_11))));
@@ -161,11 +161,11 @@ public class AuditForUpsertTwoLevelsTest {
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
         final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
-        assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE),
+        assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(PARENT_ID_1)),
                                       hasOperator(UPDATE),
                                       hasChangedFieldRecord(AuditedType.DESC, PARENT_DESC_1, NEW_PARENT_DESC_1)));
-        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE),
+        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(CHILD_ID_11)),
                                                          hasOperator(UPDATE),
                                                          hasChangedFieldRecord(AuditedChild1Type.DESC,
@@ -197,11 +197,11 @@ public class AuditForUpsertTwoLevelsTest {
                    auditRecords, hasSize(1));
         final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
 
-        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE),
+        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(child11Id)),
                                                          hasOperator(CREATE),
                                                          hasCreatedFieldRecord(AuditedChild1Type.NAME, NEW_CHILD_NAME_11))));
-        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE),
+        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(child12Id)),
                                                          hasOperator(CREATE),
                                                          hasCreatedFieldRecord(AuditedChild1Type.NAME, NEW_CHILD_NAME_12))));
@@ -234,13 +234,13 @@ public class AuditForUpsertTwoLevelsTest {
                    auditRecords, hasSize(1));
         final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
 
-        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE),
+        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(CHILD_ID_11)),
                                                          hasOperator(UPDATE),
                                                          hasChangedFieldRecord(AuditedChild1Type.DESC,
                                                                                CHILD_DESC_11,
                                                                                NEW_CHILD_DESC_11))));
-        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE),
+        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(CHILD_ID_12)),
                                                          hasOperator(UPDATE),
                                                          hasChangedFieldRecord(AuditedChild1Type.DESC,
@@ -277,12 +277,12 @@ public class AuditForUpsertTwoLevelsTest {
                    auditRecords, hasSize(1));
         final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
 
-        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE),
+        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(newChildId)),
                                                          hasOperator(CREATE),
                                                          hasCreatedFieldRecord(AuditedChild1Type.DESC,
                                                                                NEW_CHILD_DESC_11))));
-        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE),
+        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(CHILD_ID_12)),
                                                          hasOperator(UPDATE),
                                                          hasChangedFieldRecord(AuditedChild1Type.DESC,
@@ -314,11 +314,11 @@ public class AuditForUpsertTwoLevelsTest {
                    auditRecords, hasSize(1));
         final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
 
-        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE),
+        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(auditedChildId)),
                                                          hasOperator(CREATE),
                                                          hasCreatedFieldRecord(AuditedChild1Type.NAME, NEW_CHILD_NAME_11))));
-        assertThat(auditRecord, not(hasChildRecordThat(hasEntityType(NotAuditedChildType.INSTANCE))));
+        assertThat(auditRecord, not(hasChildRecordThat(hasEntityType(NotAuditedChildType.INSTANCE.getName()))));
     }
 
     @Test
@@ -349,10 +349,10 @@ public class AuditForUpsertTwoLevelsTest {
                    auditRecords, hasSize(1));
         final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
 
-        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE),
+        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(CHILD_ID_11)),
                                                          hasOperator(UPDATE))));
-        assertThat(auditRecord, not(hasChildRecordThat(hasEntityType(NotAuditedChildType.INSTANCE))));
+        assertThat(auditRecord, not(hasChildRecordThat(hasEntityType(NotAuditedChildType.INSTANCE.getName()))));
     }
 
     @Test
@@ -378,7 +378,7 @@ public class AuditForUpsertTwoLevelsTest {
                    auditRecords, hasSize(1));
         final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
 
-        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE),
+        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(CHILD_ID_12)),
                                                          hasOperator(DELETE))));
     }
@@ -407,12 +407,12 @@ public class AuditForUpsertTwoLevelsTest {
                    auditRecords, hasSize(1));
         final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
 
-        assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE),
+        assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(PARENT_ID_1)),
                                       hasOperator(UPDATE),
                                       hasChangedFieldRecord(AuditedType.DESC, PARENT_DESC_1, NEW_PARENT_DESC_1)));
 
-        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE),
+        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(childId)),
                                                          hasOperator(CREATE),
                                                          hasCreatedFieldRecord(AuditedChild1Type.NAME, NEW_CHILD_NAME_11))));
@@ -481,10 +481,10 @@ public class AuditForUpsertTwoLevelsTest {
                    auditRecords, hasSize(1));
         final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
 
-        assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE),
+        assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(PARENT_ID_1)),
                                       hasOperator(UPDATE),
-                                      not(hasChildRecordThat(hasEntityType(NotAuditedChildType.INSTANCE)))));
+                                      not(hasChildRecordThat(hasEntityType(NotAuditedChildType.INSTANCE.getName())))));
     }
 
     @Test
@@ -510,10 +510,10 @@ public class AuditForUpsertTwoLevelsTest {
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
         final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
-        assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE),
+        assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(PARENT_ID_1)),
                                       hasOperator(UPDATE)));
-        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE),
+        assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(CHILD_ID_11)),
                                                          hasOperator(UPDATE))));
     }
@@ -541,10 +541,10 @@ public class AuditForUpsertTwoLevelsTest {
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
         final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
-        assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE),
+        assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(PARENT_ID_1)),
                                       hasOperator(UPDATE),
-                                      not(hasChildRecordThat(hasEntityType(AuditedChild1Type.INSTANCE)))));
+                                      not(hasChildRecordThat(hasEntityType(AuditedChild1Type.INSTANCE.getName())))));
     }
 
     @Test
@@ -575,11 +575,11 @@ public class AuditForUpsertTwoLevelsTest {
         final AuditRecord<AuditedType> auditRecord1 = typed(auditRecords.get(0));
         final AuditRecord<AuditedType> auditRecord2 = typed(auditRecords.get(1));
 
-        assertThat(auditRecord1, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE),
+        assertThat(auditRecord1, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                           hasEntityId(String.valueOf(child1Id)),
                                                           hasOperator(CREATE),
                                                           hasCreatedFieldRecord(AuditedChild1Type.NAME, NEW_CHILD_NAME_11))));
-        assertThat(auditRecord2, hasChildRecordThat(allOf(hasEntityType(AuditedChild2Type.INSTANCE),
+        assertThat(auditRecord2, hasChildRecordThat(allOf(hasEntityType(AuditedChild2Type.INSTANCE.getName()),
                                                           hasEntityId(String.valueOf(child2Id)),
                                                           hasOperator(CREATE),
                                                           hasCreatedFieldRecord(AuditedChild2Type.NAME, NEW_CHILD_NAME_21))));
@@ -616,12 +616,12 @@ public class AuditForUpsertTwoLevelsTest {
                    auditRecords, hasSize(2));
 
         final AuditRecord<AuditedType> auditRecord1 = typed(auditRecords.get(0));
-        assertThat(auditRecord1, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE),
+        assertThat(auditRecord1, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                           hasEntityId(String.valueOf(CHILD_ID_11)),
                                                           hasOperator(UPDATE))));
 
         final AuditRecord<AuditedType> auditRecord2 = typed(auditRecords.get(1));
-        assertThat(auditRecord2, hasChildRecordThat(allOf(hasEntityType(AuditedChild2Type.INSTANCE),
+        assertThat(auditRecord2, hasChildRecordThat(allOf(hasEntityType(AuditedChild2Type.INSTANCE.getName()),
                                                           hasEntityId(String.valueOf(CHILD_ID_21)),
                                                           hasOperator(UPDATE))));
     }

--- a/main/src/main/java/com/kenshoo/pl/entity/audit/AuditRecord.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/audit/AuditRecord.java
@@ -14,14 +14,14 @@ import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
 public class AuditRecord<E extends EntityType<E>> {
-    private final E entityType;
+    private final String entityType;
     private final String entityId;
     private final Collection<? extends EntityFieldValue> mandatoryFieldValues;
     private final ChangeOperation operator;
     private final Collection<? extends FieldAuditRecord<E>> fieldRecords;
     private final Collection<? extends AuditRecord<?>> childRecords;
 
-    private AuditRecord(final E entityType,
+    private AuditRecord(final String entityType,
                         final String entityId,
                         final Collection<? extends EntityFieldValue> mandatoryFieldValues,
                         final ChangeOperation operator,
@@ -35,7 +35,7 @@ public class AuditRecord<E extends EntityType<E>> {
         this.childRecords = childRecords;
     }
 
-    public E getEntityType() {
+    public String getEntityType() {
         return entityType;
     }
 
@@ -81,7 +81,7 @@ public class AuditRecord<E extends EntityType<E>> {
             return StringUtils.EMPTY;
         }
         return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
-            .append("entityType", entityType.getName())
+            .append("entityType", entityType)
             .append("entityId", entityId)
             .append("mandatoryFieldValues", mandatoryFieldValues)
             .append("operator", operator)
@@ -98,14 +98,14 @@ public class AuditRecord<E extends EntityType<E>> {
     }
 
     public static class Builder<E extends EntityType<E>> {
-        private E entityType;
+        private String entityType;
         private String entityId;
         private Collection<? extends EntityFieldValue> mandatoryFieldValues = emptyList();
         private ChangeOperation operator;
         private Collection<? extends FieldAuditRecord<E>> fieldRecords = emptyList();
         private Collection<? extends AuditRecord<?>> childRecords = emptyList();
 
-        public Builder<E> withEntityType(E entityType) {
+        public Builder<E> withEntityType(String entityType) {
             this.entityType = entityType;
             return this;
         }

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorImpl.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorImpl.java
@@ -65,7 +65,7 @@ public class AuditRecordGeneratorImpl<E extends EntityType<E>> implements AuditR
         final Collection<FieldAuditRecord<E>> fieldRecords = fieldChangesGenerator.generate(currentState, finalState);
 
         return new AuditRecord.Builder<E>()
-            .withEntityType(entityChange.getEntityType())
+            .withEntityType(entityChange.getEntityType().getName())
             .withEntityId(entityId)
             .withMandatoryFieldValues(mandatoryFieldValues)
             .withOperator(entityChange.getChangeOperation())

--- a/main/src/test/java/com/kenshoo/pl/entity/AuditRecordTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/AuditRecordTest.java
@@ -15,6 +15,8 @@ import static org.junit.Assert.assertThat;
 
 public class AuditRecordTest {
 
+    private static final String ENTITY_TYPE = "Audited";
+
     private static final String ENTITY_ID_1 = "123";
     private static final String ENTITY_ID_2 = "456";
 
@@ -30,7 +32,7 @@ public class AuditRecordTest {
     public void hasNoChanges_WithFieldRecords_WithChildRecords_ShouldReturnFalse() {
         final AuditRecord<AuditedType> auditRecord =
             new AuditRecord.Builder<AuditedType>()
-                .withEntityType(AuditedType.INSTANCE)
+                .withEntityType(ENTITY_TYPE)
                 .withEntityId(ENTITY_ID_1)
                 .withOperator(CREATE)
                 .withFieldRecords(singleton(NAME_FIELD_RECORD))
@@ -44,7 +46,7 @@ public class AuditRecordTest {
     public void hasNoChanges_WithFieldRecords_WithoutChildRecords_ShouldReturnFalse() {
         final AuditRecord<AuditedType> auditRecord =
             new AuditRecord.Builder<AuditedType>()
-                .withEntityType(AuditedType.INSTANCE)
+                .withEntityType(ENTITY_TYPE)
                 .withEntityId(ENTITY_ID_1)
                 .withOperator(CREATE)
                 .withFieldRecords(singleton(NAME_FIELD_RECORD))
@@ -57,7 +59,7 @@ public class AuditRecordTest {
     public void hasNoChanges_WithoutFieldRecords_WithChildRecords_ShouldReturnFalse() {
         final AuditRecord<AuditedType> auditRecord =
             new AuditRecord.Builder<AuditedType>()
-                .withEntityType(AuditedType.INSTANCE)
+                .withEntityType(ENTITY_TYPE)
                 .withEntityId(ENTITY_ID_1)
                 .withOperator(CREATE)
                 .withChildRecords(singleton(childRecord))
@@ -70,7 +72,7 @@ public class AuditRecordTest {
     public void hasNoChanges_WithoutFieldRecords_WithoutChildRecords_ShouldReturnTrue() {
         final AuditRecord<AuditedType> auditRecord =
             new AuditRecord.Builder<AuditedType>()
-                .withEntityType(AuditedType.INSTANCE)
+                .withEntityType(ENTITY_TYPE)
                 .withEntityId(ENTITY_ID_1)
                 .withOperator(CREATE)
                 .build();
@@ -82,7 +84,7 @@ public class AuditRecordTest {
     public void testToString_UnlimitedDepth_OneLevel() {
         final String auditRecordStr =
             new AuditRecord.Builder<AuditedType>()
-                .withEntityType(AuditedType.INSTANCE)
+                .withEntityType(ENTITY_TYPE)
                 .withEntityId(ENTITY_ID_1)
                 .withOperator(CREATE)
                 .build()
@@ -96,11 +98,11 @@ public class AuditRecordTest {
     public void testToString_UnlimitedDepth_TwoLevels() {
         final String auditRecordStr =
             new AuditRecord.Builder<AuditedType>()
-                .withEntityType(AuditedType.INSTANCE)
+                .withEntityType(ENTITY_TYPE)
                 .withEntityId(ENTITY_ID_1)
                 .withOperator(CREATE)
                 .withChildRecords(singletonList(new AuditRecord.Builder<AuditedType>()
-                                                    .withEntityType(AuditedType.INSTANCE)
+                                                    .withEntityType(ENTITY_TYPE)
                                                     .withEntityId(ENTITY_ID_2)
                                                     .withOperator(CREATE)
                                                     .build()))
@@ -117,11 +119,11 @@ public class AuditRecordTest {
     public void testToString_MaxDepthOne_OneLevel() {
         final String auditRecordStr =
             new AuditRecord.Builder<AuditedType>()
-                .withEntityType(AuditedType.INSTANCE)
+                .withEntityType(ENTITY_TYPE)
                 .withEntityId(ENTITY_ID_1)
                 .withOperator(CREATE)
                 .withChildRecords(singletonList(new AuditRecord.Builder<AuditedType>()
-                                                    .withEntityType(AuditedType.INSTANCE)
+                                                    .withEntityType(ENTITY_TYPE)
                                                     .withEntityId(ENTITY_ID_2)
                                                     .withOperator(CREATE)
                                                     .build()))
@@ -138,7 +140,7 @@ public class AuditRecordTest {
     public void testToString_MaxDepthOne_TwoLevels() {
         final String auditRecordStr =
             new AuditRecord.Builder<AuditedType>()
-                .withEntityType(AuditedType.INSTANCE)
+                .withEntityType(ENTITY_TYPE)
                 .withEntityId(ENTITY_ID_1)
                 .withOperator(CREATE)
                 .build()
@@ -152,7 +154,7 @@ public class AuditRecordTest {
     public void testToString_MaxDepthZero_ReturnsEmptyString() {
         final String auditRecordStr =
             new AuditRecord.Builder<AuditedType>()
-                .withEntityType(AuditedType.INSTANCE)
+                .withEntityType(ENTITY_TYPE)
                 .withEntityId(ENTITY_ID_1)
                 .withOperator(CREATE)
                 .build()

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorImplForCreateTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorImplForCreateTest.java
@@ -79,7 +79,7 @@ public class AuditRecordGeneratorImplForCreateTest {
             auditRecordGenerator.generate(cmd, changeContext, emptyList());
 
         assertThat(actualOptionalAuditRecord,
-                   isPresentAnd(allOf(hasEntityType(AuditedType.INSTANCE),
+                   isPresentAnd(allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                       hasEntityId(STRING_ID),
                                       hasOperator(CREATE))));
     }

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorImplForDeleteTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorImplForDeleteTest.java
@@ -76,7 +76,7 @@ public class AuditRecordGeneratorImplForDeleteTest {
             auditRecordGenerator.generate(cmd, changeContext, emptyList());
 
         assertThat(actualOptionalAuditRecord,
-                   isPresentAnd(allOf(hasEntityType(AuditedType.INSTANCE),
+                   isPresentAnd(allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                       hasEntityId(STRING_ID),
                                       hasOperator(DELETE))));
     }

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorImplForUpdateTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorImplForUpdateTest.java
@@ -119,7 +119,7 @@ public class AuditRecordGeneratorImplForUpdateTest {
 
         assertThat(actualOptionalAuditRecord,
                    isPresentAnd(allOf(hasEntityId(STRING_ID),
-                                      hasEntityType(AuditedType.INSTANCE),
+                                      hasEntityType(AuditedType.INSTANCE.getName()),
                                       hasOperator(UPDATE),
                                       hasChangedFieldRecord(AuditedType.NAME, OLD_NAME, NEW_NAME),
                                       hasChangedFieldRecord(AuditedType.DESC, OLD_DESC, NEW_DESC))));
@@ -141,7 +141,7 @@ public class AuditRecordGeneratorImplForUpdateTest {
 
         assertThat(actualOptionalAuditRecord,
                    isPresentAnd(allOf(hasEntityId(STRING_ID),
-                                      hasEntityType(AuditedType.INSTANCE),
+                                      hasEntityType(AuditedType.INSTANCE.getName()),
                                       hasOperator(UPDATE),
                                       hasSameChildRecord(childRecords.get(0)),
                                       hasSameChildRecord(childRecords.get(1)))));
@@ -174,7 +174,7 @@ public class AuditRecordGeneratorImplForUpdateTest {
         //noinspection unchecked
         assertThat(actualOptionalAuditRecord,
                    isPresentAnd(allOf(hasEntityId(STRING_ID),
-                                      hasEntityType(AuditedType.INSTANCE),
+                                      hasEntityType(AuditedType.INSTANCE.getName()),
                                       hasOperator(UPDATE),
                                       hasMandatoryFieldValue(NotAuditedAncestorType.NAME, ANCESTOR_NAME),
                                       hasMandatoryFieldValue(NotAuditedAncestorType.DESC, ANCESTOR_DESC),

--- a/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordEntityTypeMatcher.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordEntityTypeMatcher.java
@@ -1,6 +1,5 @@
 package com.kenshoo.pl.entity.matchers.audit;
 
-import com.kenshoo.pl.entity.EntityType;
 import com.kenshoo.pl.entity.audit.AuditRecord;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
@@ -9,16 +8,16 @@ import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
 
-class AuditRecordEntityTypeMatcher<E extends EntityType<E>> extends TypeSafeMatcher<AuditRecord<E>> {
+class AuditRecordEntityTypeMatcher extends TypeSafeMatcher<AuditRecord<?>> {
 
-    private final E expectedEntityType;
+    private final String expectedEntityType;
 
-    AuditRecordEntityTypeMatcher(final E expectedEntityType) {
+    AuditRecordEntityTypeMatcher(final String expectedEntityType) {
         this.expectedEntityType = requireNonNull(expectedEntityType, "There must be an expected entity type");
     }
 
     @Override
-    protected boolean matchesSafely(final AuditRecord<E> actualRecord) {
+    protected boolean matchesSafely(final AuditRecord<?> actualRecord) {
         if (actualRecord == null) {
             return false;
         }
@@ -27,6 +26,6 @@ class AuditRecordEntityTypeMatcher<E extends EntityType<E>> extends TypeSafeMatc
 
     @Override
     public void describeTo(final Description description) {
-        description.appendValue("an AuditRecord with entity type " + expectedEntityType.getName());
+        description.appendValue("an AuditRecord with entity type " + expectedEntityType);
     }
 }

--- a/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordFieldRecordExistsMatcher.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordFieldRecordExistsMatcher.java
@@ -1,21 +1,20 @@
 package com.kenshoo.pl.entity.matchers.audit;
 
 import com.kenshoo.pl.entity.EntityField;
-import com.kenshoo.pl.entity.EntityType;
 import com.kenshoo.pl.entity.audit.AuditRecord;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
 
-class AuditRecordFieldRecordExistsMatcher<E extends EntityType<E>> extends TypeSafeMatcher<AuditRecord<E>> {
+class AuditRecordFieldRecordExistsMatcher extends TypeSafeMatcher<AuditRecord<?>> {
 
-    private final EntityField<E, ?> expectedField;
+    private final EntityField<?, ?> expectedField;
 
-    AuditRecordFieldRecordExistsMatcher(final EntityField<E, ?> expectedField) {
+    AuditRecordFieldRecordExistsMatcher(final EntityField<?, ?> expectedField) {
         this.expectedField = expectedField;
     }
 
     @Override
-    protected boolean matchesSafely(final AuditRecord<E> actualAuditRecord) {
+    protected boolean matchesSafely(final AuditRecord<?> actualAuditRecord) {
         return hasFieldRecordFor(actualAuditRecord, expectedField);
     }
 
@@ -25,7 +24,7 @@ class AuditRecordFieldRecordExistsMatcher<E extends EntityType<E>> extends TypeS
     }
 
 
-    private boolean hasFieldRecordFor(final AuditRecord<E> auditRecord, final EntityField<E, ?> field) {
+    private boolean hasFieldRecordFor(final AuditRecord<?> auditRecord, final EntityField<?, ?> field) {
         return auditRecord.getFieldRecords().stream()
                           .anyMatch(fieldRecord -> fieldRecord.getField().equals(field));
     }

--- a/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordFieldRecordMatcher.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordFieldRecordMatcher.java
@@ -6,16 +6,16 @@ import com.kenshoo.pl.entity.audit.FieldAuditRecord;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
 
-class AuditRecordFieldRecordMatcher<E extends EntityType<E>> extends TypeSafeMatcher<AuditRecord<E>> {
+class AuditRecordFieldRecordMatcher extends TypeSafeMatcher<AuditRecord<?>> {
 
-    private final FieldAuditRecord<E> expectedFieldRecord;
+    private final FieldAuditRecord<?> expectedFieldRecord;
 
-    AuditRecordFieldRecordMatcher(final FieldAuditRecord<E> expectedFieldRecord) {
+    AuditRecordFieldRecordMatcher(final FieldAuditRecord<?> expectedFieldRecord) {
         this.expectedFieldRecord = expectedFieldRecord;
     }
 
     @Override
-    protected boolean matchesSafely(final AuditRecord<E> actualAuditRecord) {
+    protected boolean matchesSafely(final AuditRecord<?> actualAuditRecord) {
         return actualAuditRecord.getFieldRecords().contains(expectedFieldRecord);
     }
 

--- a/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordHasChildRecordMatcher.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordHasChildRecordMatcher.java
@@ -1,16 +1,15 @@
 package com.kenshoo.pl.entity.matchers.audit;
 
-import com.kenshoo.pl.entity.EntityType;
 import com.kenshoo.pl.entity.audit.AuditRecord;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 
-class AuditRecordHasChildRecordMatcher<C extends EntityType<C>> extends TypeSafeMatcher<AuditRecord<?>> {
+class AuditRecordHasChildRecordMatcher extends TypeSafeMatcher<AuditRecord<?>> {
 
-    private final Matcher<? extends AuditRecord<C>> childRecordMatcher;
+    private final Matcher<AuditRecord<?>> childRecordMatcher;
 
-    AuditRecordHasChildRecordMatcher(final Matcher<? extends AuditRecord<C>> childRecordMatcher) {
+    AuditRecordHasChildRecordMatcher(final Matcher<AuditRecord<?>> childRecordMatcher) {
         this.childRecordMatcher = childRecordMatcher;
     }
 

--- a/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordMatchers.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordMatchers.java
@@ -3,15 +3,14 @@ package com.kenshoo.pl.entity.matchers.audit;
 import com.kenshoo.pl.entity.ChangeOperation;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.EntityFieldValue;
-import com.kenshoo.pl.entity.EntityType;
 import com.kenshoo.pl.entity.audit.AuditRecord;
 import com.kenshoo.pl.entity.audit.FieldAuditRecord;
 import org.hamcrest.Matcher;
 
 public class AuditRecordMatchers {
 
-    public static <E extends EntityType<E>> Matcher<AuditRecord<E>> hasEntityType(final E expectedEntityType) {
-        return new AuditRecordEntityTypeMatcher<>(expectedEntityType);
+    public static Matcher<AuditRecord<?>> hasEntityType(final String expectedEntityType) {
+        return new AuditRecordEntityTypeMatcher(expectedEntityType);
     }
 
     public static Matcher<AuditRecord<?>> hasEntityId(final String expectedEntityId) {
@@ -30,29 +29,29 @@ public class AuditRecordMatchers {
         return new AuditRecordNoMandatoryFieldsMatcher();
     }
 
-    public static <E extends EntityType<E>> Matcher<AuditRecord<E>> hasCreatedFieldRecord(final EntityField<E, ?> field, final Object value) {
+    public static Matcher<AuditRecord<?>> hasCreatedFieldRecord(final EntityField<?, ?> field, final Object value) {
         return hasFieldRecord(FieldAuditRecord.builder(field)
                                               .newValue(value)
                                               .build());
     }
 
-    public static <E extends EntityType<E>> Matcher<AuditRecord<E>> hasChangedFieldRecord(final EntityField<E, ?> field,
-                                                                                          final String oldValue,
-                                                                                          final String newValue) {
+    public static Matcher<AuditRecord<?>> hasChangedFieldRecord(final EntityField<?, ?> field,
+                                                                final String oldValue,
+                                                                final String newValue) {
         return hasFieldRecord(FieldAuditRecord.builder(field)
                                               .oldValue(oldValue)
                                               .newValue(newValue)
                                               .build());
     }
 
-    public static <E extends EntityType<E>> Matcher<AuditRecord<E>> hasDeletedFieldRecord(final EntityField<E, ?> field, final Object value) {
+    public static  Matcher<AuditRecord<?>> hasDeletedFieldRecord(final EntityField<?, ?> field, final Object value) {
         return hasFieldRecord(FieldAuditRecord.builder(field)
                                               .oldValue(value)
                                               .build());
     }
 
-    public static <E extends EntityType<E>> Matcher<AuditRecord<E>> hasFieldRecordFor(final EntityField<E, ?> expectedField) {
-        return new AuditRecordFieldRecordExistsMatcher<>(expectedField);
+    public static Matcher<AuditRecord<?>> hasFieldRecordFor(final EntityField<?, ?> expectedField) {
+        return new AuditRecordFieldRecordExistsMatcher(expectedField);
     }
 
     public static Matcher<AuditRecord<?>> hasNoFieldRecords() {
@@ -63,16 +62,16 @@ public class AuditRecordMatchers {
         return new AuditRecordSameChildRecordMatcher(expectedChildRecord);
     }
 
-    public static <C extends EntityType<C>> Matcher<AuditRecord<?>> hasChildRecordThat(final Matcher<AuditRecord<C>> childRecordMatcher) {
-        return new AuditRecordHasChildRecordMatcher<>(childRecordMatcher);
+    public static Matcher<AuditRecord<?>> hasChildRecordThat(final Matcher<AuditRecord<?>> childRecordMatcher) {
+        return new AuditRecordHasChildRecordMatcher(childRecordMatcher);
     }
 
     public static Matcher<AuditRecord<?>> hasNoChildRecords() {
         return new AuditRecordNoChildRecordsMatcher();
     }
 
-    private static <E extends EntityType<E>> Matcher<AuditRecord<E>> hasFieldRecord(final FieldAuditRecord<E> expectedFieldRecord) {
-        return new AuditRecordFieldRecordMatcher<>(expectedFieldRecord);
+    private static Matcher<AuditRecord<?>> hasFieldRecord(final FieldAuditRecord<?> expectedFieldRecord) {
+        return new AuditRecordFieldRecordMatcher(expectedFieldRecord);
     }
 
 }


### PR DESCRIPTION
Refactor the `entityType` in `AuditRecord` to be a string representing the name - instead of the entire object.
This moves the responsibility for choosing this name from the consuming service back to the PL itself.

Currently this is set to the EntityType name (always) - and in the next PR it will check the annotation to see if there is an override