### PR TITLE
PL-113: In AuditRecord replace fields with their names

### DIFF
--- a/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForCreateOneLevelTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForCreateOneLevelTest.java
@@ -86,11 +86,11 @@ public class AuditForCreateOneLevelTest {
                              auditedConfig);
         final long id = extractIdFromResult(createResult, AuditedType.ID);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
         assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(id)),
                                       hasOperator(CREATE),
@@ -106,11 +106,11 @@ public class AuditForCreateOneLevelTest {
                                            .with(AuditedType.DESC, "desc")),
                          auditedConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
         assertThat(auditRecord, allOf(hasCreatedFieldRecord(AuditedType.NAME, "name"),
                                       hasCreatedFieldRecord(AuditedType.DESC, "desc"),
                                       not(hasFieldRecordFor(AuditedType.DESC2))));
@@ -134,14 +134,14 @@ public class AuditForCreateOneLevelTest {
                                                     AuditedType.ID,
                                                     AuditedType.NAME);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of generated ids",
                    ids, hasSize(2));
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(2));
 
-        final AuditRecord<AuditedType> auditRecord1 = typed(auditRecords.get(0));
+        final AuditRecord auditRecord1 = auditRecords.get(0);
         assertThat(auditRecord1, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                        hasEntityId(String.valueOf(ids.get(0))),
                                        hasOperator(CREATE),
@@ -149,7 +149,7 @@ public class AuditForCreateOneLevelTest {
                                        hasCreatedFieldRecord(AuditedType.DESC, "descA"),
                                        hasCreatedFieldRecord(AuditedType.DESC2, "desc2A")));
 
-        final AuditRecord<AuditedType> auditRecord2 = typed(auditRecords.get(1));
+        final AuditRecord auditRecord2 = auditRecords.get(1);
         assertThat(auditRecord2, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                        hasEntityId(String.valueOf(ids.get(1))),
                                        hasOperator(CREATE),
@@ -166,11 +166,11 @@ public class AuditForCreateOneLevelTest {
                                                     .with(InclusiveAuditedType.DESC2, "desc2")),
                                   inclusiveAuditedConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<InclusiveAuditedType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
         assertThat(auditRecord, allOf(hasCreatedFieldRecord(InclusiveAuditedType.NAME, "name"),
                                       hasCreatedFieldRecord(InclusiveAuditedType.DESC, "desc"),
                                       not(hasFieldRecordFor(InclusiveAuditedType.DESC2))));
@@ -183,11 +183,11 @@ public class AuditForCreateOneLevelTest {
                                                     .with(InclusiveAuditedType.DESC, "desc")),
                                   inclusiveAuditedConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<InclusiveAuditedType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
         assertThat(auditRecord, allOf(hasCreatedFieldRecord(InclusiveAuditedType.NAME, "name"),
                                       hasCreatedFieldRecord(InclusiveAuditedType.DESC, "desc"),
                                       not(hasFieldRecordFor(InclusiveAuditedType.DESC2))));
@@ -200,11 +200,11 @@ public class AuditForCreateOneLevelTest {
                                                     .with(InclusiveAuditedType.DESC2, "desc2")),
                                   inclusiveAuditedConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<InclusiveAuditedType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
         assertThat(auditRecord, allOf(hasCreatedFieldRecord(InclusiveAuditedType.DESC, "desc"),
                                       not(hasFieldRecordFor(InclusiveAuditedType.NAME)),
                                       not(hasFieldRecordFor(InclusiveAuditedType.DESC2))));
@@ -218,11 +218,11 @@ public class AuditForCreateOneLevelTest {
                                       inclusiveAuditedConfig);
         final long id = extractIdFromResult(createResult, InclusiveAuditedType.ID);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<InclusiveAuditedType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
         assertThat(auditRecord, allOf(hasEntityType(InclusiveAuditedType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(id)),
                                       hasOperator(CREATE),
@@ -232,16 +232,16 @@ public class AuditForCreateOneLevelTest {
     @Test
     public void oneExclusiveAuditedEntity_AllEntityFieldsInCommand_ShouldCreateFieldRecordsForAuditedOnly() {
         exclusiveAuditedPL.create(singletonList(new CreateExclusiveAuditedCommand()
-                                                               .with(ExclusiveAuditedType.NAME, "name")
-                                                               .with(ExclusiveAuditedType.DESC, "desc")
-                                                               .with(ExclusiveAuditedType.DESC2, "desc2")),
+                                                    .with(ExclusiveAuditedType.NAME, "name")
+                                                    .with(ExclusiveAuditedType.DESC, "desc")
+                                                    .with(ExclusiveAuditedType.DESC2, "desc2")),
                                   exclusiveAuditedConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<ExclusiveAuditedType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
         assertThat(auditRecord, allOf(hasCreatedFieldRecord(ExclusiveAuditedType.NAME, "name"),
                                       not(hasFieldRecordFor(ExclusiveAuditedType.DESC)),
                                       not(hasFieldRecordFor(ExclusiveAuditedType.DESC2))));
@@ -252,11 +252,11 @@ public class AuditForCreateOneLevelTest {
         auditedWithoutDataFieldsPL.create(singletonList(new CreateAuditedWithoutDataFieldsCommand(ID)),
                                           auditedWithoutDataFieldsConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedWithoutDataFieldsType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
         assertThat(auditRecord, allOf(hasEntityType(AuditedWithoutDataFieldsType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(ID)),
                                       hasOperator(CREATE)));
@@ -268,7 +268,7 @@ public class AuditForCreateOneLevelTest {
                                               .with(NotAuditedType.NAME, "name")),
                             notAuditedConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat(auditRecords, is(empty()));
     }
@@ -303,10 +303,5 @@ public class AuditForCreateOneLevelTest {
                            .map(identifier -> identifier.get(idField))
                            .filter(Objects::nonNull)
                            .collect(toList());
-    }
-
-    @SuppressWarnings("unchecked")
-    private <E extends EntityType<E>> AuditRecord<E> typed(final AuditRecord<?> auditRecord) {
-        return (AuditRecord<E>) auditRecord;
     }
 }

--- a/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForCreateOneLevelWithMandatoryTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForCreateOneLevelWithMandatoryTest.java
@@ -107,11 +107,11 @@ public class AuditForCreateOneLevelWithMandatoryTest {
                                                        .with(AUD_WITH_ANC_DESC_FIELD, DESC)),
                                      auditedWithAncestorConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedWithAncestorMandatoryType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
         assertThat(auditRecord, allOf(hasMandatoryFieldValue(ANCESTOR_NAME_FIELD, ANCESTOR_NAME),
                                       hasMandatoryFieldValue(ANCESTOR_DESC_FIELD, ANCESTOR_DESC),
                                       hasCreatedFieldRecord(AUD_WITH_ANC_NAME_FIELD, NAME),
@@ -125,11 +125,11 @@ public class AuditForCreateOneLevelWithMandatoryTest {
                                                    .with(AUD_WITH_INTERNAL_DESC_FIELD, DESC)),
                                      auditedWithInternalConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedWithInternalMandatoryType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
         assertThat(auditRecord, allOf(hasMandatoryFieldValue(AUD_WITH_INTERNAL_NAME_FIELD, NAME),
                                       hasCreatedFieldRecord(AUD_WITH_INTERNAL_NAME_FIELD, NAME),
                                       hasCreatedFieldRecord(AUD_WITH_INTERNAL_DESC_FIELD, DESC)));
@@ -143,11 +143,11 @@ public class AuditForCreateOneLevelWithMandatoryTest {
                                                    .with(AUD_WITH_BOTH_DESC_FIELD, DESC)),
                                  auditedWithBothConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedWithInternalAndAncestorMandatoryType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
         assertThat(auditRecord, allOf(hasMandatoryFieldValue(AUD_WITH_BOTH_NAME_FIELD, NAME),
                                       hasMandatoryFieldValue(ANCESTOR_NAME_FIELD, ANCESTOR_NAME),
                                       hasMandatoryFieldValue(ANCESTOR_DESC_FIELD, ANCESTOR_DESC),
@@ -161,11 +161,11 @@ public class AuditForCreateOneLevelWithMandatoryTest {
                                                        .with(AUD_WITH_ANC_FK_FIELD, ANCESTOR_ID)),
                                      auditedWithAncestorConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedWithAncestorMandatoryType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
         assertThat(auditRecord, allOf(hasMandatoryFieldValue(NotAuditedAncestorType.NAME, ANCESTOR_NAME),
                                       hasMandatoryFieldValue(NotAuditedAncestorType.DESC, ANCESTOR_DESC),
                                       hasNoFieldRecords()));
@@ -177,11 +177,11 @@ public class AuditForCreateOneLevelWithMandatoryTest {
                                                    .with(AUD_WITH_INTERNAL_NAME_FIELD, NAME)),
                                      auditedWithInternalConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedWithInternalMandatoryType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
         assertThat(auditRecord, allOf(hasMandatoryFieldValue(AUD_WITH_INTERNAL_NAME_FIELD, NAME),
                                       hasCreatedFieldRecord(AUD_WITH_INTERNAL_NAME_FIELD, NAME)));
     }
@@ -204,10 +204,5 @@ public class AuditForCreateOneLevelWithMandatoryTest {
 
     private CreateAuditedWithInternalAndAncestorMandatoryCommand createAuditedWithBothCommand() {
         return new CreateAuditedWithInternalAndAncestorMandatoryCommand();
-    }
-
-    @SuppressWarnings("unchecked")
-    private <E extends EntityType<E>> AuditRecord<E> typed(final AuditRecord<?> auditRecord) {
-        return (AuditRecord<E>) auditRecord;
     }
 }

--- a/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForCreateTwoLevelsTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForCreateTwoLevelsTest.java
@@ -80,11 +80,11 @@ public class AuditForCreateTwoLevelsTest {
         final long parentId = extractAuditedParentIdFromCmd(outputParentCmd);
         final long childId = fetchChildIdByName("childName");
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
 
         assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(parentId)),
@@ -118,11 +118,11 @@ public class AuditForCreateTwoLevelsTest {
         final long child1AId = fetchChildIdByName("child1AName");
         final long child1BId = fetchChildIdByName("child1BName");
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
 
         assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(child1AId)),
@@ -156,11 +156,11 @@ public class AuditForCreateTwoLevelsTest {
         final long child1Id = fetchChildIdByName("child1Name");
         final long child2Id = fetchChildIdByName("child2Name");
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
 
         assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(child1Id)),
@@ -193,11 +193,11 @@ public class AuditForCreateTwoLevelsTest {
 
         final long auditedChildId = fetchChildIdByName("auditedChildName");
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
 
         assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(auditedChildId)),
@@ -221,7 +221,7 @@ public class AuditForCreateTwoLevelsTest {
 
         notAuditedParentPL.create(singletonList(parentCmd), flowConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat(auditRecords, is(empty()));
     }
@@ -244,11 +244,11 @@ public class AuditForCreateTwoLevelsTest {
 
         final long childId = fetchChildIdByName("childName");
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedWithoutDataFieldsType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
 
         assertThat(auditRecord, allOf(hasEntityType(AuditedWithoutDataFieldsType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(parentId)),
@@ -285,12 +285,12 @@ public class AuditForCreateTwoLevelsTest {
         final long child1Id = fetchChildIdByName("child1Name");
         final long child2Id = fetchChildIdByName("child2Name");
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(2));
-        final AuditRecord<AuditedType> auditRecord1 = typed(auditRecords.get(0));
-        final AuditRecord<AuditedType> auditRecord2 = typed(auditRecords.get(1));
+        final AuditRecord auditRecord1 = auditRecords.get(0);
+        final AuditRecord auditRecord2 = auditRecords.get(1);
 
         assertThat(auditRecord1, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                           hasEntityId(String.valueOf(child1Id)),
@@ -330,10 +330,5 @@ public class AuditForCreateTwoLevelsTest {
                          .fetchOptional()
                          .map(rec -> rec.get(ChildTable.INSTANCE.id))
                          .orElseThrow(() -> new IllegalStateException("Could not fetch id by name '" + childName + "'"));
-    }
-
-    @SuppressWarnings("unchecked")
-    private <E extends EntityType<E>> AuditRecord<E> typed(final AuditRecord<?> auditRecord) {
-        return (AuditRecord<E>) auditRecord;
     }
 }

--- a/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForDeleteOneLevelTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForDeleteOneLevelTest.java
@@ -85,11 +85,11 @@ public class AuditForDeleteOneLevelTest {
         auditedPL.delete(singletonList(new DeleteAuditedCommand(ID_1)),
                          auditedConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
         assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(ID_1)),
                                       hasOperator(DELETE)));
@@ -100,7 +100,7 @@ public class AuditForDeleteOneLevelTest {
         auditedPL.delete(singletonList(new DeleteAuditedCommand(INVALID_ID)),
                          auditedConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat(auditRecords, is(empty()));
     }
@@ -113,17 +113,17 @@ public class AuditForDeleteOneLevelTest {
 
         auditedPL.delete(cmds, auditedConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(2));
 
-        final AuditRecord<AuditedType> auditRecord1 = typed(auditRecords.get(0));
+        final AuditRecord auditRecord1 = auditRecords.get(0);
         assertThat(auditRecord1, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                        hasEntityId(String.valueOf(ID_1)),
                                        hasOperator(DELETE)));
 
-        final AuditRecord<AuditedType> auditRecord2 = typed(auditRecords.get(1));
+        final AuditRecord auditRecord2 = auditRecords.get(1);
         assertThat(auditRecord2, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                        hasEntityId(String.valueOf(ID_2)),
                                        hasOperator(DELETE)));
@@ -137,12 +137,12 @@ public class AuditForDeleteOneLevelTest {
 
         auditedPL.delete(cmds, auditedConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
 
-        final AuditRecord<AuditedType> auditRecord1 = typed(auditRecords.get(0));
+        final AuditRecord auditRecord1 = auditRecords.get(0);
         assertThat(auditRecord1, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                        hasEntityId(String.valueOf(ID_1)),
                                        hasOperator(DELETE)));
@@ -153,11 +153,11 @@ public class AuditForDeleteOneLevelTest {
         auditedWithoutDataFieldsPL.delete(singletonList(new DeleteAuditedWithoutDataFieldsCommand(ID_1)),
                                           auditedWithoutDataFieldsConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedWithoutDataFieldsType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
         assertThat(auditRecord, allOf(hasEntityType(AuditedWithoutDataFieldsType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(ID_1)),
                                       hasOperator(DELETE)));
@@ -168,7 +168,7 @@ public class AuditForDeleteOneLevelTest {
         notAuditedPL.delete(singletonList(new DeleteNotAuditedCommand(ID_1)),
                             notAuditedConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat(auditRecords, is(empty()));
     }
@@ -179,10 +179,5 @@ public class AuditForDeleteOneLevelTest {
 
     private <E extends EntityType<E>> PersistenceLayer<E> persistenceLayer() {
         return new PersistenceLayer<>(plContext);
-    }
-
-    @SuppressWarnings("unchecked")
-    private <E extends EntityType<E>> AuditRecord<E> typed(final AuditRecord<?> auditRecord) {
-        return (AuditRecord<E>) auditRecord;
     }
 }

--- a/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForDeleteOneLevelWithMandatoryTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForDeleteOneLevelWithMandatoryTest.java
@@ -100,11 +100,11 @@ public class AuditForDeleteOneLevelWithMandatoryTest {
         auditedWithAncestorPL.delete(singletonList(deleteWithAncestorCommand()),
                                      auditedWithAncestorConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedWithAncestorMandatoryType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
         assertThat(auditRecord, allOf(hasMandatoryFieldValue(ANCESTOR_NAME_FIELD, ANCESTOR_NAME),
                                       hasMandatoryFieldValue(ANCESTOR_DESC_FIELD, ANCESTOR_DESC)));
     }
@@ -114,11 +114,11 @@ public class AuditForDeleteOneLevelWithMandatoryTest {
         auditedWithInternalPL.delete(singletonList(deleteWithInternalCommand()),
                                  auditedWithInternalConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedWithAncestorMandatoryType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
         assertThat(auditRecord, hasMandatoryFieldValue(AuditedWithInternalMandatoryType.NAME, NAME));
     }
 
@@ -136,10 +136,5 @@ public class AuditForDeleteOneLevelWithMandatoryTest {
 
     private <E extends EntityType<E>> PersistenceLayer<E> persistenceLayer() {
         return new PersistenceLayer<>(plContext);
-    }
-
-    @SuppressWarnings("unchecked")
-    private <E extends EntityType<E>> AuditRecord<E> typed(final AuditRecord<?> auditRecord) {
-        return (AuditRecord<E>) auditRecord;
     }
 }

--- a/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForDeleteTwoLevelsTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForDeleteTwoLevelsTest.java
@@ -94,11 +94,11 @@ public class AuditForDeleteTwoLevelsTest {
 
         auditedParentPL.delete(singletonList(cmd), flowConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
         assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(PARENT_ID_1)),
                                       hasOperator(DELETE)));
@@ -121,11 +121,11 @@ public class AuditForDeleteTwoLevelsTest {
 
         auditedParentPL.delete(singletonList(cmd), flowConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
 
         assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(CHILD_ID_11)),
@@ -149,11 +149,11 @@ public class AuditForDeleteTwoLevelsTest {
 
         auditedParentPL.delete(singletonList(parentCmd), flowConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
 
         assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(CHILD_ID_11)),
@@ -177,11 +177,11 @@ public class AuditForDeleteTwoLevelsTest {
 
         auditedParentPL.delete(singletonList(cmd), flowConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
 
         assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(CHILD_ID_11)),
@@ -202,11 +202,11 @@ public class AuditForDeleteTwoLevelsTest {
 
         auditedParentPL.delete(singletonList(cmd), flowConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
 
         assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(CHILD_ID_11)),
@@ -229,7 +229,7 @@ public class AuditForDeleteTwoLevelsTest {
 
         auditedParentPL.delete(singletonList(cmd), flowConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat(auditRecords, is(empty()));
     }
@@ -247,7 +247,7 @@ public class AuditForDeleteTwoLevelsTest {
 
         notAuditedParentPL.delete(singletonList(cmd), flowConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat(auditRecords, is(empty()));
     }
@@ -265,11 +265,11 @@ public class AuditForDeleteTwoLevelsTest {
 
         auditedParentWithoutDataFieldsPL.delete(singletonList(cmd), flowConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedWithoutDataFieldsType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
         assertThat(auditRecord, allOf(hasEntityType(AuditedWithoutDataFieldsType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(PARENT_ID_1)),
                                       hasOperator(DELETE)));
@@ -294,17 +294,17 @@ public class AuditForDeleteTwoLevelsTest {
 
         auditedParentPL.delete(cmds, flowConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(2));
 
-        final AuditRecord<AuditedType> auditRecord1 = typed(auditRecords.get(0));
+        final AuditRecord auditRecord1 = auditRecords.get(0);
         assertThat(auditRecord1, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                           hasEntityId(String.valueOf(CHILD_ID_11)),
                                                           hasOperator(DELETE))));
 
-        final AuditRecord<AuditedType> auditRecord2 = typed(auditRecords.get(1));
+        final AuditRecord auditRecord2 = auditRecords.get(1);
         assertThat(auditRecord2, hasChildRecordThat(allOf(hasEntityType(AuditedChild2Type.INSTANCE.getName()),
                                                           hasEntityId(String.valueOf(CHILD_ID_21)),
                                                           hasOperator(DELETE))));
@@ -317,10 +317,5 @@ public class AuditForDeleteTwoLevelsTest {
 
     private <E extends EntityType<E>> PersistenceLayer<E> persistenceLayer() {
         return new PersistenceLayer<>(plContext);
-    }
-
-    @SuppressWarnings("unchecked")
-    private <E extends EntityType<E>> AuditRecord<E> typed(final AuditRecord<?> auditRecord) {
-        return (AuditRecord<E>) auditRecord;
     }
 }

--- a/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForUpdateOneLevelTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForUpdateOneLevelTest.java
@@ -98,11 +98,11 @@ public class AuditForUpdateOneLevelTest {
                                                  .with(AuditedType.DESC2, "newDesc2A")),
                          auditedConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
         assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(ID_1)),
                                       hasOperator(UPDATE),
@@ -119,11 +119,11 @@ public class AuditForUpdateOneLevelTest {
                                                  .with(AuditedType.DESC2, "desc2A")),
                          auditedConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
         assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(ID_1)),
                                       hasOperator(UPDATE),
@@ -140,7 +140,7 @@ public class AuditForUpdateOneLevelTest {
                                                  .with(AuditedType.DESC2, "desc2A")),
                          auditedConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat(auditRecords, is(empty()));
     }
@@ -152,11 +152,11 @@ public class AuditForUpdateOneLevelTest {
                                                  .with(AuditedType.DESC, "newDescA")),
                          auditedConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
         assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(ID_1)),
                                       hasOperator(UPDATE),
@@ -170,7 +170,7 @@ public class AuditForUpdateOneLevelTest {
         auditedPL.update(singletonList(new UpdateAuditedCommand(INVALID_ID)),
                          auditedConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat(auditRecords, is(empty()));
     }
@@ -189,12 +189,12 @@ public class AuditForUpdateOneLevelTest {
 
         auditedPL.update(cmds, auditedConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(2));
 
-        final AuditRecord<AuditedType> auditRecord1 = typed(auditRecords.get(0));
+        final AuditRecord auditRecord1 = auditRecords.get(0);
         assertThat(auditRecord1, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                        hasEntityId(String.valueOf(ID_1)),
                                        hasOperator(UPDATE),
@@ -202,7 +202,7 @@ public class AuditForUpdateOneLevelTest {
                                        hasChangedFieldRecord(AuditedType.DESC, "descA", "newDescA"),
                                        hasChangedFieldRecord(AuditedType.DESC2, "desc2A", "newDesc2A")));
 
-        final AuditRecord<AuditedType> auditRecord2 = typed(auditRecords.get(1));
+        final AuditRecord auditRecord2 = auditRecords.get(1);
         assertThat(auditRecord2, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                        hasEntityId(String.valueOf(ID_2)),
                                        hasOperator(UPDATE),
@@ -221,12 +221,12 @@ public class AuditForUpdateOneLevelTest {
 
         auditedPL.update(cmds, auditedConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
 
-        final AuditRecord<AuditedType> auditRecord1 = typed(auditRecords.get(0));
+        final AuditRecord auditRecord1 = auditRecords.get(0);
         assertThat(auditRecord1, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                        hasEntityId(String.valueOf(ID_1)),
                                        hasOperator(UPDATE)));
@@ -240,11 +240,11 @@ public class AuditForUpdateOneLevelTest {
                                                  .with(InclusiveAuditedType.DESC2, "newDesc2A")),
                                   inclusiveAuditedConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<InclusiveAuditedType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
         assertThat(auditRecord, allOf(hasEntityType(InclusiveAuditedType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(ID_1)),
                                       hasOperator(UPDATE),
@@ -259,11 +259,11 @@ public class AuditForUpdateOneLevelTest {
                                                            .with(InclusiveAuditedType.DESC, "newDescA")),
                                   inclusiveAuditedConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<InclusiveAuditedType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
         assertThat(auditRecord, allOf(hasEntityType(InclusiveAuditedType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(ID_1)),
                                       hasOperator(UPDATE),
@@ -277,7 +277,7 @@ public class AuditForUpdateOneLevelTest {
         auditedWithoutDataFieldsPL.update(singletonList(new UpdateAuditedWithoutDataFieldsCommand(ID_1)),
                                           auditedWithoutDataFieldsConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat(auditRecords, is(empty()));
     }
@@ -288,7 +288,7 @@ public class AuditForUpdateOneLevelTest {
                                                     .with(NotAuditedType.NAME, "newNameA")),
                             notAuditedConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("There should not be any published audit records",
                    auditRecords, is(empty()));
@@ -300,10 +300,5 @@ public class AuditForUpdateOneLevelTest {
 
     private <E extends EntityType<E>> PersistenceLayer<E> persistenceLayer() {
         return new PersistenceLayer<>(plContext);
-    }
-
-    @SuppressWarnings("unchecked")
-    private <E extends EntityType<E>> AuditRecord<E> typed(final AuditRecord<?> auditRecord) {
-        return (AuditRecord<E>) auditRecord;
     }
 }

--- a/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForUpdateOneLevelWithMandatoryTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForUpdateOneLevelWithMandatoryTest.java
@@ -115,11 +115,11 @@ public class AuditForUpdateOneLevelWithMandatoryTest {
                                                        .with(AUD_WITH_ANC_DESC_FIELD, NEW_DESC)),
                                      auditedWithAncestorConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedWithAncestorMandatoryType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
         assertThat(auditRecord, allOf(hasMandatoryFieldValue(ANCESTOR_NAME_FIELD, ANCESTOR_NAME),
                                       hasMandatoryFieldValue(ANCESTOR_DESC_FIELD, ANCESTOR_DESC),
                                       hasChangedFieldRecord(AUD_WITH_ANC_NAME_FIELD, NAME, NEW_NAME),
@@ -131,7 +131,7 @@ public class AuditForUpdateOneLevelWithMandatoryTest {
         auditedWithAncestorPL.update(singletonList(updateAuditedWithAncestorCommand()
                                                        .with(ANCESTOR_FK_FIELD, ANCESTOR_ID)),
                                      auditedWithAncestorConfig);
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("There should not be any published audit records",
                    auditRecords, is(empty()));
@@ -142,11 +142,11 @@ public class AuditForUpdateOneLevelWithMandatoryTest {
         auditedWithSelfPL.update(singletonList(updateAuditedWithSelfCommand()
                                                    .with(AUD_WITH_INTERNAL_NAME_FIELD, NEW_NAME)),
                                  auditedWithInternalConfig);
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedWithInternalMandatoryType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
         assertThat(auditRecord, allOf(hasMandatoryFieldValue(AUD_WITH_INTERNAL_NAME_FIELD, NEW_NAME),
                                       hasChangedFieldRecord(AUD_WITH_INTERNAL_NAME_FIELD, NAME, NEW_NAME)));
     }
@@ -157,11 +157,11 @@ public class AuditForUpdateOneLevelWithMandatoryTest {
                                                    .with(AUD_WITH_INTERNAL_NAME_FIELD, NEW_NAME)
                                                    .with(AUD_WITH_INTERNAL_DESC_FIELD, NEW_DESC)),
                                  auditedWithInternalConfig);
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedWithInternalMandatoryType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
         assertThat(auditRecord, allOf(hasMandatoryFieldValue(AUD_WITH_INTERNAL_NAME_FIELD, NEW_NAME),
                                       hasChangedFieldRecord(AUD_WITH_INTERNAL_NAME_FIELD, NAME, NEW_NAME),
                                       hasChangedFieldRecord(AUD_WITH_INTERNAL_DESC_FIELD, DESC, NEW_DESC)));
@@ -181,10 +181,5 @@ public class AuditForUpdateOneLevelWithMandatoryTest {
 
     private UpdateAuditedWithInternalMandatoryCommand updateAuditedWithSelfCommand() {
         return new UpdateAuditedWithInternalMandatoryCommand(ID);
-    }
-
-    @SuppressWarnings("unchecked")
-    private <E extends EntityType<E>> AuditRecord<E> typed(final AuditRecord<?> auditRecord) {
-        return (AuditRecord<E>) auditRecord;
     }
 }

--- a/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForUpdateTwoLevelsTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForUpdateTwoLevelsTest.java
@@ -112,11 +112,11 @@ public class AuditForUpdateTwoLevelsTest {
 
         auditedParentPL.update(singletonList(parentCmd), flowConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
         assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(PARENT_ID_1)),
                                       hasOperator(UPDATE),
@@ -150,11 +150,11 @@ public class AuditForUpdateTwoLevelsTest {
 
         auditedParentPL.update(singletonList(parentCmd), flowConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
 
         assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(CHILD_ID_11)),
@@ -192,11 +192,11 @@ public class AuditForUpdateTwoLevelsTest {
 
         auditedParentPL.update(singletonList(parentCmd), flowConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
 
         assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(CHILD_ID_11)),
@@ -234,11 +234,11 @@ public class AuditForUpdateTwoLevelsTest {
 
         auditedParentPL.update(singletonList(parentCmd), flowConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
 
         assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(CHILD_ID_11)),
@@ -263,11 +263,11 @@ public class AuditForUpdateTwoLevelsTest {
 
         auditedParentPL.update(singletonList(cmd), flowConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
 
         assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(CHILD_ID_12)),
@@ -291,7 +291,7 @@ public class AuditForUpdateTwoLevelsTest {
 
         auditedParentPL.update(singletonList(cmd), flowConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat(auditRecords, is(empty()));
     }
@@ -313,7 +313,7 @@ public class AuditForUpdateTwoLevelsTest {
 
         notAuditedParentPL.update(singletonList(parentCmd), flowConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat(auditRecords, is(empty()));
     }
@@ -335,11 +335,11 @@ public class AuditForUpdateTwoLevelsTest {
 
         auditedParentPL.update(singletonList(parentCmd), flowConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
 
         assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(PARENT_ID_1)),
@@ -364,11 +364,11 @@ public class AuditForUpdateTwoLevelsTest {
 
         auditedParentWithoutDataFieldsPL.update(singletonList(parentCmd), flowConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedWithoutDataFieldsType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
         assertThat(auditRecord, allOf(hasEntityType(AuditedWithoutDataFieldsType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(PARENT_ID_1)),
                                       hasOperator(UPDATE)));
@@ -395,11 +395,11 @@ public class AuditForUpdateTwoLevelsTest {
 
         auditedParentPL.update(singletonList(parentCmd), flowConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
         assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(PARENT_ID_1)),
                                       hasOperator(UPDATE)));
@@ -426,11 +426,11 @@ public class AuditForUpdateTwoLevelsTest {
 
         auditedParentPL.update(singletonList(parentCmd), flowConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
         assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(PARENT_ID_1)),
                                       hasOperator(UPDATE),
@@ -462,17 +462,17 @@ public class AuditForUpdateTwoLevelsTest {
 
         auditedParentPL.update(cmds, flowConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(2));
 
-        final AuditRecord<AuditedType> auditRecord1 = typed(auditRecords.get(0));
+        final AuditRecord auditRecord1 = auditRecords.get(0);
         assertThat(auditRecord1, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                           hasEntityId(String.valueOf(CHILD_ID_11)),
                                                           hasOperator(UPDATE))));
 
-        final AuditRecord<AuditedType> auditRecord2 = typed(auditRecords.get(1));
+        final AuditRecord auditRecord2 = auditRecords.get(1);
         assertThat(auditRecord2, hasChildRecordThat(allOf(hasEntityType(AuditedChild2Type.INSTANCE.getName()),
                                                           hasEntityId(String.valueOf(CHILD_ID_21)),
                                                           hasOperator(UPDATE))));
@@ -485,10 +485,5 @@ public class AuditForUpdateTwoLevelsTest {
 
     private <E extends EntityType<E>> PersistenceLayer<E> persistenceLayer() {
         return new PersistenceLayer<>(plContext);
-    }
-
-    @SuppressWarnings("unchecked")
-    private <E extends EntityType<E>> AuditRecord<E> typed(final AuditRecord<?> auditRecord) {
-        return (AuditRecord<E>) auditRecord;
     }
 }

--- a/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForUpsertOneLevelTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForUpsertOneLevelTest.java
@@ -92,11 +92,11 @@ public class AuditForUpsertOneLevelTest {
                                            .with(AuditedType.DESC2, "desc2")),
                          auditedConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
         assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(fetchIdByName(NEW_NAME_1))),
                                       hasOperator(CREATE),
@@ -112,11 +112,11 @@ public class AuditForUpsertOneLevelTest {
                                            .with(AuditedType.DESC2, "newDesc2A")),
                          auditedConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
         assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(EXISTING_ID_1)),
                                       hasOperator(UPDATE),
@@ -132,7 +132,7 @@ public class AuditForUpsertOneLevelTest {
                                            .with(AuditedType.DESC2, "desc2A")),
                          auditedConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat(auditRecords, is(empty()));
     }
@@ -149,12 +149,12 @@ public class AuditForUpsertOneLevelTest {
 
         auditedPL.upsert(cmds, auditedConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(2));
 
-        final AuditRecord<AuditedType> auditRecord1 = typed(auditRecords.get(0));
+        final AuditRecord auditRecord1 = auditRecords.get(0);
         assertThat(auditRecord1, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                        hasEntityId(String.valueOf(fetchIdByName(NEW_NAME_1))),
                                        hasOperator(CREATE),
@@ -162,7 +162,7 @@ public class AuditForUpsertOneLevelTest {
                                        hasCreatedFieldRecord(AuditedType.DESC, "newDescA"),
                                        hasCreatedFieldRecord(AuditedType.DESC2, "newDesc2A")));
 
-        final AuditRecord<AuditedType> auditRecord2 = typed(auditRecords.get(1));
+        final AuditRecord auditRecord2 = auditRecords.get(1);
         assertThat(auditRecord2, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                        hasEntityId(String.valueOf(fetchIdByName(NEW_NAME_2))),
                                        hasOperator(CREATE),
@@ -183,12 +183,12 @@ public class AuditForUpsertOneLevelTest {
 
         auditedPL.upsert(cmds, auditedConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(2));
 
-        final AuditRecord<AuditedType> auditRecord1 = typed(auditRecords.get(0));
+        final AuditRecord auditRecord1 = auditRecords.get(0);
         assertThat(auditRecord1, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                        hasEntityId(String.valueOf(EXISTING_ID_1)),
                                        hasOperator(UPDATE),
@@ -196,7 +196,7 @@ public class AuditForUpsertOneLevelTest {
                                        hasChangedFieldRecord(AuditedType.DESC, "descA", "newDescA"),
                                        hasChangedFieldRecord(AuditedType.DESC2, "desc2A", "newDesc2A")));
 
-        final AuditRecord<AuditedType> auditRecord2 = typed(auditRecords.get(1));
+        final AuditRecord auditRecord2 = auditRecords.get(1);
         assertThat(auditRecord2, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                        hasEntityId(String.valueOf(EXISTING_ID_2)),
                                        hasOperator(UPDATE),
@@ -217,12 +217,12 @@ public class AuditForUpsertOneLevelTest {
 
         auditedPL.upsert(cmds, auditedConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(2));
 
-        final AuditRecord<AuditedType> auditRecord1 = typed(auditRecords.get(0));
+        final AuditRecord auditRecord1 = auditRecords.get(0);
         assertThat(auditRecord1, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                        hasEntityId(String.valueOf(fetchIdByName(NEW_NAME_1))),
                                        hasOperator(CREATE),
@@ -230,7 +230,7 @@ public class AuditForUpsertOneLevelTest {
                                        hasCreatedFieldRecord(AuditedType.DESC, "newDescA"),
                                        hasCreatedFieldRecord(AuditedType.DESC2, "newDesc2A")));
 
-        final AuditRecord<AuditedType> auditRecord2 = typed(auditRecords.get(1));
+        final AuditRecord auditRecord2 = auditRecords.get(1);
         assertThat(auditRecord2, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                        hasEntityId(String.valueOf(EXISTING_ID_2)),
                                        hasOperator(UPDATE),
@@ -244,7 +244,7 @@ public class AuditForUpsertOneLevelTest {
         notAuditedPL.upsert(singletonList(new UpsertNotAuditedCommand("name")),
                             notAuditedConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat(auditRecords, is(empty()));
     }
@@ -255,7 +255,7 @@ public class AuditForUpsertOneLevelTest {
                                               .with(NotAuditedType.DESC, "newDescA")),
                             notAuditedConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("There should not be any published audit records",
                    auditRecords, is(empty()));
@@ -275,10 +275,5 @@ public class AuditForUpsertOneLevelTest {
                          .where(MainTable.INSTANCE.name.eq(name))
                          .fetchOptional(MainTable.INSTANCE.id)
                          .orElseThrow(() -> new IllegalStateException("Could not fetch the id of the entity named '" + name + "'"));
-    }
-
-    @SuppressWarnings("unchecked")
-    private <E extends EntityType<E>> AuditRecord<E> typed(final AuditRecord<?> auditRecord) {
-        return (AuditRecord<E>) auditRecord;
     }
 }

--- a/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForUpsertTwoLevelsTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForUpsertTwoLevelsTest.java
@@ -122,11 +122,11 @@ public class AuditForUpsertTwoLevelsTest {
         final long parentId = fetchNewParent1IdByName();
         final long childId = fetchChildIdByName(NEW_CHILD_NAME_11);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
 
         assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(parentId)),
@@ -156,11 +156,11 @@ public class AuditForUpsertTwoLevelsTest {
 
         auditedParentPL.upsert(singletonList(parentCmd), flowConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
         assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(PARENT_ID_1)),
                                       hasOperator(UPDATE),
@@ -191,11 +191,11 @@ public class AuditForUpsertTwoLevelsTest {
         final long child11Id = fetchChildIdByName(NEW_CHILD_NAME_11);
         final long child12Id = fetchChildIdByName(NEW_CHILD_NAME_12);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
 
         assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(child11Id)),
@@ -228,11 +228,11 @@ public class AuditForUpsertTwoLevelsTest {
 
         auditedParentPL.upsert(singletonList(parentCmd), flowConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
 
         assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(CHILD_ID_11)),
@@ -271,11 +271,11 @@ public class AuditForUpsertTwoLevelsTest {
 
         final long newChildId = fetchChildIdByName(NEW_CHILD_NAME_11);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
 
         assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(newChildId)),
@@ -308,11 +308,11 @@ public class AuditForUpsertTwoLevelsTest {
 
         final long auditedChildId = fetchChildIdByName(NEW_CHILD_NAME_11);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
 
         assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(auditedChildId)),
@@ -343,11 +343,11 @@ public class AuditForUpsertTwoLevelsTest {
 
         auditedParentPL.upsert(singletonList(parentCmd), flowConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
 
         assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(CHILD_ID_11)),
@@ -372,11 +372,11 @@ public class AuditForUpsertTwoLevelsTest {
 
         auditedParentPL.upsert(singletonList(cmd), flowConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
 
         assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                          hasEntityId(String.valueOf(CHILD_ID_12)),
@@ -401,11 +401,11 @@ public class AuditForUpsertTwoLevelsTest {
 
         final long childId = fetchChildIdByName(NEW_CHILD_NAME_11);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
 
         assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(PARENT_ID_1)),
@@ -431,7 +431,7 @@ public class AuditForUpsertTwoLevelsTest {
 
         notAuditedParentPL.upsert(singletonList(parentCmd), flowConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat(auditRecords, is(empty()));
     }
@@ -453,7 +453,7 @@ public class AuditForUpsertTwoLevelsTest {
 
         notAuditedParentPL.upsert(singletonList(parentCmd), flowConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat(auditRecords, is(empty()));
     }
@@ -475,11 +475,11 @@ public class AuditForUpsertTwoLevelsTest {
 
         auditedParentPL.upsert(singletonList(parentCmd), flowConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
 
         assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(PARENT_ID_1)),
@@ -505,11 +505,11 @@ public class AuditForUpsertTwoLevelsTest {
 
         auditedParentPL.upsert(singletonList(parentCmd), flowConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
         assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(PARENT_ID_1)),
                                       hasOperator(UPDATE)));
@@ -536,11 +536,11 @@ public class AuditForUpsertTwoLevelsTest {
 
         auditedParentPL.upsert(singletonList(parentCmd), flowConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
-        final AuditRecord<AuditedType> auditRecord = typed(auditRecords.get(0));
+        final AuditRecord auditRecord = auditRecords.get(0);
         assertThat(auditRecord, allOf(hasEntityType(AuditedType.INSTANCE.getName()),
                                       hasEntityId(String.valueOf(PARENT_ID_1)),
                                       hasOperator(UPDATE),
@@ -568,12 +568,12 @@ public class AuditForUpsertTwoLevelsTest {
         final long child1Id = fetchChildIdByName(NEW_CHILD_NAME_11);
         final long child2Id = fetchChildIdByName(NEW_CHILD_NAME_21);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(2));
-        final AuditRecord<AuditedType> auditRecord1 = typed(auditRecords.get(0));
-        final AuditRecord<AuditedType> auditRecord2 = typed(auditRecords.get(1));
+        final AuditRecord auditRecord1 = auditRecords.get(0);
+        final AuditRecord auditRecord2 = auditRecords.get(1);
 
         assertThat(auditRecord1, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                           hasEntityId(String.valueOf(child1Id)),
@@ -610,17 +610,17 @@ public class AuditForUpsertTwoLevelsTest {
 
         auditedParentPL.upsert(cmds, flowConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(2));
 
-        final AuditRecord<AuditedType> auditRecord1 = typed(auditRecords.get(0));
+        final AuditRecord auditRecord1 = auditRecords.get(0);
         assertThat(auditRecord1, hasChildRecordThat(allOf(hasEntityType(AuditedChild1Type.INSTANCE.getName()),
                                                           hasEntityId(String.valueOf(CHILD_ID_11)),
                                                           hasOperator(UPDATE))));
 
-        final AuditRecord<AuditedType> auditRecord2 = typed(auditRecords.get(1));
+        final AuditRecord auditRecord2 = auditRecords.get(1);
         assertThat(auditRecord2, hasChildRecordThat(allOf(hasEntityType(AuditedChild2Type.INSTANCE.getName()),
                                                           hasEntityId(String.valueOf(CHILD_ID_21)),
                                                           hasOperator(UPDATE))));
@@ -650,10 +650,5 @@ public class AuditForUpsertTwoLevelsTest {
                          .fetchOptional()
                          .map(rec -> rec.get(child_table.id))
                          .orElseThrow(() -> new IllegalStateException("Could not fetch child id by name '" + childName + "'"));
-    }
-
-    @SuppressWarnings("unchecked")
-    private <E extends EntityType<E>> AuditRecord<E> typed(final AuditRecord<?> auditRecord) {
-        return (AuditRecord<E>) auditRecord;
     }
 }

--- a/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditWithNameOverridesTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditWithNameOverridesTest.java
@@ -67,7 +67,7 @@ public class AuditWithNameOverridesTest {
     public void overrideNameInStandalone() {
         pl.create(singletonList(parentCreateCmd()), flowConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));
@@ -81,7 +81,7 @@ public class AuditWithNameOverridesTest {
                                           .with(child2CreateCmd())),
                   flowConfig);
 
-        final List<? extends AuditRecord<?>> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
         assertThat("Incorrect number of published records",
                    auditRecords, hasSize(1));

--- a/integration-tests/src/test/java/com/kenshoo/pl/audit/InMemoryAuditRecordPublisher.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/audit/InMemoryAuditRecordPublisher.java
@@ -11,16 +11,16 @@ import static java.util.stream.Collectors.toList;
 
 class InMemoryAuditRecordPublisher implements AuditRecordPublisher {
 
-    private final List<AuditRecord<?>> auditRecords = new ArrayList<>();
+    private final List<AuditRecord> auditRecords = new ArrayList<>();
 
     @Override
-    public void publish(Stream<? extends AuditRecord<?>> auditRecords) {
+    public void publish(Stream<? extends AuditRecord> auditRecords) {
         if (auditRecords != null) {
             this.auditRecords.addAll(auditRecords.collect(toList()));
         }
     }
 
-    public Stream<? extends AuditRecord<?>> getAuditRecords() {
+    public Stream<? extends AuditRecord> getAuditRecords() {
         return auditRecords.stream();
     }
 }

--- a/main/src/main/java/com/kenshoo/pl/entity/PersistenceLayer.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/PersistenceLayer.java
@@ -4,7 +4,10 @@ import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.kenshoo.pl.entity.audit.AuditRecord;
-import com.kenshoo.pl.entity.internal.*;
+import com.kenshoo.pl.entity.internal.ChangesFilter;
+import com.kenshoo.pl.entity.internal.EntitiesFetcher;
+import com.kenshoo.pl.entity.internal.EntitiesToContextFetcher;
+import com.kenshoo.pl.entity.internal.RequiredFieldsChangesFilter;
 import com.kenshoo.pl.entity.internal.audit.RecursiveAuditRecordGenerator;
 import com.kenshoo.pl.entity.internal.validators.ValidationFilter;
 import com.kenshoo.pl.entity.spi.CurrentStateConsumer;
@@ -122,7 +125,7 @@ public class PersistenceLayer<ROOT extends EntityType<ROOT>> {
         if (!validCmds.isEmpty()) {
             flowConfig.retryer().run((() -> dslContext().transaction((configuration) -> generateOutputRecursive(flowConfig, validCmds, overridingCtx))));
         }
-        final Stream<? extends AuditRecord<ROOT>> auditRecords =
+        final Stream<? extends AuditRecord> auditRecords =
             recursiveAuditRecordGenerator.generateMany(flowConfig,
                                                        validCmds.stream(),
                                                        overridingCtx);

--- a/main/src/main/java/com/kenshoo/pl/entity/audit/AuditRecord.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/audit/AuditRecord.java
@@ -1,32 +1,31 @@
 package com.kenshoo.pl.entity.audit;
 
 import com.kenshoo.pl.entity.ChangeOperation;
-import com.kenshoo.pl.entity.EntityFieldValue;
-import com.kenshoo.pl.entity.EntityType;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
 import java.util.Collection;
+import java.util.Map.Entry;
 
 import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
-public class AuditRecord<E extends EntityType<E>> {
+public class AuditRecord {
     private final String entityType;
     private final String entityId;
-    private final Collection<? extends EntityFieldValue> mandatoryFieldValues;
+    private final Collection<? extends Entry<String, ?>> mandatoryFieldValues;
     private final ChangeOperation operator;
-    private final Collection<? extends FieldAuditRecord<E>> fieldRecords;
-    private final Collection<? extends AuditRecord<?>> childRecords;
+    private final Collection<? extends FieldAuditRecord> fieldRecords;
+    private final Collection<? extends AuditRecord> childRecords;
 
     private AuditRecord(final String entityType,
                         final String entityId,
-                        final Collection<? extends EntityFieldValue> mandatoryFieldValues,
+                        final Collection<? extends Entry<String, ?>> mandatoryFieldValues,
                         final ChangeOperation operator,
-                        final Collection<? extends FieldAuditRecord<E>> fieldRecords,
-                        final Collection<? extends AuditRecord<?>> childRecords) {
+                        final Collection<? extends FieldAuditRecord> fieldRecords,
+                        final Collection<? extends AuditRecord> childRecords) {
         this.entityType = requireNonNull(entityType, "entityType is required");
         this.entityId = requireNonNull(entityId, "entityId is required");
         this.mandatoryFieldValues = mandatoryFieldValues;
@@ -43,7 +42,7 @@ public class AuditRecord<E extends EntityType<E>> {
         return entityId;
     }
 
-    public Collection<? extends EntityFieldValue> getMandatoryFieldValues() {
+    public Collection<? extends Entry<String, ?>> getMandatoryFieldValues() {
         return mandatoryFieldValues;
     }
 
@@ -51,11 +50,11 @@ public class AuditRecord<E extends EntityType<E>> {
         return operator;
     }
 
-    public Collection<? extends FieldAuditRecord<E>> getFieldRecords() {
+    public Collection<? extends FieldAuditRecord> getFieldRecords() {
         return fieldRecords;
     }
 
-    public Collection<? extends AuditRecord<?>> getChildRecords() {
+    public Collection<? extends AuditRecord> getChildRecords() {
         return childRecords;
     }
 
@@ -97,51 +96,51 @@ public class AuditRecord<E extends EntityType<E>> {
             .toString();
     }
 
-    public static class Builder<E extends EntityType<E>> {
+    public static class Builder {
         private String entityType;
         private String entityId;
-        private Collection<? extends EntityFieldValue> mandatoryFieldValues = emptyList();
+        private Collection<? extends Entry<String, ?>> mandatoryFieldValues = emptyList();
         private ChangeOperation operator;
-        private Collection<? extends FieldAuditRecord<E>> fieldRecords = emptyList();
-        private Collection<? extends AuditRecord<?>> childRecords = emptyList();
+        private Collection<? extends FieldAuditRecord> fieldRecords = emptyList();
+        private Collection<? extends AuditRecord> childRecords = emptyList();
 
-        public Builder<E> withEntityType(String entityType) {
+        public Builder withEntityType(String entityType) {
             this.entityType = entityType;
             return this;
         }
 
-        public Builder<E> withEntityId(String entityId) {
+        public Builder withEntityId(String entityId) {
             this.entityId = entityId;
             return this;
         }
 
-        public Builder<E> withOperator(ChangeOperation operator) {
+        public Builder withOperator(ChangeOperation operator) {
             this.operator = operator;
             return this;
         }
 
-        public Builder<E> withMandatoryFieldValues(final Collection<? extends EntityFieldValue> fieldValues) {
+        public Builder withMandatoryFieldValues(final Collection<? extends Entry<String, ?>> fieldValues) {
             this.mandatoryFieldValues = fieldValues == null ? emptyList() : fieldValues;
             return this;
         }
 
-        public Builder<E> withFieldRecords(Collection<? extends FieldAuditRecord<E>> fieldRecords) {
+        public Builder withFieldRecords(Collection<? extends FieldAuditRecord> fieldRecords) {
             this.fieldRecords = fieldRecords == null ? emptyList() : fieldRecords;
             return this;
         }
 
-        public Builder<E> withChildRecords(Collection<? extends AuditRecord<?>> childRecords) {
+        public Builder withChildRecords(Collection<? extends AuditRecord> childRecords) {
             this.childRecords = childRecords == null ? emptyList() : childRecords;
             return this;
         }
 
-        public AuditRecord<E> build() {
-            return new AuditRecord<>(entityType,
-                                     entityId,
-                                     mandatoryFieldValues,
-                                     operator,
-                                     fieldRecords,
-                                     childRecords);
+        public AuditRecord build() {
+            return new AuditRecord(entityType,
+                                   entityId,
+                                   mandatoryFieldValues,
+                                   operator,
+                                   fieldRecords,
+                                   childRecords);
         }
     }
 }

--- a/main/src/main/java/com/kenshoo/pl/entity/audit/FieldAuditRecord.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/audit/FieldAuditRecord.java
@@ -1,7 +1,6 @@
 package com.kenshoo.pl.entity.audit;
 
 import com.kenshoo.pl.entity.EntityField;
-import com.kenshoo.pl.entity.EntityType;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -11,12 +10,12 @@ import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
-public class FieldAuditRecord<E extends EntityType<E>> {
-    private final EntityField<E, ?> field;
+public class FieldAuditRecord {
+    private final String field;
     private final Object oldValue;
     private final Object newValue;
 
-    private FieldAuditRecord(final EntityField<E, ?> field,
+    private FieldAuditRecord(final String field,
                              final Object oldValue,
                              final Object newValue) {
         this.field = field;
@@ -24,7 +23,7 @@ public class FieldAuditRecord<E extends EntityType<E>> {
         this.newValue = newValue;
     }
 
-    public EntityField<E, ?> getField() {
+    public String getField() {
         return field;
     }
 
@@ -36,8 +35,12 @@ public class FieldAuditRecord<E extends EntityType<E>> {
         return Optional.ofNullable(newValue);
     }
 
-    public static <E extends EntityType<E>> Builder<E> builder(final EntityField<E, ?> field) {
-        return new Builder<>(field);
+    public static Builder builder(final EntityField<?, ?> field) {
+        return new Builder(field.toString());
+    }
+
+    public static Builder builder(final String field) {
+        return new Builder(field);
     }
 
     @Override
@@ -46,8 +49,7 @@ public class FieldAuditRecord<E extends EntityType<E>> {
 
         if (o == null || getClass() != o.getClass()) return false;
 
-        @SuppressWarnings("unchecked")
-        final FieldAuditRecord<E> that = (FieldAuditRecord<E>) o;
+        final FieldAuditRecord that = (FieldAuditRecord) o;
 
         return new EqualsBuilder()
             .append(field, that.field)
@@ -68,33 +70,33 @@ public class FieldAuditRecord<E extends EntityType<E>> {
     @Override
     public String toString() {
         return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
-            .append("field", field.getEntityType().getName() + "." + field)
+            .append("field", field)
             .append("oldValue", oldValue)
             .append("newValue", newValue)
             .toString();
     }
 
-    public static class Builder<E extends EntityType<E>> {
-        private final EntityField<E, ?> field;
+    public static class Builder {
+        private final String field;
         private Object oldValue;
         private Object newValue;
 
-        private Builder(final EntityField<E, ?> field) {
+        private Builder(final String field) {
             this.field = requireNonNull(field, "A field is required");
         }
 
-        public Builder<E> oldValue(Object oldValue) {
+        public Builder oldValue(Object oldValue) {
             this.oldValue = oldValue;
             return this;
         }
 
-        public Builder<E> newValue(Object newValue) {
+        public Builder newValue(Object newValue) {
             this.newValue = newValue;
             return this;
         }
 
-        public FieldAuditRecord<E> build() {
-            return new FieldAuditRecord<>(field, oldValue, newValue);
+        public FieldAuditRecord build() {
+            return new FieldAuditRecord(field, oldValue, newValue);
         }
     }
 }

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditFieldChangeGenerator.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditFieldChangeGenerator.java
@@ -12,9 +12,9 @@ import static java.util.Objects.requireNonNull;
 
 public class AuditFieldChangeGenerator {
 
-    <E extends EntityType<E>> Optional<FieldAuditRecord<E>> generate(final CurrentEntityState currentState,
-                                                                     final FinalEntityState finalState,
-                                                                     final EntityField<E, ?> field) {
+    <E extends EntityType<E>> Optional<FieldAuditRecord> generate(final CurrentEntityState currentState,
+                                                                  final FinalEntityState finalState,
+                                                                  final EntityField<E, ?> field) {
         requireNonNull(currentState, "A current state is required");
         requireNonNull(finalState, "A final state is required");
         requireNonNull(field, "A field is required");
@@ -36,10 +36,10 @@ public class AuditFieldChangeGenerator {
         return currentState.safeGet(field).equals(finalState.safeGet(field), field::valuesEqual);
     }
 
-    private <E extends EntityType<E>> FieldAuditRecord<E> buildFieldRecord(final CurrentEntityState currentState,
-                                                                           final FinalEntityState finalState,
-                                                                           final EntityField<E, ?> field) {
-        final FieldAuditRecord.Builder<E> fieldRecordBuilder = FieldAuditRecord.builder(field);
+    private <E extends EntityType<E>> FieldAuditRecord buildFieldRecord(final CurrentEntityState currentState,
+                                                                        final FinalEntityState finalState,
+                                                                        final EntityField<E, ?> field) {
+        final FieldAuditRecord.Builder fieldRecordBuilder = FieldAuditRecord.builder(field.toString());
         currentState.safeGet(field).ifNotNull(fieldRecordBuilder::oldValue);
         finalState.safeGet(field).ifNotNull(fieldRecordBuilder::newValue);
         return fieldRecordBuilder.build();

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditFieldChangesGenerator.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditFieldChangesGenerator.java
@@ -32,8 +32,8 @@ public class AuditFieldChangesGenerator<E extends EntityType<E>> {
         this.singleGenerator = singleGenerator;
     }
 
-    Collection<FieldAuditRecord<E>> generate(final CurrentEntityState currentState,
-                                             final FinalEntityState finalState) {
+    Collection<FieldAuditRecord> generate(final CurrentEntityState currentState,
+                                          final FinalEntityState finalState) {
         return seq(onChangeFields)
             .map(field -> singleGenerator.generate(currentState, finalState, field))
             .filter(Optional::isPresent)

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditMandatoryFieldValuesGenerator.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditMandatoryFieldValuesGenerator.java
@@ -1,13 +1,14 @@
 package com.kenshoo.pl.entity.internal.audit;
 
 import com.kenshoo.pl.entity.EntityField;
-import com.kenshoo.pl.entity.EntityFieldValue;
 import com.kenshoo.pl.entity.FinalEntityState;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
 import java.util.Collection;
+import java.util.Map.Entry;
 import java.util.stream.Stream;
 
+import static java.util.Map.entry;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 import static org.jooq.lambda.Seq.seq;
@@ -21,12 +22,12 @@ public class AuditMandatoryFieldValuesGenerator {
         this.mandatoryFields = mandatoryFields.collect(toList());
     }
 
-    Collection<EntityFieldValue> generate(final FinalEntityState finalState) {
+    Collection<Entry<String, ?>> generate(final FinalEntityState finalState) {
         requireNonNull(finalState, "finalState is required");
         return seq(mandatoryFields)
             .map(field -> ImmutablePair.of(field, finalState.safeGet(field)))
             .filter(pair -> pair.getValue().isNotNull())
-            .map(pair -> new EntityFieldValue(pair.getKey(), pair.getValue().get()))
+            .map(pair -> entry(pair.getKey().toString(), pair.getValue().get()))
             .collect(toList());
     }
 }

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGenerator.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGenerator.java
@@ -10,9 +10,9 @@ import java.util.Collection;
 import java.util.Optional;
 
 public interface AuditRecordGenerator<E extends EntityType<E>> {
-    Optional<AuditRecord<E>> generate(EntityChange<E> entityChange,
-                                      ChangeContext context,
-                                      Collection<? extends AuditRecord<?>> childRecords);
+    Optional<AuditRecord> generate(EntityChange<E> entityChange,
+                                   ChangeContext context,
+                                   Collection<? extends AuditRecord> childRecords);
 
     @VisibleForTesting
     String getEntityTypeName();

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorImpl.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorImpl.java
@@ -7,6 +7,7 @@ import com.kenshoo.pl.entity.audit.FieldAuditRecord;
 import com.kenshoo.pl.entity.internal.EntityIdExtractor;
 
 import java.util.Collection;
+import java.util.Map.Entry;
 import java.util.Optional;
 
 import static com.kenshoo.pl.entity.ChangeOperation.UPDATE;
@@ -40,14 +41,14 @@ public class AuditRecordGeneratorImpl<E extends EntityType<E>> implements AuditR
     }
 
     @Override
-    public Optional<AuditRecord<E>> generate(final EntityChange<E> entityChange,
-                                             final ChangeContext context,
-                                             final Collection<? extends AuditRecord<?>> childRecords) {
+    public Optional<AuditRecord> generate(final EntityChange<E> entityChange,
+                                          final ChangeContext context,
+                                          final Collection<? extends AuditRecord> childRecords) {
         requireNonNull(entityChange, "entityChange is required");
 
-        final AuditRecord<E> auditRecord = generateInner(entityChange,
-                                                         context,
-                                                         childRecords);
+        final AuditRecord auditRecord = generateInner(entityChange,
+                                                      context,
+                                                      childRecords);
 
         if (entityChange.getChangeOperation() == UPDATE && auditRecord.hasNoChanges()) {
             return Optional.empty();
@@ -55,9 +56,9 @@ public class AuditRecordGeneratorImpl<E extends EntityType<E>> implements AuditR
         return Optional.of(auditRecord);
     }
 
-    private AuditRecord<E> generateInner(final EntityChange<E> entityChange,
-                                         final ChangeContext context,
-                                         final Collection<? extends AuditRecord<?>> childRecords) {
+    private AuditRecord generateInner(final EntityChange<E> entityChange,
+                                      final ChangeContext context,
+                                      final Collection<? extends AuditRecord> childRecords) {
         requireNonNull(context, "context is required");
 
         final CurrentEntityState currentState = context.getEntity(entityChange);
@@ -65,11 +66,11 @@ public class AuditRecordGeneratorImpl<E extends EntityType<E>> implements AuditR
 
         final String entityId = extractEntityId(entityChange, currentState);
 
-        final Collection<EntityFieldValue> mandatoryFieldValues = mandatoryFieldValuesGenerator.generate(finalState);
+        final Collection<? extends Entry<String, ?>> mandatoryFieldValues = mandatoryFieldValuesGenerator.generate(finalState);
 
-        final Collection<FieldAuditRecord<E>> fieldRecords = fieldChangesGenerator.generate(currentState, finalState);
+        final Collection<FieldAuditRecord> fieldRecords = fieldChangesGenerator.generate(currentState, finalState);
 
-        return new AuditRecord.Builder<E>()
+        return new AuditRecord.Builder()
             .withEntityType(entityTypeName)
             .withEntityId(entityId)
             .withMandatoryFieldValues(mandatoryFieldValues)

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/audit/RecursiveAuditRecordGenerator.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/audit/RecursiveAuditRecordGenerator.java
@@ -14,40 +14,40 @@ import static java.util.stream.Collectors.toList;
 
 public class RecursiveAuditRecordGenerator {
 
-    public <E extends EntityType<E>> Stream<? extends AuditRecord<E>> generateMany(
+    public <E extends EntityType<E>> Stream<? extends AuditRecord> generateMany(
         final ChangeFlowConfig<E> flowConfig,
         final Stream<? extends EntityChange<E>> entityChanges,
         final ChangeContext changeContext) {
 
         return flowConfig.auditRecordGenerator()
-                         .map(auditRecordGenerator -> this.<E>generateMany(flowConfig,
-                                                                           auditRecordGenerator,
-                                                                           entityChanges,
-                                                                           changeContext))
+                         .map(auditRecordGenerator -> this.generateMany(flowConfig,
+                                                                        auditRecordGenerator,
+                                                                        entityChanges,
+                                                                        changeContext))
                          .orElse(Stream.empty());
     }
 
-    private <E extends EntityType<E>> Stream<? extends AuditRecord<E>> generateMany(
+    private <E extends EntityType<E>> Stream<? extends AuditRecord> generateMany(
         final ChangeFlowConfig<E> flowConfig,
         final AuditRecordGenerator<E> auditRecordGenerator,
         final Stream<? extends EntityChange<E>> entityChanges,
         final ChangeContext changeContext) {
 
-        return entityChanges.map(entityChange -> this.<E>generateOne(flowConfig,
-                                                                     auditRecordGenerator,
-                                                                     entityChange,
-                                                                     changeContext))
+        return entityChanges.map(entityChange -> this.generateOne(flowConfig,
+                                                                  auditRecordGenerator,
+                                                                  entityChange,
+                                                                  changeContext))
                             .filter(Optional::isPresent)
                             .map(Optional::get);
     }
 
-    private <E extends EntityType<E>> Optional<? extends AuditRecord<E>> generateOne(
+    private <E extends EntityType<E>> Optional<? extends AuditRecord> generateOne(
         final ChangeFlowConfig<E> flowConfig,
         final AuditRecordGenerator<E> auditRecordGenerator,
         final EntityChange<E> entityChange,
         final ChangeContext changeContext) {
 
-        final Collection<? extends AuditRecord<?>> childAuditRecords =
+        final Collection<? extends AuditRecord> childAuditRecords =
             flowConfig.childFlows().stream()
                       .flatMap(childFlowConfig -> generateChildrenUntyped(childFlowConfig,
                                                                           entityChange,
@@ -59,7 +59,7 @@ public class RecursiveAuditRecordGenerator {
                                              childAuditRecords);
     }
 
-    private <E extends EntityType<E>> Stream<? extends AuditRecord<? extends EntityType<?>>> generateChildrenUntyped(
+    private <E extends EntityType<E>> Stream<? extends AuditRecord> generateChildrenUntyped(
         final ChangeFlowConfig<? extends EntityType<?>> childFlowConfig,
         final EntityChange<E> entityChange,
         final ChangeContext changeContext) {
@@ -69,7 +69,7 @@ public class RecursiveAuditRecordGenerator {
                                      changeContext);
     }
 
-    private <P extends EntityType<P>, C extends EntityType<C>> Stream<? extends AuditRecord<C>> generateChildrenTyped(
+    private <P extends EntityType<P>, C extends EntityType<C>> Stream<? extends AuditRecord> generateChildrenTyped(
         final ChangeFlowConfig<C> childFlowConfig,
         final EntityChange<P> entityChange,
         final ChangeContext changeContext) {

--- a/main/src/main/java/com/kenshoo/pl/entity/spi/audit/AuditRecordPublisher.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/spi/audit/AuditRecordPublisher.java
@@ -9,5 +9,5 @@ public interface AuditRecordPublisher {
     // Default implementation in case the client does not provide a publisher
     AuditRecordPublisher NO_OP = auditRecords -> {};
 
-    void publish(final Stream<? extends AuditRecord<?>> auditRecords);
+    void publish(final Stream<? extends AuditRecord> auditRecords);
 }

--- a/main/src/test/java/com/kenshoo/pl/entity/AuditRecordTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/AuditRecordTest.java
@@ -20,18 +20,18 @@ public class AuditRecordTest {
     private static final String ENTITY_ID_1 = "123";
     private static final String ENTITY_ID_2 = "456";
 
-    private static final FieldAuditRecord<AuditedType> NAME_FIELD_RECORD =
+    private static final FieldAuditRecord NAME_FIELD_RECORD =
         FieldAuditRecord.builder(AuditedType.NAME)
                         .newValue("name")
                         .build();
 
     @Mock
-    private AuditRecord<?> childRecord;
+    private AuditRecord childRecord;
 
     @Test
     public void hasNoChanges_WithFieldRecords_WithChildRecords_ShouldReturnFalse() {
-        final AuditRecord<AuditedType> auditRecord =
-            new AuditRecord.Builder<AuditedType>()
+        final AuditRecord auditRecord =
+            new AuditRecord.Builder()
                 .withEntityType(ENTITY_TYPE)
                 .withEntityId(ENTITY_ID_1)
                 .withOperator(CREATE)
@@ -44,8 +44,8 @@ public class AuditRecordTest {
 
     @Test
     public void hasNoChanges_WithFieldRecords_WithoutChildRecords_ShouldReturnFalse() {
-        final AuditRecord<AuditedType> auditRecord =
-            new AuditRecord.Builder<AuditedType>()
+        final AuditRecord auditRecord =
+            new AuditRecord.Builder()
                 .withEntityType(ENTITY_TYPE)
                 .withEntityId(ENTITY_ID_1)
                 .withOperator(CREATE)
@@ -57,8 +57,8 @@ public class AuditRecordTest {
 
     @Test
     public void hasNoChanges_WithoutFieldRecords_WithChildRecords_ShouldReturnFalse() {
-        final AuditRecord<AuditedType> auditRecord =
-            new AuditRecord.Builder<AuditedType>()
+        final AuditRecord auditRecord =
+            new AuditRecord.Builder()
                 .withEntityType(ENTITY_TYPE)
                 .withEntityId(ENTITY_ID_1)
                 .withOperator(CREATE)
@@ -70,8 +70,8 @@ public class AuditRecordTest {
 
     @Test
     public void hasNoChanges_WithoutFieldRecords_WithoutChildRecords_ShouldReturnTrue() {
-        final AuditRecord<AuditedType> auditRecord =
-            new AuditRecord.Builder<AuditedType>()
+        final AuditRecord auditRecord =
+            new AuditRecord.Builder()
                 .withEntityType(ENTITY_TYPE)
                 .withEntityId(ENTITY_ID_1)
                 .withOperator(CREATE)
@@ -83,7 +83,7 @@ public class AuditRecordTest {
     @Test
     public void testToString_UnlimitedDepth_OneLevel() {
         final String auditRecordStr =
-            new AuditRecord.Builder<AuditedType>()
+            new AuditRecord.Builder()
                 .withEntityType(ENTITY_TYPE)
                 .withEntityId(ENTITY_ID_1)
                 .withOperator(CREATE)
@@ -97,11 +97,11 @@ public class AuditRecordTest {
     @Test
     public void testToString_UnlimitedDepth_TwoLevels() {
         final String auditRecordStr =
-            new AuditRecord.Builder<AuditedType>()
+            new AuditRecord.Builder()
                 .withEntityType(ENTITY_TYPE)
                 .withEntityId(ENTITY_ID_1)
                 .withOperator(CREATE)
-                .withChildRecords(singletonList(new AuditRecord.Builder<AuditedType>()
+                .withChildRecords(singletonList(new AuditRecord.Builder()
                                                     .withEntityType(ENTITY_TYPE)
                                                     .withEntityId(ENTITY_ID_2)
                                                     .withOperator(CREATE)
@@ -118,11 +118,11 @@ public class AuditRecordTest {
     @Test
     public void testToString_MaxDepthOne_OneLevel() {
         final String auditRecordStr =
-            new AuditRecord.Builder<AuditedType>()
+            new AuditRecord.Builder()
                 .withEntityType(ENTITY_TYPE)
                 .withEntityId(ENTITY_ID_1)
                 .withOperator(CREATE)
-                .withChildRecords(singletonList(new AuditRecord.Builder<AuditedType>()
+                .withChildRecords(singletonList(new AuditRecord.Builder()
                                                     .withEntityType(ENTITY_TYPE)
                                                     .withEntityId(ENTITY_ID_2)
                                                     .withOperator(CREATE)
@@ -139,7 +139,7 @@ public class AuditRecordTest {
     @Test
     public void testToString_MaxDepthOne_TwoLevels() {
         final String auditRecordStr =
-            new AuditRecord.Builder<AuditedType>()
+            new AuditRecord.Builder()
                 .withEntityType(ENTITY_TYPE)
                 .withEntityId(ENTITY_ID_1)
                 .withOperator(CREATE)
@@ -153,7 +153,7 @@ public class AuditRecordTest {
     @Test
     public void testToString_MaxDepthZero_ReturnsEmptyString() {
         final String auditRecordStr =
-            new AuditRecord.Builder<AuditedType>()
+            new AuditRecord.Builder()
                 .withEntityType(ENTITY_TYPE)
                 .withEntityId(ENTITY_ID_1)
                 .withOperator(CREATE)

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditFieldChangeGeneratorTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditFieldChangeGeneratorTest.java
@@ -131,7 +131,7 @@ public class AuditFieldChangeGeneratorTest {
         assertThat(generate(NAME), isEmpty());
     }
 
-    private Optional<? extends FieldAuditRecord<AuditedType>> generate(final EntityField<AuditedType, ?> field) {
+    private Optional<? extends FieldAuditRecord> generate(final EntityField<AuditedType, ?> field) {
         return generator.generate(currentState, finalState, field);
     }
 }

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditFieldChangesGeneratorTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditFieldChangesGeneratorTest.java
@@ -41,7 +41,7 @@ public class AuditFieldChangesGeneratorTest {
 
     @Test
     public void generate_twoFields_BothGenerated_ShouldReturnBothFieldChanges() {
-        final List<FieldAuditRecord<AuditedType>> expectedFieldChanges = ImmutableList.of(mockFieldChange(), mockFieldChange());
+        final List<FieldAuditRecord> expectedFieldChanges = ImmutableList.of(mockFieldChange(), mockFieldChange());
 
         Seq.of(AuditedType.NAME, AuditedType.DESC)
            .zipWithIndex()
@@ -50,10 +50,10 @@ public class AuditFieldChangesGeneratorTest {
                             .thenReturn(Optional.of(expectedFieldChanges.get(fieldWithIdx.v2.intValue())))
                    );
 
-        final Collection<FieldAuditRecord<AuditedType>> actualFieldChanges =
+        final Collection<FieldAuditRecord> actualFieldChanges =
             newGenerator(Stream.of(AuditedType.NAME, AuditedType.DESC)).generate(currentState, finalState);
 
-        final List<FieldAuditRecord<AuditedType>> sortedActualFieldChanges =
+        final List<FieldAuditRecord> sortedActualFieldChanges =
             actualFieldChanges.stream()
                               .sorted(Comparator.comparing(expectedFieldChanges::indexOf))
                               .collect(toList());
@@ -63,12 +63,12 @@ public class AuditFieldChangesGeneratorTest {
 
     @Test
     public void generate_twoFields_OnlyFirstGenerated_ShouldReturnFirstFieldChange() {
-        final FieldAuditRecord<AuditedType> expectedFieldChange = mockFieldChange();
+        final FieldAuditRecord expectedFieldChange = mockFieldChange();
 
         when(singleGenerator.generate(currentState, finalState, AuditedType.NAME)).thenReturn(Optional.of(expectedFieldChange));
         when(singleGenerator.generate(currentState, finalState, AuditedType.DESC)).thenReturn(Optional.empty());
 
-        final Collection<FieldAuditRecord<AuditedType>> actualFieldChanges =
+        final Collection<FieldAuditRecord> actualFieldChanges =
             newGenerator(Stream.of(AuditedType.NAME, AuditedType.DESC)).generate(currentState, finalState);
 
         assertThat(ImmutableSet.copyOf(actualFieldChanges), is(singleton(expectedFieldChange)));
@@ -76,12 +76,12 @@ public class AuditFieldChangesGeneratorTest {
 
     @Test
     public void generate_twoFields_OnlySecondGenerated_ShouldReturnSecondFieldChange() {
-        final FieldAuditRecord<AuditedType> expectedFieldChange = mockFieldChange();
+        final FieldAuditRecord expectedFieldChange = mockFieldChange();
 
         when(singleGenerator.generate(currentState, finalState, AuditedType.NAME)).thenReturn(Optional.empty());
         when(singleGenerator.generate(currentState, finalState, AuditedType.DESC)).thenReturn(Optional.of(expectedFieldChange));
 
-        final Collection<FieldAuditRecord<AuditedType>> actualFieldChanges =
+        final Collection<FieldAuditRecord> actualFieldChanges =
             newGenerator(Stream.of(AuditedType.NAME, AuditedType.DESC)).generate(currentState, finalState);
 
         assertThat(ImmutableSet.copyOf(actualFieldChanges), is(singleton(expectedFieldChange)));
@@ -92,7 +92,7 @@ public class AuditFieldChangesGeneratorTest {
         when(singleGenerator.generate(currentState, finalState, AuditedType.NAME)).thenReturn(Optional.empty());
         when(singleGenerator.generate(currentState, finalState, AuditedType.DESC)).thenReturn(Optional.empty());
 
-        final Collection<FieldAuditRecord<AuditedType>> actualFieldChanges =
+        final Collection<FieldAuditRecord> actualFieldChanges =
             newGenerator(Stream.of(AuditedType.NAME, AuditedType.DESC)).generate(currentState, finalState);
 
         assertThat(actualFieldChanges, empty());
@@ -100,7 +100,7 @@ public class AuditFieldChangesGeneratorTest {
 
     @Test
     public void generate_noFields_ShouldReturnEmpty() {
-        final Collection<FieldAuditRecord<AuditedType>> actualFieldChanges =
+        final Collection<FieldAuditRecord> actualFieldChanges =
             newGenerator(Stream.empty()).generate(currentState, finalState);
 
         assertThat(actualFieldChanges, empty());
@@ -110,8 +110,7 @@ public class AuditFieldChangesGeneratorTest {
         return new AuditFieldChangesGenerator<>(onChangeFields, singleGenerator);
     }
 
-    @SuppressWarnings("unchecked")
-    private FieldAuditRecord<AuditedType> mockFieldChange() {
+    private FieldAuditRecord mockFieldChange() {
         return mock(FieldAuditRecord.class);
     }
 }

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditMandatoryFieldValuesGeneratorTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditMandatoryFieldValuesGeneratorTest.java
@@ -2,7 +2,6 @@ package com.kenshoo.pl.entity.internal.audit;
 
 import com.google.common.collect.ImmutableSet;
 import com.kenshoo.pl.entity.EntityField;
-import com.kenshoo.pl.entity.EntityFieldValue;
 import com.kenshoo.pl.entity.FinalEntityState;
 import com.kenshoo.pl.entity.Triptional;
 import com.kenshoo.pl.entity.internal.audit.entitytypes.NotAuditedAncestorType;
@@ -12,10 +11,12 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Collection;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Stream;
 
 import static java.util.Collections.singleton;
+import static java.util.Map.entry;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.junit.Assert.assertThat;
@@ -38,10 +39,10 @@ public class AuditMandatoryFieldValuesGeneratorTest {
         final AuditMandatoryFieldValuesGenerator generator = newGenerator(Stream.of(NotAuditedAncestorType.NAME,
                                                                                     NotAuditedAncestorType.DESC));
 
-        final Collection<? extends EntityFieldValue> actualFieldValues = generator.generate(finalState);
+        final Collection<? extends Entry<String, ?>> actualFieldValues = generator.generate(finalState);
 
-        final Set<EntityFieldValue> expectedFieldValues = ImmutableSet.of(new EntityFieldValue(NotAuditedAncestorType.NAME, ANCESTOR_NAME),
-                                                                          new EntityFieldValue(NotAuditedAncestorType.DESC, ANCESTOR_DESC));
+        final Set<Entry<String, ?>> expectedFieldValues = Set.of(entry(NotAuditedAncestorType.NAME.toString(), ANCESTOR_NAME),
+                                                                 entry(NotAuditedAncestorType.DESC.toString(), ANCESTOR_DESC));
 
         assertThat(ImmutableSet.copyOf(actualFieldValues), is(expectedFieldValues));
     }
@@ -54,7 +55,7 @@ public class AuditMandatoryFieldValuesGeneratorTest {
         final AuditMandatoryFieldValuesGenerator generator = newGenerator(Stream.of(NotAuditedAncestorType.NAME,
                                                                                     NotAuditedAncestorType.DESC));
 
-        final Collection<? extends EntityFieldValue> actualFieldValues = generator.generate(finalState);
+        final Collection<? extends Entry<String, ?>> actualFieldValues = generator.generate(finalState);
 
         assertThat(ImmutableSet.copyOf(actualFieldValues), is(empty()));
     }
@@ -67,7 +68,7 @@ public class AuditMandatoryFieldValuesGeneratorTest {
         final AuditMandatoryFieldValuesGenerator generator = newGenerator(Stream.of(NotAuditedAncestorType.NAME,
                                                                                     NotAuditedAncestorType.DESC));
 
-        final Collection<? extends EntityFieldValue> actualFieldValues = generator.generate(finalState);
+        final Collection<? extends Entry<String, ?>> actualFieldValues = generator.generate(finalState);
 
         assertThat(ImmutableSet.copyOf(actualFieldValues), is(empty()));
     }
@@ -81,9 +82,9 @@ public class AuditMandatoryFieldValuesGeneratorTest {
                                                                                     NotAuditedAncestorType.DESC));
 
 
-        final Set<EntityFieldValue> expectedFieldValues = singleton(new EntityFieldValue(NotAuditedAncestorType.NAME, ANCESTOR_NAME));
+        final Set<Entry<String, ?>> expectedFieldValues = singleton(entry(NotAuditedAncestorType.NAME.toString(), ANCESTOR_NAME));
 
-        final Collection<? extends EntityFieldValue> actualFieldValues = generator.generate(finalState);
+        final Collection<? extends Entry<String, ?>> actualFieldValues = generator.generate(finalState);
 
         assertThat(ImmutableSet.copyOf(actualFieldValues), is(expectedFieldValues));
     }
@@ -97,9 +98,9 @@ public class AuditMandatoryFieldValuesGeneratorTest {
                                                                                     NotAuditedAncestorType.DESC));
 
 
-        final Set<EntityFieldValue> expectedFieldValues = singleton(new EntityFieldValue(NotAuditedAncestorType.DESC, ANCESTOR_DESC));
+        final Set<Entry<String, ?>> expectedFieldValues = singleton(entry(NotAuditedAncestorType.DESC.toString(), ANCESTOR_DESC));
 
-        final Collection<? extends EntityFieldValue> actualFieldValues = generator.generate(finalState);
+        final Collection<? extends Entry<String, ?>> actualFieldValues = generator.generate(finalState);
 
         assertThat(ImmutableSet.copyOf(actualFieldValues), is(expectedFieldValues));
     }

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorImplForCreateTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorImplForCreateTest.java
@@ -1,7 +1,10 @@
 package com.kenshoo.pl.entity.internal.audit;
 
 import com.google.common.collect.ImmutableList;
-import com.kenshoo.pl.entity.*;
+import com.kenshoo.pl.entity.ChangeContext;
+import com.kenshoo.pl.entity.CurrentEntityState;
+import com.kenshoo.pl.entity.EntityChange;
+import com.kenshoo.pl.entity.FinalEntityState;
 import com.kenshoo.pl.entity.audit.AuditRecord;
 import com.kenshoo.pl.entity.audit.FieldAuditRecord;
 import com.kenshoo.pl.entity.internal.EntityIdExtractor;
@@ -15,12 +18,14 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map.Entry;
 import java.util.Optional;
 
 import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresentAnd;
 import static com.kenshoo.pl.entity.ChangeOperation.CREATE;
 import static com.kenshoo.pl.entity.matchers.audit.AuditRecordMatchers.*;
 import static java.util.Collections.emptyList;
+import static java.util.Map.entry;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
@@ -78,7 +83,7 @@ public class AuditRecordGeneratorImplForCreateTest {
         when(mandatoryFieldValuesGenerator.generate(finalState)).thenReturn(emptyList());
         when(fieldChangesGenerator.generate(currentState, finalState)).thenReturn(emptyList());
 
-        final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
+        final Optional<? extends AuditRecord> actualOptionalAuditRecord =
             auditRecordGenerator.generate(cmd, changeContext, emptyList());
 
         assertThat(actualOptionalAuditRecord,
@@ -89,14 +94,14 @@ public class AuditRecordGeneratorImplForCreateTest {
 
     @Test
     public void generate_WithMandatoryOnly_ShouldReturnMandatoryFieldValues() {
-        final Collection<EntityFieldValue> expectedMandatoryFieldValues =
-            ImmutableList.of(new EntityFieldValue(NotAuditedAncestorType.NAME, ANCESTOR_NAME),
-                             new EntityFieldValue(NotAuditedAncestorType.DESC, ANCESTOR_DESC));
+        final Collection<Entry<String, ?>> expectedMandatoryFieldValues =
+            List.of(entry(NotAuditedAncestorType.NAME.toString(), ANCESTOR_NAME),
+                    entry(NotAuditedAncestorType.DESC.toString(), ANCESTOR_DESC));
 
         when(mandatoryFieldValuesGenerator.generate(finalState)).thenReturn(expectedMandatoryFieldValues);
         when(fieldChangesGenerator.generate(currentState, finalState)).thenReturn(emptyList());
 
-        final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
+        final Optional<? extends AuditRecord> actualOptionalAuditRecord =
             auditRecordGenerator.generate(cmd, changeContext, emptyList());
 
         assertThat(actualOptionalAuditRecord,
@@ -106,7 +111,7 @@ public class AuditRecordGeneratorImplForCreateTest {
 
     @Test
     public void generate_WithFieldChangesOnly_ShouldReturnFieldChanges() {
-        final Collection<FieldAuditRecord<AuditedType>> expectedFieldChanges =
+        final Collection<FieldAuditRecord> expectedFieldChanges =
             ImmutableList.of(FieldAuditRecord.builder(AuditedType.NAME)
                                              .newValue(NAME)
                                              .build(),
@@ -117,7 +122,7 @@ public class AuditRecordGeneratorImplForCreateTest {
         when(mandatoryFieldValuesGenerator.generate(finalState)).thenReturn(emptyList());
         when(fieldChangesGenerator.generate(currentState, finalState)).thenReturn(expectedFieldChanges);
 
-        final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
+        final Optional<? extends AuditRecord> actualOptionalAuditRecord =
             auditRecordGenerator.generate(cmd, changeContext, emptyList());
 
         assertThat(actualOptionalAuditRecord,
@@ -130,9 +135,9 @@ public class AuditRecordGeneratorImplForCreateTest {
         when(mandatoryFieldValuesGenerator.generate(finalState)).thenReturn(emptyList());
         when(fieldChangesGenerator.generate(currentState, finalState)).thenReturn(emptyList());
 
-        final List<AuditRecord<?>> childRecords = ImmutableList.of(mockChildRecord(), mockChildRecord());
+        final List<AuditRecord> childRecords = ImmutableList.of(mockChildRecord(), mockChildRecord());
 
-        final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
+        final Optional<? extends AuditRecord> actualOptionalAuditRecord =
             auditRecordGenerator.generate(cmd, changeContext, childRecords);
 
         assertThat(actualOptionalAuditRecord,
@@ -142,11 +147,11 @@ public class AuditRecordGeneratorImplForCreateTest {
 
     @Test
     public void generate_WithMandatoryAndFieldChangesOnly_ShouldReturnMandatoryFieldValuesAndFieldChanges() {
-        final Collection<EntityFieldValue> expectedMandatoryFieldValues =
-            ImmutableList.of(new EntityFieldValue(NotAuditedAncestorType.NAME, ANCESTOR_NAME),
-                             new EntityFieldValue(NotAuditedAncestorType.DESC, ANCESTOR_DESC));
+        final Collection<Entry<String, ?>> expectedMandatoryFieldValues =
+            List.of(entry(NotAuditedAncestorType.NAME.toString(), ANCESTOR_NAME),
+                    entry(NotAuditedAncestorType.DESC.toString(), ANCESTOR_DESC));
 
-        final Collection<FieldAuditRecord<AuditedType>> expectedFieldChanges =
+        final Collection<FieldAuditRecord> expectedFieldChanges =
             ImmutableList.of(FieldAuditRecord.builder(AuditedType.NAME)
                                              .newValue(NAME)
                                              .build(),
@@ -157,7 +162,7 @@ public class AuditRecordGeneratorImplForCreateTest {
         when(mandatoryFieldValuesGenerator.generate(finalState)).thenReturn(expectedMandatoryFieldValues);
         when(fieldChangesGenerator.generate(currentState, finalState)).thenReturn(expectedFieldChanges);
 
-        final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
+        final Optional<? extends AuditRecord> actualOptionalAuditRecord =
             auditRecordGenerator.generate(cmd, changeContext, emptyList());
 
         assertThat(actualOptionalAuditRecord,
@@ -169,11 +174,11 @@ public class AuditRecordGeneratorImplForCreateTest {
 
     @Test
     public void generate_WithEverything_ShouldReturnEverything() {
-        final Collection<EntityFieldValue> expectedMandatoryFieldValues =
-            ImmutableList.of(new EntityFieldValue(NotAuditedAncestorType.NAME, ANCESTOR_NAME),
-                             new EntityFieldValue(NotAuditedAncestorType.DESC, ANCESTOR_DESC));
+        final Collection<Entry<String, ?>> expectedMandatoryFieldValues =
+            List.of(entry(NotAuditedAncestorType.NAME.toString(), ANCESTOR_NAME),
+                    entry(NotAuditedAncestorType.DESC.toString(), ANCESTOR_DESC));
 
-        final Collection<FieldAuditRecord<AuditedType>> expectedFieldChanges =
+        final Collection<FieldAuditRecord> expectedFieldChanges =
             ImmutableList.of(FieldAuditRecord.builder(AuditedType.NAME)
                                              .newValue(NAME)
                                              .build(),
@@ -184,9 +189,9 @@ public class AuditRecordGeneratorImplForCreateTest {
         when(mandatoryFieldValuesGenerator.generate(finalState)).thenReturn(expectedMandatoryFieldValues);
         when(fieldChangesGenerator.generate(currentState, finalState)).thenReturn(expectedFieldChanges);
 
-        final List<AuditRecord<?>> childRecords = ImmutableList.of(mockChildRecord(), mockChildRecord());
+        final List<AuditRecord> childRecords = ImmutableList.of(mockChildRecord(), mockChildRecord());
 
-        final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
+        final Optional<? extends AuditRecord> actualOptionalAuditRecord =
             auditRecordGenerator.generate(cmd, changeContext, childRecords);
 
         assertThat(actualOptionalAuditRecord,
@@ -198,7 +203,7 @@ public class AuditRecordGeneratorImplForCreateTest {
                                       hasSameChildRecord(childRecords.get(1)))));
     }
 
-    private AuditRecord<?> mockChildRecord() {
+    private AuditRecord mockChildRecord() {
         return mock(AuditRecord.class);
     }
 }

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorImplForDeleteTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorImplForDeleteTest.java
@@ -1,7 +1,10 @@
 package com.kenshoo.pl.entity.internal.audit;
 
 import com.google.common.collect.ImmutableList;
-import com.kenshoo.pl.entity.*;
+import com.kenshoo.pl.entity.ChangeContext;
+import com.kenshoo.pl.entity.CurrentEntityState;
+import com.kenshoo.pl.entity.EntityChange;
+import com.kenshoo.pl.entity.FinalEntityState;
 import com.kenshoo.pl.entity.audit.AuditRecord;
 import com.kenshoo.pl.entity.internal.EntityIdExtractor;
 import com.kenshoo.pl.entity.internal.audit.entitytypes.AuditedType;
@@ -14,12 +17,14 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map.Entry;
 import java.util.Optional;
 
 import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresentAnd;
 import static com.kenshoo.pl.entity.ChangeOperation.DELETE;
 import static com.kenshoo.pl.entity.matchers.audit.AuditRecordMatchers.*;
 import static java.util.Collections.emptyList;
+import static java.util.Map.entry;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
@@ -75,7 +80,7 @@ public class AuditRecordGeneratorImplForDeleteTest {
     public void generate_WithIdOnly_ShouldGenerateBasicData() {
         when(mandatoryFieldValuesGenerator.generate(finalState)).thenReturn(emptyList());
 
-        final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
+        final Optional<? extends AuditRecord> actualOptionalAuditRecord =
             auditRecordGenerator.generate(cmd, changeContext, emptyList());
 
         assertThat(actualOptionalAuditRecord,
@@ -93,13 +98,13 @@ public class AuditRecordGeneratorImplForDeleteTest {
 
     @Test
     public void generate_WithMandatoryOnly_ShouldGenerateMandatoryFieldValues() {
-        final Collection<EntityFieldValue> expectedMandatoryFieldValues =
-            ImmutableList.of(new EntityFieldValue(NotAuditedAncestorType.NAME, ANCESTOR_NAME),
-                             new EntityFieldValue(NotAuditedAncestorType.DESC, ANCESTOR_DESC));
+        final Collection<Entry<String, ?>> expectedMandatoryFieldValues =
+            List.of(entry(NotAuditedAncestorType.NAME.toString(), ANCESTOR_NAME),
+                    entry(NotAuditedAncestorType.DESC.toString(), ANCESTOR_DESC));
 
         when(mandatoryFieldValuesGenerator.generate(finalState)).thenReturn(expectedMandatoryFieldValues);
 
-        final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
+        final Optional<? extends AuditRecord> actualOptionalAuditRecord =
             auditRecordGenerator.generate(cmd, changeContext, emptyList());
 
         assertThat(actualOptionalAuditRecord,
@@ -111,9 +116,9 @@ public class AuditRecordGeneratorImplForDeleteTest {
     public void generate_WithChildRecordsOnly_ShouldGenerateChildRecords() {
         when(mandatoryFieldValuesGenerator.generate(finalState)).thenReturn(emptyList());
 
-        final List<AuditRecord<?>> childRecords = ImmutableList.of(mockChildRecord(), mockChildRecord());
+        final List<AuditRecord> childRecords = ImmutableList.of(mockChildRecord(), mockChildRecord());
 
-        final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
+        final Optional<? extends AuditRecord> actualOptionalAuditRecord =
             auditRecordGenerator.generate(cmd, changeContext, childRecords);
 
         assertThat(actualOptionalAuditRecord,
@@ -123,15 +128,15 @@ public class AuditRecordGeneratorImplForDeleteTest {
 
     @Test
     public void generate_WithMandatoryAndChildRecords_ShouldGenerateMandatoryFieldValuesAndChildRecords() {
-        final Collection<EntityFieldValue> expectedMandatoryFieldValues =
-            ImmutableList.of(new EntityFieldValue(NotAuditedAncestorType.NAME, ANCESTOR_NAME),
-                             new EntityFieldValue(NotAuditedAncestorType.DESC, ANCESTOR_DESC));
+        final Collection<Entry<String, ?>> expectedMandatoryFieldValues =
+            List.of(entry(NotAuditedAncestorType.NAME.toString(), ANCESTOR_NAME),
+                    entry(NotAuditedAncestorType.DESC.toString(), ANCESTOR_DESC));
 
         when(mandatoryFieldValuesGenerator.generate(finalState)).thenReturn(expectedMandatoryFieldValues);
 
-        final List<AuditRecord<?>> childRecords = ImmutableList.of(mockChildRecord(), mockChildRecord());
+        final List<AuditRecord> childRecords = ImmutableList.of(mockChildRecord(), mockChildRecord());
 
-        final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
+        final Optional<? extends AuditRecord> actualOptionalAuditRecord =
             auditRecordGenerator.generate(cmd, changeContext, childRecords);
 
         assertThat(actualOptionalAuditRecord,
@@ -141,7 +146,7 @@ public class AuditRecordGeneratorImplForDeleteTest {
                                       hasSameChildRecord(childRecords.get(1)))));
     }
 
-    private AuditRecord<?> mockChildRecord() {
+    private AuditRecord mockChildRecord() {
         return mock(AuditRecord.class);
     }
 }

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorImplForUpdateTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorImplForUpdateTest.java
@@ -1,7 +1,10 @@
 package com.kenshoo.pl.entity.internal.audit;
 
 import com.google.common.collect.ImmutableList;
-import com.kenshoo.pl.entity.*;
+import com.kenshoo.pl.entity.ChangeContext;
+import com.kenshoo.pl.entity.CurrentEntityState;
+import com.kenshoo.pl.entity.EntityChange;
+import com.kenshoo.pl.entity.FinalEntityState;
 import com.kenshoo.pl.entity.audit.AuditRecord;
 import com.kenshoo.pl.entity.audit.FieldAuditRecord;
 import com.kenshoo.pl.entity.internal.EntityIdExtractor;
@@ -15,6 +18,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map.Entry;
 import java.util.Optional;
 
 import static com.github.npathai.hamcrestopt.OptionalMatchers.isEmpty;
@@ -22,6 +26,7 @@ import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresentAnd;
 import static com.kenshoo.pl.entity.ChangeOperation.UPDATE;
 import static com.kenshoo.pl.entity.matchers.audit.AuditRecordMatchers.*;
 import static java.util.Collections.emptyList;
+import static java.util.Map.entry;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
@@ -81,7 +86,7 @@ public class AuditRecordGeneratorImplForUpdateTest {
         when(mandatoryFieldValuesGenerator.generate(finalState)).thenReturn(emptyList());
         when(fieldChangesGenerator.generate(currentState, finalState)).thenReturn(emptyList());
 
-        final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
+        final Optional<? extends AuditRecord> actualOptionalAuditRecord =
             auditRecordGenerator.generate(cmd, changeContext, emptyList());
 
         assertThat(actualOptionalAuditRecord, isEmpty());
@@ -89,14 +94,14 @@ public class AuditRecordGeneratorImplForUpdateTest {
 
     @Test
     public void generate_WithMandatoryOnly_ShouldReturnEmpty() {
-        final Collection<EntityFieldValue> expectedMandatoryFieldValues =
-            ImmutableList.of(new EntityFieldValue(NotAuditedAncestorType.NAME, ANCESTOR_NAME),
-                             new EntityFieldValue(NotAuditedAncestorType.DESC, ANCESTOR_DESC));
+        final Collection<Entry<String, ?>> expectedMandatoryFieldValues =
+            List.of(entry(NotAuditedAncestorType.NAME.toString(), ANCESTOR_NAME),
+                    entry(NotAuditedAncestorType.DESC.toString(), ANCESTOR_DESC));
 
         when(mandatoryFieldValuesGenerator.generate(finalState)).thenReturn(expectedMandatoryFieldValues);
         when(fieldChangesGenerator.generate(currentState, finalState)).thenReturn(emptyList());
 
-        final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
+        final Optional<? extends AuditRecord> actualOptionalAuditRecord =
             auditRecordGenerator.generate(cmd, changeContext, emptyList());
 
         assertThat(actualOptionalAuditRecord, isEmpty());
@@ -104,7 +109,7 @@ public class AuditRecordGeneratorImplForUpdateTest {
 
     @Test
     public void generate_WithFieldChangesOnly_ShouldReturnBasicDataAndFieldChanges() {
-        final Collection<FieldAuditRecord<AuditedType>> expectedFieldChanges =
+        final Collection<FieldAuditRecord> expectedFieldChanges =
             ImmutableList.of(FieldAuditRecord.builder(AuditedType.NAME)
                                              .oldValue(OLD_NAME)
                                              .newValue(NEW_NAME)
@@ -117,7 +122,7 @@ public class AuditRecordGeneratorImplForUpdateTest {
         when(mandatoryFieldValuesGenerator.generate(finalState)).thenReturn(emptyList());
         when(fieldChangesGenerator.generate(currentState, finalState)).thenReturn(expectedFieldChanges);
 
-        final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
+        final Optional<? extends AuditRecord> actualOptionalAuditRecord =
             auditRecordGenerator.generate(cmd, changeContext, emptyList());
 
         assertThat(actualOptionalAuditRecord,
@@ -130,16 +135,16 @@ public class AuditRecordGeneratorImplForUpdateTest {
 
     @Test
     public void generate_WithChildRecordsOnly_ShouldReturnBasicDataAndChildRecords() {
-        final Collection<EntityFieldValue> expectedMandatoryFieldValues =
-            ImmutableList.of(new EntityFieldValue(NotAuditedAncestorType.NAME, ANCESTOR_NAME),
-                             new EntityFieldValue(NotAuditedAncestorType.DESC, ANCESTOR_DESC));
+        final Collection<Entry<String, ?>> expectedMandatoryFieldValues =
+            ImmutableList.of(entry(NotAuditedAncestorType.NAME.toString(), ANCESTOR_NAME),
+                             entry(NotAuditedAncestorType.DESC.toString(), ANCESTOR_DESC));
 
         when(mandatoryFieldValuesGenerator.generate(finalState)).thenReturn(expectedMandatoryFieldValues);
         when(fieldChangesGenerator.generate(currentState, finalState)).thenReturn(emptyList());
 
-        final List<AuditRecord<?>> childRecords = ImmutableList.of(mockChildRecord(), mockChildRecord());
+        final List<AuditRecord> childRecords = ImmutableList.of(mockChildRecord(), mockChildRecord());
 
-        final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
+        final Optional<? extends AuditRecord> actualOptionalAuditRecord =
             auditRecordGenerator.generate(cmd, changeContext, childRecords);
 
         assertThat(actualOptionalAuditRecord,
@@ -152,11 +157,11 @@ public class AuditRecordGeneratorImplForUpdateTest {
 
     @Test
     public void generate_WithEverything_ShouldGenerateEverything() {
-        final Collection<EntityFieldValue> expectedMandatoryFieldValues =
-            ImmutableList.of(new EntityFieldValue(NotAuditedAncestorType.NAME, ANCESTOR_NAME),
-                             new EntityFieldValue(NotAuditedAncestorType.DESC, ANCESTOR_DESC));
+        final Collection<Entry<String, ?>> expectedMandatoryFieldValues =
+            List.of(entry(NotAuditedAncestorType.NAME.toString(), ANCESTOR_NAME),
+                    entry(NotAuditedAncestorType.DESC.toString(), ANCESTOR_DESC));
 
-        final Collection<FieldAuditRecord<AuditedType>> expectedFieldChanges =
+        final Collection<FieldAuditRecord> expectedFieldChanges =
             ImmutableList.of(FieldAuditRecord.builder(AuditedType.NAME)
                                              .oldValue(OLD_NAME)
                                              .newValue(NEW_NAME)
@@ -169,9 +174,9 @@ public class AuditRecordGeneratorImplForUpdateTest {
         when(mandatoryFieldValuesGenerator.generate(finalState)).thenReturn(expectedMandatoryFieldValues);
         when(fieldChangesGenerator.generate(currentState, finalState)).thenReturn(expectedFieldChanges);
 
-        final List<AuditRecord<?>> childRecords = ImmutableList.of(mockChildRecord(), mockChildRecord());
+        final List<AuditRecord> childRecords = ImmutableList.of(mockChildRecord(), mockChildRecord());
 
-        final Optional<? extends AuditRecord<AuditedType>> actualOptionalAuditRecord =
+        final Optional<? extends AuditRecord> actualOptionalAuditRecord =
             auditRecordGenerator.generate(cmd, changeContext, childRecords);
 
         //noinspection unchecked
@@ -187,7 +192,7 @@ public class AuditRecordGeneratorImplForUpdateTest {
                                       hasSameChildRecord(childRecords.get(1)))));
     }
 
-    private AuditRecord<?> mockChildRecord() {
+    private AuditRecord mockChildRecord() {
         return mock(AuditRecord.class);
     }
 }

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/RecursiveAuditRecordGeneratorTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/RecursiveAuditRecordGeneratorTest.java
@@ -55,12 +55,12 @@ public class RecursiveAuditRecordGeneratorTest {
     @Test
     public void generateMany_OneAuditedEntity_WithChanges_ShouldGenerateRecord() {
         final ChangeEntityCommand<AuditedType> cmd = mockCommand();
-        final AuditRecord<AuditedType> auditRecord = mockAuditRecord();
+        final AuditRecord auditRecord = mockAuditRecord();
 
         when(flowConfig.auditRecordGenerator()).thenReturn(Optional.of(auditRecordGenerator));
         doReturn(Optional.of(auditRecord)).when(auditRecordGenerator).generate(cmd, changeContext, emptyList());
 
-        final Stream<? extends AuditRecord<AuditedType>> actualAuditRecords =
+        final Stream<? extends AuditRecord> actualAuditRecords =
             recursiveAuditRecordGenerator.generateMany(flowConfig, Stream.of(cmd), changeContext);
 
         assertThat(actualAuditRecords.collect(toSet()), equalTo(singleton(auditRecord)));
@@ -73,7 +73,7 @@ public class RecursiveAuditRecordGeneratorTest {
         when(flowConfig.auditRecordGenerator()).thenReturn(Optional.of(auditRecordGenerator));
         doReturn(Optional.empty()).when(auditRecordGenerator).generate(cmd, changeContext, emptyList());
 
-        final Stream<? extends AuditRecord<AuditedType>> actualAuditRecords =
+        final Stream<? extends AuditRecord> actualAuditRecords =
             recursiveAuditRecordGenerator.generateMany(flowConfig, Stream.of(cmd), changeContext);
 
         assertThat(actualAuditRecords.collect(toSet()), is(empty()));
@@ -85,7 +85,7 @@ public class RecursiveAuditRecordGeneratorTest {
 
         when(flowConfig.auditRecordGenerator()).thenReturn(Optional.empty());
 
-        final Stream<? extends AuditRecord<AuditedType>> actualAuditRecords =
+        final Stream<? extends AuditRecord> actualAuditRecords =
             recursiveAuditRecordGenerator.generateMany(flowConfig, Stream.of(cmd), changeContext);
 
         assertThat(actualAuditRecords.collect(toSet()), is(empty()));
@@ -96,18 +96,18 @@ public class RecursiveAuditRecordGeneratorTest {
         final ChangeEntityCommand<AuditedType> cmd1 = mockCommand();
         final ChangeEntityCommand<AuditedType> cmd2 = mockCommand();
 
-        final AuditRecord<AuditedType> auditRecord1 = mockAuditRecord();
-        final AuditRecord<AuditedType> auditRecord2 = mockAuditRecord();
+        final AuditRecord auditRecord1 = mockAuditRecord();
+        final AuditRecord auditRecord2 = mockAuditRecord();
 
         when(flowConfig.auditRecordGenerator()).thenReturn(Optional.of(auditRecordGenerator));
 
         doReturn(Optional.of(auditRecord1)).when(auditRecordGenerator).generate(cmd1, changeContext, emptyList());
         doReturn(Optional.of(auditRecord2)).when(auditRecordGenerator).generate(cmd2, changeContext, emptyList());
 
-        final Set<AuditRecord<AuditedType>> expectedAuditRecords =
+        final Set<AuditRecord> expectedAuditRecords =
             ImmutableSet.of(auditRecord1, auditRecord2);
 
-        final Stream<? extends AuditRecord<AuditedType>> actualAuditRecords =
+        final Stream<? extends AuditRecord> actualAuditRecords =
             recursiveAuditRecordGenerator.generateMany(flowConfig, Stream.of(cmd1, cmd2), changeContext);
 
         assertThat(actualAuditRecords.collect(toSet()), equalTo(expectedAuditRecords));
@@ -118,14 +118,14 @@ public class RecursiveAuditRecordGeneratorTest {
         final ChangeEntityCommand<AuditedType> cmd1 = mockCommand();
         final ChangeEntityCommand<AuditedType> cmd2 = mockCommand();
 
-        final AuditRecord<AuditedType> auditRecord1 = mockAuditRecord();
+        final AuditRecord auditRecord1 = mockAuditRecord();
 
         when(flowConfig.auditRecordGenerator()).thenReturn(Optional.of(auditRecordGenerator));
 
         doReturn(Optional.of(auditRecord1)).when(auditRecordGenerator).generate(cmd1, changeContext, emptyList());
         doReturn(Optional.empty()).when(auditRecordGenerator).generate(cmd2, changeContext, emptyList());
 
-        final Stream<? extends AuditRecord<AuditedType>> actualAuditRecords =
+        final Stream<? extends AuditRecord> actualAuditRecords =
             recursiveAuditRecordGenerator.generateMany(flowConfig, Stream.of(cmd1, cmd2), changeContext);
 
         assertThat(actualAuditRecords.collect(toSet()), equalTo(singleton(auditRecord1)));
@@ -137,10 +137,10 @@ public class RecursiveAuditRecordGeneratorTest {
         final ChangeEntityCommand<TestChild1EntityType> childCmd1A = mockCommand();
         final ChangeEntityCommand<TestChild1EntityType> childCmd1B = mockCommand();
 
-        final AuditRecord<AuditedType> expectedAuditRecord = mockAuditRecord();
-        final AuditRecord<TestChild1EntityType> childAuditRecord1A = mockAuditRecord();
-        final AuditRecord<TestChild1EntityType> childAuditRecord1B = mockAuditRecord();
-        final List<AuditRecord<TestChild1EntityType>> childAuditRecords = ImmutableList.of(childAuditRecord1A, childAuditRecord1B);
+        final AuditRecord expectedAuditRecord = mockAuditRecord();
+        final AuditRecord childAuditRecord1A = mockAuditRecord();
+        final AuditRecord childAuditRecord1B = mockAuditRecord();
+        final List<AuditRecord> childAuditRecords = ImmutableList.of(childAuditRecord1A, childAuditRecord1B);
 
         when(flowConfig.auditRecordGenerator()).thenReturn(Optional.of(auditRecordGenerator));
         when(flowConfig.childFlows()).thenReturn(singletonList(child1FlowConfig));
@@ -155,7 +155,7 @@ public class RecursiveAuditRecordGeneratorTest {
         doReturn(Optional.of(childAuditRecord1B)).when(child1AuditRecordGenerator).generate(childCmd1B, changeContext, emptyList());
         doReturn(Optional.of(expectedAuditRecord)).when(auditRecordGenerator).generate(cmd, changeContext, childAuditRecords);
 
-        final Stream<? extends AuditRecord<AuditedType>> actualAuditRecords =
+        final Stream<? extends AuditRecord> actualAuditRecords =
             recursiveAuditRecordGenerator.generateMany(flowConfig, Stream.of(cmd), changeContext);
 
         assertThat(actualAuditRecords.collect(toSet()), equalTo(singleton(expectedAuditRecord)));
@@ -168,8 +168,8 @@ public class RecursiveAuditRecordGeneratorTest {
         final ChangeEntityCommand<TestChild1EntityType> childCmd1A = mockCommand();
         final ChangeEntityCommand<TestChild1EntityType> childCmd1B = mockCommand();
 
-        final AuditRecord<AuditedType> expectedAuditRecord = mockAuditRecord();
-        final AuditRecord<TestChild1EntityType> childAuditRecord1A = mockAuditRecord();
+        final AuditRecord expectedAuditRecord = mockAuditRecord();
+        final AuditRecord childAuditRecord1A = mockAuditRecord();
 
         when(flowConfig.auditRecordGenerator()).thenReturn(Optional.of(auditRecordGenerator));
         when(flowConfig.childFlows()).thenReturn(singletonList(child1FlowConfig));
@@ -184,7 +184,7 @@ public class RecursiveAuditRecordGeneratorTest {
         doReturn(Optional.empty()).when(child1AuditRecordGenerator).generate(childCmd1B, changeContext, emptyList());
         doReturn(Optional.of(expectedAuditRecord)).when(auditRecordGenerator).generate(cmd, changeContext, singletonList(childAuditRecord1A));
 
-        final Stream<? extends AuditRecord<AuditedType>> actualAuditRecords =
+        final Stream<? extends AuditRecord> actualAuditRecords =
             recursiveAuditRecordGenerator.generateMany(flowConfig, Stream.of(cmd), changeContext);
 
         assertThat(actualAuditRecords.collect(toSet()), equalTo(singleton(expectedAuditRecord)));
@@ -197,8 +197,8 @@ public class RecursiveAuditRecordGeneratorTest {
         final ChangeEntityCommand<TestChild1EntityType> auditedChildCmd = mockCommand();
         final ChangeEntityCommand<TestChild2EntityType> notAuditedChildCmd = mockCommand();
 
-        final AuditRecord<AuditedType> expectedAuditRecord = mockAuditRecord();
-        final AuditRecord<TestChild1EntityType> auditedChildRecord = mockAuditRecord();
+        final AuditRecord expectedAuditRecord = mockAuditRecord();
+        final AuditRecord auditedChildRecord = mockAuditRecord();
 
         when(flowConfig.auditRecordGenerator()).thenReturn(Optional.of(auditRecordGenerator));
         when(flowConfig.childFlows()).thenReturn(ImmutableList.of(child1FlowConfig, child2FlowConfig));
@@ -216,7 +216,7 @@ public class RecursiveAuditRecordGeneratorTest {
         doReturn(Optional.of(auditedChildRecord)).when(child1AuditRecordGenerator).generate(auditedChildCmd, changeContext, emptyList());
         doReturn(Optional.of(expectedAuditRecord)).when(auditRecordGenerator).generate(cmd, changeContext, singletonList(auditedChildRecord));
 
-        final Stream<? extends AuditRecord<AuditedType>> actualAuditRecords =
+        final Stream<? extends AuditRecord> actualAuditRecords =
             recursiveAuditRecordGenerator.generateMany(flowConfig, Stream.of(cmd), changeContext);
 
         assertThat(actualAuditRecords.collect(toSet()), equalTo(singleton(expectedAuditRecord)));
@@ -230,15 +230,15 @@ public class RecursiveAuditRecordGeneratorTest {
         final ChangeEntityCommand<TestChild2EntityType> childCmd2A = mockCommand();
         final ChangeEntityCommand<TestChild2EntityType> childCmd2B = mockCommand();
 
-        final AuditRecord<AuditedType> expectedAuditRecord = mockAuditRecord();
-        final AuditRecord<TestChild1EntityType> childAuditRecord1A = mockAuditRecord();
-        final AuditRecord<TestChild1EntityType> childAuditRecord1B = mockAuditRecord();
-        final AuditRecord<TestChild2EntityType> childAuditRecord2A = mockAuditRecord();
-        final AuditRecord<TestChild2EntityType> childAuditRecord2B = mockAuditRecord();
-        final List<AuditRecord<?>> allChildAuditRecords = ImmutableList.of(childAuditRecord1A,
-                                                                           childAuditRecord1B,
-                                                                           childAuditRecord2A,
-                                                                           childAuditRecord2B);
+        final AuditRecord expectedAuditRecord = mockAuditRecord();
+        final AuditRecord childAuditRecord1A = mockAuditRecord();
+        final AuditRecord childAuditRecord1B = mockAuditRecord();
+        final AuditRecord childAuditRecord2A = mockAuditRecord();
+        final AuditRecord childAuditRecord2B = mockAuditRecord();
+        final List<AuditRecord> allChildAuditRecords = ImmutableList.of(childAuditRecord1A,
+                                                                        childAuditRecord1B,
+                                                                        childAuditRecord2A,
+                                                                        childAuditRecord2B);
 
         when(flowConfig.auditRecordGenerator()).thenReturn(Optional.of(auditRecordGenerator));
         when(flowConfig.childFlows()).thenReturn(ImmutableList.of(child1FlowConfig, child2FlowConfig));
@@ -260,7 +260,7 @@ public class RecursiveAuditRecordGeneratorTest {
         doReturn(Optional.of(childAuditRecord2B)).when(child2AuditRecordGenerator).generate(childCmd2B, changeContext, emptyList());
         doReturn(Optional.of(expectedAuditRecord)).when(auditRecordGenerator).generate(cmd, changeContext, allChildAuditRecords);
 
-        final Stream<? extends AuditRecord<AuditedType>> actualAuditRecords =
+        final Stream<? extends AuditRecord> actualAuditRecords =
             recursiveAuditRecordGenerator.generateMany(flowConfig, Stream.of(cmd), changeContext);
 
         assertThat(actualAuditRecords.collect(toSet()), equalTo(singleton(expectedAuditRecord)));
@@ -273,9 +273,9 @@ public class RecursiveAuditRecordGeneratorTest {
         final ChangeEntityCommand<TestChild1EntityType> childCmd = mockCommand();
         final ChangeEntityCommand<TestGrandchildEntityType> grandchildCmd = mockCommand();
 
-        final AuditRecord<AuditedType> expectedAuditRecord = mockAuditRecord();
-        final AuditRecord<TestChild1EntityType> childAuditRecord = mockAuditRecord();
-        final AuditRecord<TestGrandchildEntityType> grandchildAuditRecord = mockAuditRecord();
+        final AuditRecord expectedAuditRecord = mockAuditRecord();
+        final AuditRecord childAuditRecord = mockAuditRecord();
+        final AuditRecord grandchildAuditRecord = mockAuditRecord();
 
         when(flowConfig.auditRecordGenerator()).thenReturn(Optional.of(auditRecordGenerator));
         when(flowConfig.childFlows()).thenReturn(singletonList(child1FlowConfig));
@@ -298,7 +298,7 @@ public class RecursiveAuditRecordGeneratorTest {
         doReturn(Optional.of(expectedAuditRecord))
             .when(auditRecordGenerator).generate(cmd, changeContext, singletonList(childAuditRecord));
 
-        final Stream<? extends AuditRecord<AuditedType>> actualAuditRecords =
+        final Stream<? extends AuditRecord> actualAuditRecords =
             recursiveAuditRecordGenerator.generateMany(flowConfig, Stream.of(cmd), changeContext);
 
         assertThat(actualAuditRecords.collect(toSet()), equalTo(singleton(expectedAuditRecord)));
@@ -309,8 +309,7 @@ public class RecursiveAuditRecordGeneratorTest {
         return mock(ChangeEntityCommand.class);
     }
 
-    @SuppressWarnings("unchecked")
-    private <E extends EntityType<E>> AuditRecord<E> mockAuditRecord() {
+    private AuditRecord mockAuditRecord() {
         return mock(AuditRecord.class);
     }
 

--- a/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordEntityIdMatcher.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordEntityIdMatcher.java
@@ -8,7 +8,7 @@ import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
 
-class AuditRecordEntityIdMatcher extends TypeSafeMatcher<AuditRecord<?>> {
+class AuditRecordEntityIdMatcher extends TypeSafeMatcher<AuditRecord> {
 
     private final String expectedEntityId;
 
@@ -17,7 +17,7 @@ class AuditRecordEntityIdMatcher extends TypeSafeMatcher<AuditRecord<?>> {
     }
 
     @Override
-    protected boolean matchesSafely(final AuditRecord<?> actualRecord) {
+    protected boolean matchesSafely(final AuditRecord actualRecord) {
         if (actualRecord == null) {
             return false;
         }

--- a/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordEntityTypeMatcher.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordEntityTypeMatcher.java
@@ -8,7 +8,7 @@ import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
 
-class AuditRecordEntityTypeMatcher extends TypeSafeMatcher<AuditRecord<?>> {
+class AuditRecordEntityTypeMatcher extends TypeSafeMatcher<AuditRecord> {
 
     private final String expectedEntityType;
 
@@ -17,7 +17,7 @@ class AuditRecordEntityTypeMatcher extends TypeSafeMatcher<AuditRecord<?>> {
     }
 
     @Override
-    protected boolean matchesSafely(final AuditRecord<?> actualRecord) {
+    protected boolean matchesSafely(final AuditRecord actualRecord) {
         if (actualRecord == null) {
             return false;
         }

--- a/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordFieldRecordExistsMatcher.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordFieldRecordExistsMatcher.java
@@ -1,20 +1,19 @@
 package com.kenshoo.pl.entity.matchers.audit;
 
-import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.audit.AuditRecord;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
 
-class AuditRecordFieldRecordExistsMatcher extends TypeSafeMatcher<AuditRecord<?>> {
+class AuditRecordFieldRecordExistsMatcher extends TypeSafeMatcher<AuditRecord> {
 
-    private final EntityField<?, ?> expectedField;
+    private final String expectedField;
 
-    AuditRecordFieldRecordExistsMatcher(final EntityField<?, ?> expectedField) {
+    AuditRecordFieldRecordExistsMatcher(final String expectedField) {
         this.expectedField = expectedField;
     }
 
     @Override
-    protected boolean matchesSafely(final AuditRecord<?> actualAuditRecord) {
+    protected boolean matchesSafely(final AuditRecord actualAuditRecord) {
         return hasFieldRecordFor(actualAuditRecord, expectedField);
     }
 
@@ -24,7 +23,7 @@ class AuditRecordFieldRecordExistsMatcher extends TypeSafeMatcher<AuditRecord<?>
     }
 
 
-    private boolean hasFieldRecordFor(final AuditRecord<?> auditRecord, final EntityField<?, ?> field) {
+    private boolean hasFieldRecordFor(final AuditRecord auditRecord, final String field) {
         return auditRecord.getFieldRecords().stream()
                           .anyMatch(fieldRecord -> fieldRecord.getField().equals(field));
     }

--- a/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordFieldRecordMatcher.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordFieldRecordMatcher.java
@@ -1,21 +1,20 @@
 package com.kenshoo.pl.entity.matchers.audit;
 
-import com.kenshoo.pl.entity.EntityType;
 import com.kenshoo.pl.entity.audit.AuditRecord;
 import com.kenshoo.pl.entity.audit.FieldAuditRecord;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
 
-class AuditRecordFieldRecordMatcher extends TypeSafeMatcher<AuditRecord<?>> {
+class AuditRecordFieldRecordMatcher extends TypeSafeMatcher<AuditRecord> {
 
-    private final FieldAuditRecord<?> expectedFieldRecord;
+    private final FieldAuditRecord expectedFieldRecord;
 
-    AuditRecordFieldRecordMatcher(final FieldAuditRecord<?> expectedFieldRecord) {
+    AuditRecordFieldRecordMatcher(final FieldAuditRecord expectedFieldRecord) {
         this.expectedFieldRecord = expectedFieldRecord;
     }
 
     @Override
-    protected boolean matchesSafely(final AuditRecord<?> actualAuditRecord) {
+    protected boolean matchesSafely(final AuditRecord actualAuditRecord) {
         return actualAuditRecord.getFieldRecords().contains(expectedFieldRecord);
     }
 

--- a/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordHasChildRecordMatcher.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordHasChildRecordMatcher.java
@@ -5,16 +5,16 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 
-class AuditRecordHasChildRecordMatcher extends TypeSafeMatcher<AuditRecord<?>> {
+class AuditRecordHasChildRecordMatcher extends TypeSafeMatcher<AuditRecord> {
 
-    private final Matcher<AuditRecord<?>> childRecordMatcher;
+    private final Matcher<AuditRecord> childRecordMatcher;
 
-    AuditRecordHasChildRecordMatcher(final Matcher<AuditRecord<?>> childRecordMatcher) {
+    AuditRecordHasChildRecordMatcher(final Matcher<AuditRecord> childRecordMatcher) {
         this.childRecordMatcher = childRecordMatcher;
     }
 
     @Override
-    protected boolean matchesSafely(final AuditRecord<?> actualAuditRecord) {
+    protected boolean matchesSafely(final AuditRecord actualAuditRecord) {
         return actualAuditRecord.getChildRecords().stream()
                                 .anyMatch(childRecordMatcher::matches);
     }

--- a/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordMandatoryFieldValueMatcher.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordMandatoryFieldValueMatcher.java
@@ -1,22 +1,23 @@
 package com.kenshoo.pl.entity.matchers.audit;
 
-import com.kenshoo.pl.entity.EntityFieldValue;
 import com.kenshoo.pl.entity.audit.AuditRecord;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
 
+import java.util.Map.Entry;
+
 import static java.util.Objects.requireNonNull;
 
-class AuditRecordMandatoryFieldValueMatcher extends TypeSafeMatcher<AuditRecord<?>> {
+class AuditRecordMandatoryFieldValueMatcher extends TypeSafeMatcher<AuditRecord> {
 
-    private final EntityFieldValue expectedFieldValue;
+    private final Entry<String, ?> expectedFieldValue;
 
-    AuditRecordMandatoryFieldValueMatcher(final EntityFieldValue expectedFieldValue) {
+    AuditRecordMandatoryFieldValueMatcher(final Entry<String, ?> expectedFieldValue) {
         this.expectedFieldValue = requireNonNull(expectedFieldValue, "expectedFieldValue is required");
     }
 
     @Override
-    protected boolean matchesSafely(final AuditRecord<?> actualRecord) {
+    protected boolean matchesSafely(final AuditRecord actualRecord) {
         if (actualRecord == null) {
             return false;
         }

--- a/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordMatchers.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordMatchers.java
@@ -2,75 +2,76 @@ package com.kenshoo.pl.entity.matchers.audit;
 
 import com.kenshoo.pl.entity.ChangeOperation;
 import com.kenshoo.pl.entity.EntityField;
-import com.kenshoo.pl.entity.EntityFieldValue;
 import com.kenshoo.pl.entity.audit.AuditRecord;
 import com.kenshoo.pl.entity.audit.FieldAuditRecord;
 import org.hamcrest.Matcher;
 
+import static java.util.Map.entry;
+
 public class AuditRecordMatchers {
 
-    public static Matcher<AuditRecord<?>> hasEntityType(final String expectedEntityType) {
+    public static Matcher<AuditRecord> hasEntityType(final String expectedEntityType) {
         return new AuditRecordEntityTypeMatcher(expectedEntityType);
     }
 
-    public static Matcher<AuditRecord<?>> hasEntityId(final String expectedEntityId) {
+    public static Matcher<AuditRecord> hasEntityId(final String expectedEntityId) {
         return new AuditRecordEntityIdMatcher(expectedEntityId);
     }
 
-    public static Matcher<AuditRecord<?>> hasOperator(final ChangeOperation expectedOperator) {
+    public static Matcher<AuditRecord> hasOperator(final ChangeOperation expectedOperator) {
         return new AuditRecordOperatorMatcher(expectedOperator);
     }
 
-    public static Matcher<AuditRecord<?>> hasMandatoryFieldValue(final EntityField<?, ?> field, final Object value) {
-        return new AuditRecordMandatoryFieldValueMatcher(new EntityFieldValue(field, value));
+    public static Matcher<AuditRecord> hasMandatoryFieldValue(final EntityField<?, ?> field, final Object value) {
+        return new AuditRecordMandatoryFieldValueMatcher(entry(field.toString(), value));
     }
 
-    public static Matcher<AuditRecord<?>> hasNoMandatoryFieldValues() {
+    public static Matcher<AuditRecord> hasNoMandatoryFieldValues() {
         return new AuditRecordNoMandatoryFieldsMatcher();
     }
 
-    public static Matcher<AuditRecord<?>> hasCreatedFieldRecord(final EntityField<?, ?> field, final Object value) {
+    public static Matcher<AuditRecord> hasCreatedFieldRecord(final EntityField<?, ?> field, final Object value) {
         return hasFieldRecord(FieldAuditRecord.builder(field)
                                               .newValue(value)
                                               .build());
     }
 
-    public static Matcher<AuditRecord<?>> hasChangedFieldRecord(final EntityField<?, ?> field,
-                                                                final String oldValue,
-                                                                final String newValue) {
+    public static Matcher<AuditRecord> hasChangedFieldRecord(final EntityField<?, ?> field,
+                                                             final String oldValue,
+                                                             final String newValue) {
         return hasFieldRecord(FieldAuditRecord.builder(field)
                                               .oldValue(oldValue)
                                               .newValue(newValue)
                                               .build());
     }
 
-    public static  Matcher<AuditRecord<?>> hasDeletedFieldRecord(final EntityField<?, ?> field, final Object value) {
-        return hasFieldRecord(FieldAuditRecord.builder(field)
+    public static  Matcher<AuditRecord> hasDeletedFieldRecord(final EntityField<?, ?> field, final Object value) {
+        return hasFieldRecord(FieldAuditRecord.builder(field.toString())
                                               .oldValue(value)
                                               .build());
     }
 
-    public static Matcher<AuditRecord<?>> hasFieldRecordFor(final EntityField<?, ?> expectedField) {
-        return new AuditRecordFieldRecordExistsMatcher(expectedField);
+    public static Matcher<AuditRecord> hasFieldRecordFor(final EntityField<?, ?> expectedField) {
+        return new AuditRecordFieldRecordExistsMatcher(expectedField.toString());
     }
 
-    public static Matcher<AuditRecord<?>> hasNoFieldRecords() {
+    public static Matcher<AuditRecord> hasNoFieldRecords() {
         return new AuditRecordNoFieldRecordsMatcher();
     }
 
-    public static Matcher<AuditRecord<?>> hasSameChildRecord(final AuditRecord<?> expectedChildRecord) {
+    public static Matcher<AuditRecord> hasSameChildRecord(final AuditRecord expectedChildRecord) {
         return new AuditRecordSameChildRecordMatcher(expectedChildRecord);
     }
 
-    public static Matcher<AuditRecord<?>> hasChildRecordThat(final Matcher<AuditRecord<?>> childRecordMatcher) {
+    public static Matcher<AuditRecord> hasChildRecordThat(final Matcher<AuditRecord> childRecordMatcher) {
         return new AuditRecordHasChildRecordMatcher(childRecordMatcher);
     }
 
-    public static Matcher<AuditRecord<?>> hasNoChildRecords() {
+    public static Matcher<AuditRecord> hasNoChildRecords() {
         return new AuditRecordNoChildRecordsMatcher();
     }
 
-    private static Matcher<AuditRecord<?>> hasFieldRecord(final FieldAuditRecord<?> expectedFieldRecord) {
+    private static Matcher<AuditRecord> hasFieldRecord(final FieldAuditRecord expectedFieldRecord) {
         return new AuditRecordFieldRecordMatcher(expectedFieldRecord);
     }
 

--- a/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordNoChildRecordsMatcher.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordNoChildRecordsMatcher.java
@@ -4,10 +4,10 @@ import com.kenshoo.pl.entity.audit.AuditRecord;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
 
-class AuditRecordNoChildRecordsMatcher extends TypeSafeMatcher<AuditRecord<?>> {
+class AuditRecordNoChildRecordsMatcher extends TypeSafeMatcher<AuditRecord> {
 
     @Override
-    protected boolean matchesSafely(final AuditRecord<?> actualAuditRecord) {
+    protected boolean matchesSafely(final AuditRecord actualAuditRecord) {
         return actualAuditRecord.getChildRecords().isEmpty();
     }
 

--- a/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordNoFieldRecordsMatcher.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordNoFieldRecordsMatcher.java
@@ -4,10 +4,10 @@ import com.kenshoo.pl.entity.audit.AuditRecord;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
 
-class AuditRecordNoFieldRecordsMatcher extends TypeSafeMatcher<AuditRecord<?>> {
+class AuditRecordNoFieldRecordsMatcher extends TypeSafeMatcher<AuditRecord> {
 
     @Override
-    protected boolean matchesSafely(final AuditRecord<?> actualAuditRecord) {
+    protected boolean matchesSafely(final AuditRecord actualAuditRecord) {
         return actualAuditRecord.getFieldRecords().isEmpty();
     }
 

--- a/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordNoMandatoryFieldsMatcher.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordNoMandatoryFieldsMatcher.java
@@ -4,10 +4,10 @@ import com.kenshoo.pl.entity.audit.AuditRecord;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
 
-public class AuditRecordNoMandatoryFieldsMatcher extends TypeSafeMatcher<AuditRecord<?>> {
+public class AuditRecordNoMandatoryFieldsMatcher extends TypeSafeMatcher<AuditRecord> {
 
     @Override
-    protected boolean matchesSafely(AuditRecord<?> actualAuditRecord) {
+    protected boolean matchesSafely(AuditRecord actualAuditRecord) {
         return actualAuditRecord.getMandatoryFieldValues().isEmpty();
     }
 

--- a/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordOperatorMatcher.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordOperatorMatcher.java
@@ -9,7 +9,7 @@ import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
 
-class AuditRecordOperatorMatcher extends TypeSafeMatcher<AuditRecord<?>> {
+class AuditRecordOperatorMatcher extends TypeSafeMatcher<AuditRecord> {
 
     private final ChangeOperation expectedOperator;
 
@@ -18,7 +18,7 @@ class AuditRecordOperatorMatcher extends TypeSafeMatcher<AuditRecord<?>> {
     }
 
     @Override
-    protected boolean matchesSafely(final AuditRecord<?> actualRecord) {
+    protected boolean matchesSafely(final AuditRecord actualRecord) {
         if (actualRecord == null) {
             return false;
         }

--- a/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordSameChildRecordMatcher.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordSameChildRecordMatcher.java
@@ -4,16 +4,16 @@ import com.kenshoo.pl.entity.audit.AuditRecord;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
 
-class AuditRecordSameChildRecordMatcher extends TypeSafeMatcher<AuditRecord<?>> {
+class AuditRecordSameChildRecordMatcher extends TypeSafeMatcher<AuditRecord> {
 
-    private final AuditRecord<?> expectedChildRecord;
+    private final AuditRecord expectedChildRecord;
 
-    AuditRecordSameChildRecordMatcher(final AuditRecord<?> expectedChildRecord) {
+    AuditRecordSameChildRecordMatcher(final AuditRecord expectedChildRecord) {
         this.expectedChildRecord = expectedChildRecord;
     }
 
     @Override
-    protected boolean matchesSafely(final AuditRecord<?> actualAuditRecord) {
+    protected boolean matchesSafely(final AuditRecord actualAuditRecord) {
         return actualAuditRecord.getChildRecords().contains(expectedChildRecord);
     }
 


### PR DESCRIPTION
In `AuditRecord` replacing all `EntityField` usages with strings representing the field names.

The fields are currently nested inside two other objects:
 - `EntityFieldValue` which is used to contain a mandatory field (field which always appears: "descriptive field", agency etc.) - and its value.
 The usages of this object have been completely replaced by a simple `Map.Entry<String, ?>`
 - `FieldAuditRecord` which is used to contain: (changed) field, old value and new value. Here I just replaced the `EntityField` with a `String`.
 
 The field names currently have a default which is the `toString()` of the name.
 In the next PR-s I will support the overrides.
