### PR TITLE
PL-114: In AuditedEntityType replace EntityField-s with AuditedField-s having a name

### DIFF
--- a/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditFieldChangeGenerator.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditFieldChangeGenerator.java
@@ -1,7 +1,6 @@
 package com.kenshoo.pl.entity.internal.audit;
 
 import com.kenshoo.pl.entity.CurrentEntityState;
-import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.EntityType;
 import com.kenshoo.pl.entity.FinalEntityState;
 import com.kenshoo.pl.entity.audit.FieldAuditRecord;
@@ -14,7 +13,7 @@ public class AuditFieldChangeGenerator {
 
     <E extends EntityType<E>> Optional<FieldAuditRecord> generate(final CurrentEntityState currentState,
                                                                   final FinalEntityState finalState,
-                                                                  final EntityField<E, ?> field) {
+                                                                  final AuditedField<E, ?> field) {
         requireNonNull(currentState, "A current state is required");
         requireNonNull(finalState, "A final state is required");
         requireNonNull(field, "A field is required");
@@ -26,22 +25,22 @@ public class AuditFieldChangeGenerator {
 
     private <E extends EntityType<E>, T> boolean fieldWasChanged(final CurrentEntityState currentState,
                                                                  final FinalEntityState finalState,
-                                                                 final EntityField<E, T> field) {
+                                                                 final AuditedField<E, T> field) {
         return !fieldStayedTheSame(currentState, finalState, field);
     }
 
     private <E extends EntityType<E>, T> boolean fieldStayedTheSame(final CurrentEntityState currentState,
                                                                     final FinalEntityState finalState,
-                                                                    final EntityField<E, T> field) {
-        return currentState.safeGet(field).equals(finalState.safeGet(field), field::valuesEqual);
+                                                                    final AuditedField<E, T> field) {
+        return field.getValue(currentState).equals(field.getValue(finalState), field::valuesEqual);
     }
 
     private <E extends EntityType<E>> FieldAuditRecord buildFieldRecord(final CurrentEntityState currentState,
                                                                         final FinalEntityState finalState,
-                                                                        final EntityField<E, ?> field) {
-        final FieldAuditRecord.Builder fieldRecordBuilder = FieldAuditRecord.builder(field.toString());
-        currentState.safeGet(field).ifNotNull(fieldRecordBuilder::oldValue);
-        finalState.safeGet(field).ifNotNull(fieldRecordBuilder::newValue);
+                                                                        final AuditedField<E, ?> field) {
+        final FieldAuditRecord.Builder fieldRecordBuilder = FieldAuditRecord.builder(field.getName());
+        field.getValue(currentState).ifNotNull(fieldRecordBuilder::oldValue);
+        field.getValue(finalState).ifNotNull(fieldRecordBuilder::newValue);
         return fieldRecordBuilder.build();
     }
 }

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditFieldChangesGenerator.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditFieldChangesGenerator.java
@@ -2,7 +2,6 @@ package com.kenshoo.pl.entity.internal.audit;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.kenshoo.pl.entity.CurrentEntityState;
-import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.EntityType;
 import com.kenshoo.pl.entity.FinalEntityState;
 import com.kenshoo.pl.entity.audit.FieldAuditRecord;
@@ -17,15 +16,15 @@ import static org.jooq.lambda.Seq.seq;
 
 public class AuditFieldChangesGenerator<E extends EntityType<E>> {
 
-    private final Collection<EntityField<E, ?>> onChangeFields;
+    private final Collection<AuditedField<E, ?>> onChangeFields;
     private final AuditFieldChangeGenerator singleGenerator;
 
-    public AuditFieldChangesGenerator(final Stream<? extends EntityField<E, ?>> onChangeFields) {
+    public AuditFieldChangesGenerator(final Stream<? extends AuditedField<E, ?>> onChangeFields) {
         this(onChangeFields, new AuditFieldChangeGenerator());
     }
 
     @VisibleForTesting
-    AuditFieldChangesGenerator(final Stream<? extends EntityField<E, ?>> onChangeFields,
+    AuditFieldChangesGenerator(final Stream<? extends AuditedField<E, ?>> onChangeFields,
                                final AuditFieldChangeGenerator singleGenerator) {
         requireNonNull(onChangeFields, "onChangeFields must not be null (can be empty)");
         this.onChangeFields = onChangeFields.collect(toList());

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditMandatoryFieldValuesGenerator.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditMandatoryFieldValuesGenerator.java
@@ -1,6 +1,5 @@
 package com.kenshoo.pl.entity.internal.audit;
 
-import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.FinalEntityState;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
@@ -15,9 +14,9 @@ import static org.jooq.lambda.Seq.seq;
 
 public class AuditMandatoryFieldValuesGenerator {
 
-    private final Collection<EntityField<?, ?>> mandatoryFields;
+    private final Collection<AuditedField<?, ?>> mandatoryFields;
 
-    public AuditMandatoryFieldValuesGenerator(final Stream<? extends EntityField<?, ?>> mandatoryFields) {
+    public AuditMandatoryFieldValuesGenerator(final Stream<? extends AuditedField<?, ?>> mandatoryFields) {
         requireNonNull(mandatoryFields, "mandatoryFields must not be null (can be empty)");
         this.mandatoryFields = mandatoryFields.collect(toList());
     }
@@ -25,9 +24,9 @@ public class AuditMandatoryFieldValuesGenerator {
     Collection<Entry<String, ?>> generate(final FinalEntityState finalState) {
         requireNonNull(finalState, "finalState is required");
         return seq(mandatoryFields)
-            .map(field -> ImmutablePair.of(field, finalState.safeGet(field)))
+            .map(field -> ImmutablePair.of(field, field.getValue(finalState)))
             .filter(pair -> pair.getValue().isNotNull())
-            .map(pair -> entry(pair.getKey().toString(), pair.getValue().get()))
+            .map(pair -> entry(pair.getKey().getName(), pair.getValue().get()))
             .collect(toList());
     }
 }

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditRequiredFieldsCalculator.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditRequiredFieldsCalculator.java
@@ -26,13 +26,13 @@ public class AuditRequiredFieldsCalculator<E extends EntityType<E>> implements C
     public Stream<? extends EntityField<?, ?>> requiredFields(final Collection<? extends EntityField<E, ?>> fieldsToChange,
                                                               final ChangeOperation changeOperation) {
 
-        final Set<? extends EntityField<E, ?>> onChangeFields = auditedEntityType.getOnChangeFields().collect(toSet());
+        final Set<? extends EntityField<E, ?>> onChangeFields = auditedEntityType.getUnderlyingOnChangeFields().collect(toSet());
 
         final Seq<? extends EntityField<E, ?>> intersectedChangeFields =
             seq(fieldsToChange).filter(onChangeFields::contains);
 
         return Seq.<EntityField<?, ?>>of(auditedEntityType.getIdField())
-            .append(auditedEntityType.getMandatoryFields())
+            .append(auditedEntityType.getUnderlyingMandatoryFields())
             .append(intersectedChangeFields);
     }
 }

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditedEntityType.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditedEntityType.java
@@ -1,7 +1,6 @@
 package com.kenshoo.pl.entity.internal.audit;
 
 import com.google.common.collect.HashMultimap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.SetMultimap;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.EntityType;
@@ -10,6 +9,7 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
@@ -17,8 +17,8 @@ import java.util.stream.Stream;
 
 import static com.kenshoo.pl.entity.audit.AuditTrigger.*;
 import static java.util.Collections.emptySet;
-import static java.util.Collections.singleton;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toUnmodifiableSet;
 import static org.apache.commons.lang3.builder.ToStringStyle.SHORT_PREFIX_STYLE;
 
 public class AuditedEntityType<E extends EntityType<E>> {
@@ -28,15 +28,15 @@ public class AuditedEntityType<E extends EntityType<E>> {
     private final String name;
 
     // Fields from other entities which are included always in the audit record with their current values
-    private final Set<? extends EntityField<?, ?>> externalFields;
+    private final Set<? extends AuditedField<?, ?>> externalFields;
 
     // Fields from current entity (besides id), keyed by audit trigger type
-    private final SetMultimap<AuditTrigger, ? extends EntityField<E, ?>> internalFields;
+    private final SetMultimap<AuditTrigger, ? extends AuditedField<E, ?>> internalFields;
 
     private AuditedEntityType(final EntityField<E, ? extends Number> idField,
                               final String name,
-                              final Set<? extends EntityField<?, ?>> externalFields,
-                              final SetMultimap<AuditTrigger, ? extends EntityField<E, ?>> internalFields) {
+                              final Set<? extends AuditedField<?, ?>> externalFields,
+                              final SetMultimap<AuditTrigger, ? extends AuditedField<E, ?>> internalFields) {
         this.idField = idField;
         this.name = name;
         this.externalFields = externalFields;
@@ -51,33 +51,31 @@ public class AuditedEntityType<E extends EntityType<E>> {
         return name;
     }
 
-    public Set<? extends EntityField<?, ?>> getExternalFields() {
+    public Set<? extends AuditedField<?, ?>> getExternalFields() {
         return externalFields;
     }
 
-    public Stream<? extends EntityField<?, ?>> getMandatoryFields() {
+    public Stream<? extends EntityField<?, ?>> getUnderlyingMandatoryFields() {
+        return getMandatoryFields().map(AuditedField::getField);
+    }
+
+    public Stream<? extends AuditedField<?, ?>> getMandatoryFields() {
         return Stream.of(externalFields, internalFields.get(ALWAYS))
                      .flatMap(Set::stream);
     }
 
-    public Stream<? extends EntityField<E, ?>> getOnChangeFields() {
+    public Stream<? extends EntityField<E, ?>> getUnderlyingOnChangeFields() {
         return Stream.of(ON_CREATE_OR_UPDATE, ON_UPDATE)
-                     .flatMap(trigger -> internalFields.get(trigger).stream());
+                     .flatMap(trigger -> internalFields.get(trigger).stream())
+                     .map(AuditedField::getField);
     }
 
-    public Stream<? extends EntityField<E, ?>> getInternalFields() {
+    public Stream<? extends AuditedField<E, ?>> getInternalFields() {
         return internalFields.values().stream();
     }
 
     public boolean hasInternalFields() {
         return !internalFields.isEmpty();
-    }
-
-    public Stream<? extends EntityField<?, ?>> getAllFields() {
-        return Stream.of(singleton(idField),
-                         externalFields,
-                         internalFields.values())
-                     .flatMap(Collection::stream);
     }
 
     public static <E extends EntityType<E>> Builder<E> builder(final EntityField<E, ? extends Number> idField) {
@@ -87,8 +85,8 @@ public class AuditedEntityType<E extends EntityType<E>> {
     public static class Builder<E extends EntityType<E>> {
         private final EntityField<E, ? extends Number> idField;
         private String name;
-        private Set<? extends EntityField<?, ?>> externalFields = emptySet();
-        private final SetMultimap<AuditTrigger, EntityField<E, ?>> internalFields = HashMultimap.create();
+        private Set<? extends AuditedField<?, ?>> externalFields = emptySet();
+        private final SetMultimap<AuditTrigger, AuditedField<E, ?>> internalFields = HashMultimap.create();
 
         public Builder(final EntityField<E, ? extends Number> idField) {
             this.idField = requireNonNull(idField, "idField is required");
@@ -102,37 +100,45 @@ public class AuditedEntityType<E extends EntityType<E>> {
             return this;
         }
 
-        public Builder<E> withExternalFields(final EntityField<?, ?>... externalFields) {
-            this.externalFields = externalFields == null ? emptySet() : ImmutableSet.copyOf(externalFields);
+        public Builder<E> withUnderlyingExternalFields(final EntityField<?, ?>... externalFields) {
+            if (externalFields == null) {
+                this.externalFields = emptySet();
+                return this;
+            } else {
+                return withUnderlyingExternalFields(Stream.of(externalFields));
+            }
+        }
+
+        public Builder<E> withUnderlyingExternalFields(final Stream<? extends EntityField<?, ?>> externalFields) {
+            if (externalFields == null) {
+                this.externalFields = emptySet();
+                return this;
+            } else {
+                return withExternalFields(externalFields.map(AuditedField::new));
+            }
+        }
+
+        public Builder<E> withExternalFields(final Stream<? extends AuditedField<?, ?>> externalFields) {
+            this.externalFields = externalFields == null ? emptySet() : externalFields.collect(toUnmodifiableSet());
             return this;
         }
 
-        public Builder<E> withExternalFields(final Iterable<? extends EntityField<?, ?>> externalFields) {
-            this.externalFields = externalFields == null ? emptySet() : ImmutableSet.copyOf(externalFields);
+        @SafeVarargs
+        public final Builder<E> withUnderlyingInternalFields(final AuditTrigger trigger,
+                                                             final EntityField<E, ?>... internalFields) {
+            final var auditedFields = Arrays.stream(internalFields)
+                                            .map(AuditedField::new)
+                                            .collect(toUnmodifiableSet());
+            this.internalFields.putAll(trigger, auditedFields);
             return this;
         }
 
-        public final Builder<E> withInternalFields(final Map<AuditTrigger, ? extends Collection<EntityField<E, ?>>> internalFields) {
+        public final Builder<E> withInternalFields(final Map<AuditTrigger, ? extends Collection<AuditedField<E, ?>>> internalFields) {
             if (internalFields != null) {
                 internalFields.forEach(this.internalFields::putAll);
             } else {
                 this.internalFields.clear();
             }
-            return this;
-        }
-
-        @SafeVarargs
-        public final Builder<E> withInternalFields(final AuditTrigger trigger,
-                                                   final EntityField<E, ?>... internalMandatoryFields) {
-            internalFields.putAll(trigger,
-                                  internalMandatoryFields == null ? emptySet() : ImmutableSet.copyOf(internalMandatoryFields));
-            return this;
-        }
-
-        public Builder<E> withInternalFields(final AuditTrigger trigger,
-                                             final Iterable<? extends EntityField<E, ?>> internalMandatoryFields) {
-            internalFields.putAll(trigger,
-                                  internalMandatoryFields == null ? emptySet() : ImmutableSet.copyOf(internalMandatoryFields));
             return this;
         }
 

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditedField.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditedField.java
@@ -1,0 +1,65 @@
+package com.kenshoo.pl.entity.internal.audit;
+
+import com.kenshoo.pl.entity.Entity;
+import com.kenshoo.pl.entity.EntityField;
+import com.kenshoo.pl.entity.EntityType;
+import com.kenshoo.pl.entity.Triptional;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import static java.util.Objects.requireNonNull;
+
+public class AuditedField<E extends EntityType<E>, T> {
+
+    private final EntityField<E, T> field;
+    private final String name;
+
+    public AuditedField(final EntityField<E, T> field) {
+        this(requireNonNull(field, "A field must be provided"),
+             field.toString());
+    }
+
+    public AuditedField(final EntityField<E, T> field,
+                        final String name) {
+        this.field = requireNonNull(field, "An underlying field must be provided");
+        this.name = requireNonNull(name, "A name must be provided");
+    }
+
+    public EntityField<E, T> getField() {
+        return field;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Triptional<T> getValue(final Entity entity) {
+        return entity.safeGet(field);
+    }
+
+    public boolean valuesEqual(T v1, T v2) {
+        return field.valuesEqual(v1, v2);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+
+        if (o == null || getClass() != o.getClass()) return false;
+
+        AuditedField<?, ?> that = (AuditedField<?, ?>) o;
+
+        return new EqualsBuilder()
+            .append(field, that.field)
+            .append(name, that.name)
+            .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37)
+            .append(field)
+            .append(name)
+            .toHashCode();
+    }
+}

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditedFieldTrigger.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditedFieldTrigger.java
@@ -1,19 +1,18 @@
 package com.kenshoo.pl.entity.internal.audit;
 
-import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.EntityType;
 import com.kenshoo.pl.entity.audit.AuditTrigger;
 
 class AuditedFieldTrigger<E extends EntityType<E>> {
-    private final EntityField<E, ?> field;
+    private final AuditedField<E, ?> field;
     private final AuditTrigger trigger;
 
-    AuditedFieldTrigger(final EntityField<E, ?> field, final AuditTrigger trigger) {
+    AuditedFieldTrigger(final AuditedField<E, ?> field, final AuditTrigger trigger) {
         this.field = field;
         this.trigger = trigger;
     }
 
-    EntityField<E, ?> getField() {
+    AuditedField<E, ?> getField() {
         return field;
     }
 

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/audit/ExternalMandatoryFieldsExtractor.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/audit/ExternalMandatoryFieldsExtractor.java
@@ -1,6 +1,5 @@
 package com.kenshoo.pl.entity.internal.audit;
 
-import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.EntityType;
 import com.kenshoo.pl.entity.annotation.audit.Audited;
 import com.kenshoo.pl.entity.spi.audit.AuditExtensions;
@@ -17,11 +16,12 @@ public class ExternalMandatoryFieldsExtractor {
 
     static final ExternalMandatoryFieldsExtractor INSTANCE = new ExternalMandatoryFieldsExtractor();
 
-    public Stream<? extends EntityField<?, ?>> extract(final EntityType<?> entityType) {
+    public Stream<? extends AuditedField<?, ?>> extract(final EntityType<?> entityType) {
         return Optional.ofNullable(entityType.getClass().getAnnotation(Audited.class))
                        .map(Audited::extensions)
                        .flatMap(this::createExtensions)
                        .map(AuditExtensions::externalMandatoryFields)
+                       .map(fields -> fields.map(AuditedField::new))
                        .orElse(Stream.empty());
     }
 

--- a/main/src/test/java/com/kenshoo/pl/entity/ChangeFlowConfigTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/ChangeFlowConfigTest.java
@@ -179,8 +179,8 @@ public class ChangeFlowConfigTest {
     public void audit_required_fields_calculator_should_be_in_state_consumers_if_audited_fields_defined() {
 
         final AuditedEntityType<TestEntity> auditedEntityType = AuditedEntityType.builder(TestEntity.ID)
-                                                                                 .withInternalFields(ON_CREATE_OR_UPDATE,
-                                                                                               TestEntity.FIELD_1, TestEntity.FIELD_2)
+                                                                                 .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE,
+                                                                                                               TestEntity.FIELD_1, TestEntity.FIELD_2)
                                                                                  .build();
         doReturn(Optional.of(auditedEntityType)).when(auditedEntityTypeResolver).resolve(TestEntity.INSTANCE);
 
@@ -218,8 +218,8 @@ public class ChangeFlowConfigTest {
 
         final AuditedEntityType<TestEntity> auditedEntityType = AuditedEntityType.builder(TestEntity.ID)
                                                                                  .withName(AUDITED_ENTITY_TYPE_NAME)
-                                                                                 .withInternalFields(ON_CREATE_OR_UPDATE,
-                                                                                               TestEntity.FIELD_1, TestEntity.FIELD_2)
+                                                                                 .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE,
+                                                                                                               TestEntity.FIELD_1, TestEntity.FIELD_2)
                                                                                  .build();
         doReturn(Optional.of(auditedEntityType)).when(auditedEntityTypeResolver).resolve(TestEntity.INSTANCE);
 

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditFieldChangeGeneratorTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditFieldChangeGeneratorTest.java
@@ -132,6 +132,6 @@ public class AuditFieldChangeGeneratorTest {
     }
 
     private Optional<? extends FieldAuditRecord> generate(final EntityField<AuditedType, ?> field) {
-        return generator.generate(currentState, finalState, field);
+        return generator.generate(currentState, finalState, new AuditedField<>(field));
     }
 }

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditFieldChangesGeneratorTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditFieldChangesGeneratorTest.java
@@ -46,7 +46,7 @@ public class AuditFieldChangesGeneratorTest {
         Seq.of(AuditedType.NAME, AuditedType.DESC)
            .zipWithIndex()
            .forEach(fieldWithIdx ->
-                        when(singleGenerator.generate(currentState, finalState, fieldWithIdx.v1))
+                        when(singleGenerator.generate(currentState, finalState, new AuditedField<>(fieldWithIdx.v1)))
                             .thenReturn(Optional.of(expectedFieldChanges.get(fieldWithIdx.v2.intValue())))
                    );
 
@@ -65,8 +65,8 @@ public class AuditFieldChangesGeneratorTest {
     public void generate_twoFields_OnlyFirstGenerated_ShouldReturnFirstFieldChange() {
         final FieldAuditRecord expectedFieldChange = mockFieldChange();
 
-        when(singleGenerator.generate(currentState, finalState, AuditedType.NAME)).thenReturn(Optional.of(expectedFieldChange));
-        when(singleGenerator.generate(currentState, finalState, AuditedType.DESC)).thenReturn(Optional.empty());
+        when(singleGenerator.generate(currentState, finalState, new AuditedField<>(AuditedType.NAME))).thenReturn(Optional.of(expectedFieldChange));
+        when(singleGenerator.generate(currentState, finalState, new AuditedField<>(AuditedType.DESC))).thenReturn(Optional.empty());
 
         final Collection<FieldAuditRecord> actualFieldChanges =
             newGenerator(Stream.of(AuditedType.NAME, AuditedType.DESC)).generate(currentState, finalState);
@@ -78,8 +78,8 @@ public class AuditFieldChangesGeneratorTest {
     public void generate_twoFields_OnlySecondGenerated_ShouldReturnSecondFieldChange() {
         final FieldAuditRecord expectedFieldChange = mockFieldChange();
 
-        when(singleGenerator.generate(currentState, finalState, AuditedType.NAME)).thenReturn(Optional.empty());
-        when(singleGenerator.generate(currentState, finalState, AuditedType.DESC)).thenReturn(Optional.of(expectedFieldChange));
+        when(singleGenerator.generate(currentState, finalState, new AuditedField<>(AuditedType.NAME))).thenReturn(Optional.empty());
+        when(singleGenerator.generate(currentState, finalState, new AuditedField<>(AuditedType.DESC))).thenReturn(Optional.of(expectedFieldChange));
 
         final Collection<FieldAuditRecord> actualFieldChanges =
             newGenerator(Stream.of(AuditedType.NAME, AuditedType.DESC)).generate(currentState, finalState);
@@ -89,8 +89,8 @@ public class AuditFieldChangesGeneratorTest {
 
     @Test
     public void generate_twoFields_NoneGenerated_ShouldReturnEmpty() {
-        when(singleGenerator.generate(currentState, finalState, AuditedType.NAME)).thenReturn(Optional.empty());
-        when(singleGenerator.generate(currentState, finalState, AuditedType.DESC)).thenReturn(Optional.empty());
+        when(singleGenerator.generate(currentState, finalState, new AuditedField<>(AuditedType.NAME))).thenReturn(Optional.empty());
+        when(singleGenerator.generate(currentState, finalState, new AuditedField<>(AuditedType.DESC))).thenReturn(Optional.empty());
 
         final Collection<FieldAuditRecord> actualFieldChanges =
             newGenerator(Stream.of(AuditedType.NAME, AuditedType.DESC)).generate(currentState, finalState);
@@ -107,7 +107,7 @@ public class AuditFieldChangesGeneratorTest {
     }
 
     private AuditFieldChangesGenerator<AuditedType> newGenerator(final Stream<? extends EntityField<AuditedType, ?>> onChangeFields) {
-        return new AuditFieldChangesGenerator<>(onChangeFields, singleGenerator);
+        return new AuditFieldChangesGenerator<>(onChangeFields.map(AuditedField::new), singleGenerator);
     }
 
     private FieldAuditRecord mockFieldChange() {

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditMandatoryFieldValuesGeneratorTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditMandatoryFieldValuesGeneratorTest.java
@@ -113,6 +113,6 @@ public class AuditMandatoryFieldValuesGeneratorTest {
     }
 
     private AuditMandatoryFieldValuesGenerator newGenerator(final Stream<? extends EntityField<?, ?>> mandatoryFields) {
-        return new AuditMandatoryFieldValuesGenerator(mandatoryFields);
+        return new AuditMandatoryFieldValuesGenerator(mandatoryFields.map(AuditedField::new));
     }
 }

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditedEntityTypeResolverTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditedEntityTypeResolverTest.java
@@ -1,6 +1,5 @@
 package com.kenshoo.pl.entity.internal.audit;
 
-import com.google.common.collect.ImmutableSet;
 import com.kenshoo.jooq.DataTable;
 import com.kenshoo.pl.entity.AbstractEntityType;
 import com.kenshoo.pl.entity.EntityField;
@@ -43,8 +42,8 @@ public class AuditedEntityTypeResolverTest {
         final AuditedEntityType<AuditedType> expectedAuditedEntityType =
             AuditedEntityType.builder(AuditedType.ID)
                              .withName(ENTITY_TYPE_NAME)
-                             .withInternalFields(ON_CREATE_OR_UPDATE,
-                                               AuditedType.NAME, AuditedType.DESC, AuditedType.DESC2, AuditedType.AMOUNT)
+                             .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE,
+                                                           AuditedType.NAME, AuditedType.DESC, AuditedType.DESC2, AuditedType.AMOUNT)
                              .build();
 
         assertThat(auditedEntityTypeResolver.resolve(AuditedType.INSTANCE),
@@ -59,10 +58,10 @@ public class AuditedEntityTypeResolverTest {
         final AuditedEntityType<AuditedWithOnUpdateType> expectedAuditedEntityType =
             AuditedEntityType.builder(AuditedWithOnUpdateType.ID)
                              .withName(ENTITY_TYPE_NAME)
-                             .withInternalFields(ON_UPDATE,
-                                               AuditedWithOnUpdateType.NAME,
-                                               AuditedWithOnUpdateType.DESC,
-                                               AuditedWithOnUpdateType.DESC2)
+                             .withUnderlyingInternalFields(ON_UPDATE,
+                                                           AuditedWithOnUpdateType.NAME,
+                                                           AuditedWithOnUpdateType.DESC,
+                                                           AuditedWithOnUpdateType.DESC2)
                              .build();
 
         assertThat(auditedEntityTypeResolver.resolve(AuditedWithOnUpdateType.INSTANCE),
@@ -77,7 +76,7 @@ public class AuditedEntityTypeResolverTest {
         final AuditedEntityType<AuditedWithInternalMandatoryOnlyType> expectedAuditedEntityType =
             AuditedEntityType.builder(AuditedWithInternalMandatoryOnlyType.ID)
                              .withName(ENTITY_TYPE_NAME)
-                             .withInternalFields(ALWAYS, AuditedWithInternalMandatoryOnlyType.NAME)
+                             .withUnderlyingInternalFields(ALWAYS, AuditedWithInternalMandatoryOnlyType.NAME)
                              .build();
 
         assertThat(auditedEntityTypeResolver.resolve(AuditedWithInternalMandatoryOnlyType.INSTANCE),
@@ -87,17 +86,17 @@ public class AuditedEntityTypeResolverTest {
     @Test
     public void resolve_WhenAudited_AndHasId_AndExternalMandatoryFields_AndOtherFields_ShouldReturnIdAndExternalMandatoryAndOnChange() {
         when(auditedEntityTypeNameResolver.resolve(AuditedWithAncestorMandatoryType.INSTANCE)).thenReturn(ENTITY_TYPE_NAME);
-        doReturn(Stream.of(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC))
+        doReturn(Stream.of(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC).map(AuditedField::new))
             .when(externalMandatoryFieldsExtractor).extract(AuditedWithAncestorMandatoryType.INSTANCE);
 
         final AuditedEntityType<AuditedWithAncestorMandatoryType> expectedAuditedEntityType =
             AuditedEntityType.builder(AuditedWithAncestorMandatoryType.ID)
                              .withName(ENTITY_TYPE_NAME)
-                             .withInternalFields(ON_CREATE_OR_UPDATE,
-                                               AuditedWithAncestorMandatoryType.NAME,
-                                               AuditedWithAncestorMandatoryType.DESC,
-                                               AuditedWithAncestorMandatoryType.DESC2)
-                             .withExternalFields(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC)
+                             .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE,
+                                                           AuditedWithAncestorMandatoryType.NAME,
+                                                           AuditedWithAncestorMandatoryType.DESC,
+                                                           AuditedWithAncestorMandatoryType.DESC2)
+                             .withUnderlyingExternalFields(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC)
                              .build();
 
         assertThat(auditedEntityTypeResolver.resolve(AuditedWithAncestorMandatoryType.INSTANCE),
@@ -107,16 +106,16 @@ public class AuditedEntityTypeResolverTest {
     @Test
     public void resolve_WhenAudited_AndHasEverything_ShouldReturnEverything() {
         when(auditedEntityTypeNameResolver.resolve(AuditedWithAllVariationsType.INSTANCE)).thenReturn(ENTITY_TYPE_NAME);
-        doReturn(Stream.of(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC))
+        doReturn(Stream.of(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC).map(AuditedField::new))
             .when(externalMandatoryFieldsExtractor).extract(AuditedWithAllVariationsType.INSTANCE);
 
         final AuditedEntityType<AuditedWithAllVariationsType> expectedAuditedEntityType =
             AuditedEntityType.builder(AuditedWithAllVariationsType.ID)
                              .withName(ENTITY_TYPE_NAME)
-                             .withExternalFields(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC)
-                             .withInternalFields(ALWAYS, AuditedWithAllVariationsType.NAME)
-                             .withInternalFields(ON_CREATE_OR_UPDATE, AuditedWithAllVariationsType.DESC)
-                             .withInternalFields(ON_UPDATE, AuditedWithAllVariationsType.DESC2)
+                             .withUnderlyingExternalFields(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC)
+                             .withUnderlyingInternalFields(ALWAYS, AuditedWithAllVariationsType.NAME)
+                             .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE, AuditedWithAllVariationsType.DESC)
+                             .withUnderlyingInternalFields(ON_UPDATE, AuditedWithAllVariationsType.DESC2)
                              .build();
 
         assertThat(auditedEntityTypeResolver.resolve(AuditedWithAllVariationsType.INSTANCE),
@@ -131,8 +130,8 @@ public class AuditedEntityTypeResolverTest {
         final AuditedEntityType<InclusiveAuditedType> expectedAuditedEntityType =
             AuditedEntityType.builder(InclusiveAuditedType.ID)
                              .withName(ENTITY_TYPE_NAME)
-                             .withInternalFields(ON_CREATE_OR_UPDATE,
-                                               InclusiveAuditedType.NAME, InclusiveAuditedType.DESC)
+                             .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE,
+                                                           InclusiveAuditedType.NAME, InclusiveAuditedType.DESC)
                              .build();
 
         assertThat(auditedEntityTypeResolver.resolve(InclusiveAuditedType.INSTANCE),
@@ -147,7 +146,7 @@ public class AuditedEntityTypeResolverTest {
         final AuditedEntityType<ExclusiveAuditedType> expectedAuditedEntityType =
             AuditedEntityType.builder(ExclusiveAuditedType.ID)
                              .withName(ENTITY_TYPE_NAME)
-                             .withInternalFields(ON_CREATE_OR_UPDATE, ImmutableSet.of(ExclusiveAuditedType.NAME))
+                             .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE, ExclusiveAuditedType.NAME)
                              .build();
 
         assertThat(auditedEntityTypeResolver.resolve(ExclusiveAuditedType.INSTANCE),

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditedEntityTypeTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditedEntityTypeTest.java
@@ -7,11 +7,12 @@ import com.kenshoo.pl.entity.internal.audit.entitytypes.NotAuditedAncestorType;
 import org.junit.Test;
 
 import java.util.Set;
+import java.util.stream.Stream;
 
 import static com.kenshoo.pl.entity.audit.AuditTrigger.*;
 import static com.kenshoo.pl.entity.internal.audit.AuditedEntityType.builder;
-import static java.util.Collections.singleton;
 import static java.util.stream.Collectors.toSet;
+import static java.util.stream.Collectors.toUnmodifiableSet;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.junit.Assert.assertThat;
@@ -38,172 +39,91 @@ public class AuditedEntityTypeTest {
     }
 
     @Test
-    public void getAllFields_IdOnly() {
-        final AuditedEntityType<AuditedType> auditedEntityType =
-            builder(AuditedType.ID).build();
-
-        final Set<EntityField<?, ?>> expectedAllFields = singleton(AuditedType.ID);
-
-        assertThat(auditedEntityType.getAllFields().collect(toSet()), is(expectedAllFields));
-    }
-
-    @Test
-    public void getAllFields_IdAndExternalMandatory() {
+    public void getInternalFields_WhenHasOnCreateOrUpdate() {
         final AuditedEntityType<AuditedType> auditedEntityType =
             builder(AuditedType.ID)
-                .withExternalFields(ImmutableSet.of(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC))
+                .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE, AuditedType.NAME, AuditedType.DESC)
                 .build();
 
-        final Set<EntityField<?, ?>> expectedAllFields =
-            ImmutableSet.of(AuditedType.ID,
-                            NotAuditedAncestorType.NAME,
-                            NotAuditedAncestorType.DESC);
+        final Set<AuditedField<?, ?>> expectedInternalFields =
+            Stream.<EntityField<?, ?>>of(AuditedType.NAME,
+                                         AuditedType.DESC)
+                  .map(AuditedField::new)
+                  .collect(toUnmodifiableSet());
 
-        assertThat(auditedEntityType.getAllFields().collect(toSet()), is(expectedAllFields));
+        assertThat(auditedEntityType.getInternalFields().collect(toSet()), is(expectedInternalFields));
     }
 
     @Test
-    public void getAllFields_IdAndInternalMandatory() {
+    public void getInternalFields_WhenHasOnUpdate() {
         final AuditedEntityType<AuditedType> auditedEntityType =
             builder(AuditedType.ID)
-                .withInternalFields(ALWAYS, AuditedType.NAME, AuditedType.DESC)
+                .withUnderlyingInternalFields(ON_UPDATE, AuditedType.NAME, AuditedType.DESC)
                 .build();
 
-        final Set<EntityField<?, ?>> expectedAllFields =
-            ImmutableSet.of(AuditedType.ID,
-                            AuditedType.NAME,
-                            AuditedType.DESC);
+        final Set<AuditedField<?, ?>> expectedInternalFields =
+            Stream.<EntityField<?, ?>>of(AuditedType.NAME,
+                                         AuditedType.DESC)
+                  .map(AuditedField::new)
+                  .collect(toUnmodifiableSet());
 
-        assertThat(auditedEntityType.getAllFields().collect(toSet()), is(expectedAllFields));
+        assertThat(auditedEntityType.getInternalFields().collect(toSet()), is(expectedInternalFields));
     }
 
     @Test
-    public void getAllFields_IdAndOnCreateOrUpdate() {
+    public void getInternalFields_WhenHasInternalMandatory() {
         final AuditedEntityType<AuditedType> auditedEntityType =
             builder(AuditedType.ID)
-                .withInternalFields(ON_CREATE_OR_UPDATE, AuditedType.NAME, AuditedType.DESC)
+                .withUnderlyingInternalFields(ALWAYS, AuditedType.NAME, AuditedType.DESC)
                 .build();
 
-        final Set<EntityField<?, ?>> expectedAllFields =
-            ImmutableSet.of(AuditedType.ID,
-                            AuditedType.NAME,
-                            AuditedType.DESC);
+        final Set<AuditedField<?, ?>> expectedInternalFields =
+            Stream.<EntityField<?, ?>>of(AuditedType.NAME,
+                                         AuditedType.DESC)
+                  .map(AuditedField::new)
+                  .collect(toUnmodifiableSet());
 
-        assertThat(auditedEntityType.getAllFields().collect(toSet()), is(expectedAllFields));
+        assertThat(auditedEntityType.getInternalFields().collect(toSet()), is(expectedInternalFields));
     }
 
     @Test
-    public void getAllFields_IdAndOnUpdate() {
+    public void getInternalFields_WhenHasOnCreateOrUpdateAndOnUpdate() {
         final AuditedEntityType<AuditedType> auditedEntityType =
             builder(AuditedType.ID)
-                .withInternalFields(ON_UPDATE, AuditedType.NAME, AuditedType.DESC)
+                .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE, AuditedType.NAME, AuditedType.DESC)
+                .withUnderlyingInternalFields(ON_UPDATE, AuditedType.DESC2)
                 .build();
 
-        final Set<EntityField<?, ?>> expectedAllFields =
-            ImmutableSet.of(AuditedType.ID,
-                            AuditedType.NAME,
-                            AuditedType.DESC);
+        final Set<AuditedField<?, ?>> expectedInternalFields =
+            Stream.<EntityField<?, ?>>of(AuditedType.NAME,
+                                         AuditedType.DESC,
+                                         AuditedType.DESC2)
+                  .map(AuditedField::new)
+                  .collect(toUnmodifiableSet());
 
-        assertThat(auditedEntityType.getAllFields().collect(toSet()), is(expectedAllFields));
+        assertThat(auditedEntityType.getInternalFields().collect(toSet()), is(expectedInternalFields));
     }
 
     @Test
-    public void getAllFields_AllTypes() {
+    public void getInternalFields_WhenHasOnCreateOrUpdateAndInternalMandatory() {
         final AuditedEntityType<AuditedType> auditedEntityType =
             builder(AuditedType.ID)
-                .withExternalFields(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC)
-                .withInternalFields(ALWAYS, AuditedType.NAME)
-                .withInternalFields(ON_CREATE_OR_UPDATE, AuditedType.DESC)
-                .withInternalFields(ON_UPDATE, AuditedType.DESC2)
+                .withUnderlyingInternalFields(ALWAYS, AuditedType.NAME)
+                .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE, AuditedType.DESC, AuditedType.DESC2)
                 .build();
 
-        final Set<EntityField<?, ?>> expectedAllFields =
-            ImmutableSet.of(AuditedType.ID,
-                            NotAuditedAncestorType.NAME,
-                            NotAuditedAncestorType.DESC,
-                            AuditedType.NAME,
-                            AuditedType.DESC,
-                            AuditedType.DESC2);
+        final Set<AuditedField<?, ?>> expectedInternalFields =
+            Stream.<EntityField<?, ?>>of(AuditedType.NAME,
+                                         AuditedType.DESC,
+                                         AuditedType.DESC2)
+                  .map(AuditedField::new)
+                  .collect(toUnmodifiableSet());
 
-        assertThat(auditedEntityType.getAllFields().collect(toSet()), is(expectedAllFields));
+        assertThat(auditedEntityType.getInternalFields().collect(toSet()), is(expectedInternalFields));
     }
 
     @Test
-    public void getAllInternalFields_WhenHasOnCreateOrUpdate() {
-        final AuditedEntityType<AuditedType> auditedEntityType =
-            builder(AuditedType.ID)
-                .withInternalFields(ON_CREATE_OR_UPDATE, AuditedType.NAME, AuditedType.DESC)
-                .build();
-
-        final Set<EntityField<?, ?>> expectedAllFields =
-            ImmutableSet.of(AuditedType.NAME,
-                            AuditedType.DESC);
-
-        assertThat(auditedEntityType.getInternalFields().collect(toSet()), is(expectedAllFields));
-    }
-
-    @Test
-    public void getAllInternalFields_WhenHasOnUpdate() {
-        final AuditedEntityType<AuditedType> auditedEntityType =
-            builder(AuditedType.ID)
-                .withInternalFields(ON_UPDATE, AuditedType.NAME, AuditedType.DESC)
-                .build();
-
-        final Set<EntityField<?, ?>> expectedAllFields =
-            ImmutableSet.of(AuditedType.NAME,
-                            AuditedType.DESC);
-
-        assertThat(auditedEntityType.getInternalFields().collect(toSet()), is(expectedAllFields));
-    }
-
-    @Test
-    public void getAllInternalFields_WhenHasInternalMandatory() {
-        final AuditedEntityType<AuditedType> auditedEntityType =
-            builder(AuditedType.ID)
-                .withInternalFields(ALWAYS, AuditedType.NAME, AuditedType.DESC)
-                .build();
-
-        final Set<EntityField<?, ?>> expectedAllFields =
-            ImmutableSet.of(AuditedType.NAME,
-                            AuditedType.DESC);
-
-        assertThat(auditedEntityType.getInternalFields().collect(toSet()), is(expectedAllFields));
-    }
-
-    @Test
-    public void getAllInternalFields_WhenHasOnCreateOrUpdateAndOnUpdate() {
-        final AuditedEntityType<AuditedType> auditedEntityType =
-            builder(AuditedType.ID)
-                .withInternalFields(ON_CREATE_OR_UPDATE, AuditedType.NAME, AuditedType.DESC)
-                .withInternalFields(ON_UPDATE, AuditedType.DESC2)
-                .build();
-
-        final Set<EntityField<?, ?>> expectedAllFields =
-            ImmutableSet.of(AuditedType.NAME,
-                            AuditedType.DESC,
-                            AuditedType.DESC2);
-
-        assertThat(auditedEntityType.getInternalFields().collect(toSet()), is(expectedAllFields));
-    }
-
-    @Test
-    public void getAllInternalFields_WhenHasOnCreateOrUpdateAndInternalMandatory() {
-        final AuditedEntityType<AuditedType> auditedEntityType =
-            builder(AuditedType.ID)
-                .withInternalFields(ALWAYS, AuditedType.NAME)
-                .withInternalFields(ON_CREATE_OR_UPDATE, AuditedType.DESC, AuditedType.DESC2)
-                .build();
-
-        final Set<EntityField<?, ?>> expectedAllFields =
-            ImmutableSet.of(AuditedType.NAME,
-                            AuditedType.DESC,
-                            AuditedType.DESC2);
-
-        assertThat(auditedEntityType.getInternalFields().collect(toSet()), is(expectedAllFields));
-    }
-
-    @Test
-    public void getAllInternalFields_WhenHasNone() {
+    public void getInternalFields_WhenHasNone() {
         final AuditedEntityType<AuditedType> auditedEntityType =
             builder(AuditedType.ID).build();
 
@@ -211,57 +131,57 @@ public class AuditedEntityTypeTest {
     }
 
     @Test
-    public void getOnChangeFields_WhenHasOnCreateOrUpdate() {
+    public void getUnderlyingOnChangeFields_WhenHasOnCreateOrUpdate() {
         final AuditedEntityType<AuditedType> auditedEntityType =
             builder(AuditedType.ID)
-                .withInternalFields(ON_CREATE_OR_UPDATE, AuditedType.NAME, AuditedType.DESC)
+                .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE, AuditedType.NAME, AuditedType.DESC)
                 .build();
 
         final Set<EntityField<?, ?>> expectedOnChangeFields =
             ImmutableSet.of(AuditedType.NAME, AuditedType.DESC);
 
-        assertThat(auditedEntityType.getOnChangeFields().collect(toSet()), is(expectedOnChangeFields));
+        assertThat(auditedEntityType.getUnderlyingOnChangeFields().collect(toSet()), is(expectedOnChangeFields));
     }
 
     @Test
-    public void getOnChangeFields_WhenHasOnUpdate() {
+    public void getUnderlyingOnChangeFields_WhenHasOnUpdate() {
         final AuditedEntityType<AuditedType> auditedEntityType =
             builder(AuditedType.ID)
-                .withInternalFields(ON_UPDATE, AuditedType.NAME, AuditedType.DESC)
+                .withUnderlyingInternalFields(ON_UPDATE, AuditedType.NAME, AuditedType.DESC)
                 .build();
 
         final Set<EntityField<?, ?>> expectedOnChangeFields =
             ImmutableSet.of(AuditedType.NAME, AuditedType.DESC);
 
-        assertThat(auditedEntityType.getOnChangeFields().collect(toSet()), is(expectedOnChangeFields));
+        assertThat(auditedEntityType.getUnderlyingOnChangeFields().collect(toSet()), is(expectedOnChangeFields));
     }
 
     @Test
-    public void getOnChangeFields_WhenHasExternalMandatory() {
+    public void getUnderlyingOnChangeFields_WhenHasExternalMandatory() {
         final AuditedEntityType<AuditedType> auditedEntityType =
             builder(AuditedType.ID)
-                .withExternalFields(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC)
+                .withUnderlyingExternalFields(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC)
                 .build();
 
-        assertThat(auditedEntityType.getOnChangeFields().collect(toSet()), is(empty()));
+        assertThat(auditedEntityType.getUnderlyingOnChangeFields().collect(toSet()), is(empty()));
     }
 
     @Test
-    public void getOnChangeFields_WhenHasInternalMandatory() {
+    public void getUnderlyingOnChangeFields_WhenHasInternalMandatory() {
         final AuditedEntityType<AuditedType> auditedEntityType =
             builder(AuditedType.ID)
-                .withInternalFields(ALWAYS, AuditedType.NAME, AuditedType.DESC)
+                .withUnderlyingInternalFields(ALWAYS, AuditedType.NAME, AuditedType.DESC)
                 .build();
 
-        assertThat(auditedEntityType.getOnChangeFields().collect(toSet()), is(empty()));
+        assertThat(auditedEntityType.getUnderlyingOnChangeFields().collect(toSet()), is(empty()));
     }
 
     @Test
-    public void getOnChangeFields_WhenHasOnCreateOrUpdateAndOnUpdate() {
+    public void getUnderlyingOnChangeFields_WhenHasOnCreateOrUpdateAndOnUpdate() {
         final AuditedEntityType<AuditedType> auditedEntityType =
             builder(AuditedType.ID)
-                .withInternalFields(ON_CREATE_OR_UPDATE, AuditedType.NAME, AuditedType.DESC)
-                .withInternalFields(ON_UPDATE, AuditedType.DESC2)
+                .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE, AuditedType.NAME, AuditedType.DESC)
+                .withUnderlyingInternalFields(ON_UPDATE, AuditedType.DESC2)
                 .build();
 
         final Set<EntityField<?, ?>> expectedOnChangeFields =
@@ -269,79 +189,138 @@ public class AuditedEntityTypeTest {
                             AuditedType.DESC,
                             AuditedType.DESC2);
 
-        assertThat(auditedEntityType.getOnChangeFields().collect(toSet()), is(expectedOnChangeFields));
+        assertThat(auditedEntityType.getUnderlyingOnChangeFields().collect(toSet()), is(expectedOnChangeFields));
     }
 
     @Test
-    public void getOnChangeFields_WhenHasOnCreateOrUpdateAndInternalMandatory() {
+    public void getUnderlyingOnChangeFields_WhenHasOnCreateOrUpdateAndInternalMandatory() {
         final AuditedEntityType<AuditedType> auditedEntityType =
             builder(AuditedType.ID)
-                .withInternalFields(ALWAYS, AuditedType.NAME)
-                .withInternalFields(ON_CREATE_OR_UPDATE, AuditedType.DESC, AuditedType.DESC2)
+                .withUnderlyingInternalFields(ALWAYS, AuditedType.NAME)
+                .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE, AuditedType.DESC, AuditedType.DESC2)
                 .build();
 
         final Set<EntityField<?, ?>> expectedOnChangeFields =
             ImmutableSet.of(AuditedType.DESC, AuditedType.DESC2);
 
-        assertThat(auditedEntityType.getOnChangeFields().collect(toSet()), is(expectedOnChangeFields));
+        assertThat(auditedEntityType.getUnderlyingOnChangeFields().collect(toSet()), is(expectedOnChangeFields));
     }
 
     @Test
-    public void getOnChangeFields_WhenHasNone() {
+    public void getUnderlyingOnChangeFields_WhenHasNone() {
         final AuditedEntityType<AuditedType> auditedEntityType =
             builder(AuditedType.ID).build();
 
-        assertThat(auditedEntityType.getOnChangeFields().collect(toSet()), is(empty()));
+        assertThat(auditedEntityType.getUnderlyingOnChangeFields().collect(toSet()), is(empty()));
     }
 
     @Test
-    public void getAllMandatoryFields_WhenHasExternalMandatory() {
+    public void getUnderlyingMandatoryFields_WhenHasExternalMandatory() {
         final AuditedEntityType<AuditedType> auditedEntityType =
             builder(AuditedType.ID)
-                .withExternalFields(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC)
+                .withUnderlyingExternalFields(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC)
+                .build();
+
+        final Set<EntityField<?, ?>> expectedFields =
+            Set.of(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC);
+
+        assertThat(auditedEntityType.getUnderlyingMandatoryFields().collect(toSet()), is(expectedFields));
+    }
+
+    @Test
+    public void getUnderlyingMandatoryFields_WhenHasInternalMandatory() {
+        final AuditedEntityType<AuditedType> auditedEntityType =
+            builder(AuditedType.ID)
+                .withUnderlyingInternalFields(ALWAYS, AuditedType.NAME, AuditedType.DESC)
+                .build();
+
+        final Set<EntityField<?, ?>> expectedFields =
+            Set.of(AuditedType.NAME, AuditedType.DESC);
+
+        assertThat(auditedEntityType.getUnderlyingMandatoryFields().collect(toSet()), is(expectedFields));
+    }
+
+    @Test
+    public void getUnderlyingMandatoryFields_WhenHasExternalAndInternalMandatory() {
+        final AuditedEntityType<AuditedType> auditedEntityType =
+            builder(AuditedType.ID)
+                .withUnderlyingExternalFields(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC)
+                .withUnderlyingInternalFields(ALWAYS, AuditedType.NAME, AuditedType.DESC)
                 .build();
 
         final Set<EntityField<?, ?>> expectedAllFields =
-            ImmutableSet.of(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC);
+            Set.of(NotAuditedAncestorType.NAME,
+                   NotAuditedAncestorType.DESC,
+                   AuditedType.NAME,
+                   AuditedType.DESC);
+
+        assertThat(auditedEntityType.getUnderlyingMandatoryFields().collect(toSet()), is(expectedAllFields));
+    }
+
+    @Test
+    public void getUnderlyingMandatoryFields_WhenHasNoMandatory() {
+        final AuditedEntityType<AuditedType> auditedEntityType =
+            builder(AuditedType.ID)
+                .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE, AuditedType.NAME, AuditedType.DESC)
+                .build();
+
+        assertThat(auditedEntityType.getUnderlyingMandatoryFields().collect(toSet()), is(empty()));
+    }
+
+    @Test
+    public void getMandatoryFields_WhenHasExternalMandatory() {
+        final AuditedEntityType<AuditedType> auditedEntityType =
+            builder(AuditedType.ID)
+                .withUnderlyingExternalFields(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC)
+                .build();
+
+        final Set<AuditedField<?, ?>> expectedAllFields =
+            Stream.of(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC)
+                  .map(AuditedField::new)
+                  .collect(toUnmodifiableSet());
 
         assertThat(auditedEntityType.getMandatoryFields().collect(toSet()), is(expectedAllFields));
     }
 
     @Test
-    public void getAllMandatoryFields_WhenHasInternalMandatory() {
+    public void getMandatoryFields_WhenHasInternalMandatory() {
         final AuditedEntityType<AuditedType> auditedEntityType =
             builder(AuditedType.ID)
-                .withExternalFields(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC)
+                .withUnderlyingInternalFields(ALWAYS, AuditedType.NAME, AuditedType.DESC)
                 .build();
 
-        final Set<EntityField<?, ?>> expectedAllFields =
-            ImmutableSet.of(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC);
+        final Set<AuditedField<?, ?>> expectedAllFields =
+            Stream.of(AuditedType.NAME, AuditedType.DESC)
+                  .map(AuditedField::new)
+                  .collect(toUnmodifiableSet());
 
         assertThat(auditedEntityType.getMandatoryFields().collect(toSet()), is(expectedAllFields));
     }
 
     @Test
-    public void getAllMandatoryFields_WhenHasExternalAndInternalMandatory() {
+    public void getMandatoryFields_WhenHasExternalAndInternalMandatory() {
         final AuditedEntityType<AuditedType> auditedEntityType =
             builder(AuditedType.ID)
-                .withExternalFields(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC)
-                .withInternalFields(ALWAYS, AuditedType.NAME, AuditedType.DESC)
+                .withUnderlyingExternalFields(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC)
+                .withUnderlyingInternalFields(ALWAYS, AuditedType.NAME, AuditedType.DESC)
                 .build();
 
-        final Set<EntityField<?, ?>> expectedAllFields =
-            ImmutableSet.of(NotAuditedAncestorType.NAME,
-                            NotAuditedAncestorType.DESC,
-                            AuditedType.NAME,
-                            AuditedType.DESC);
+        final Set<AuditedField<?, ?>> expectedAllFields =
+            Stream.<EntityField<?, ?>>of(NotAuditedAncestorType.NAME,
+                                         NotAuditedAncestorType.DESC,
+                                         AuditedType.NAME,
+                                         AuditedType.DESC)
+                  .map(AuditedField::new)
+                  .collect(toUnmodifiableSet());
 
         assertThat(auditedEntityType.getMandatoryFields().collect(toSet()), is(expectedAllFields));
     }
 
     @Test
-    public void getAllMandatoryFields_WhenHasNoMandatory() {
+    public void getMandatoryFields_WhenHasNoMandatory() {
         final AuditedEntityType<AuditedType> auditedEntityType =
             builder(AuditedType.ID)
-                .withInternalFields(ON_CREATE_OR_UPDATE, AuditedType.NAME, AuditedType.DESC)
+                .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE, AuditedType.NAME, AuditedType.DESC)
                 .build();
 
         assertThat(auditedEntityType.getMandatoryFields().collect(toSet()), is(empty()));
@@ -351,7 +330,7 @@ public class AuditedEntityTypeTest {
     public void hasInternalFields_WhenHasOnCreateOrUpdateFields_ShouldReturnTrue() {
         final AuditedEntityType<AuditedType> auditedEntityType =
             builder(AuditedType.ID)
-                .withInternalFields(ON_CREATE_OR_UPDATE, AuditedType.NAME, AuditedType.DESC)
+                .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE, AuditedType.NAME, AuditedType.DESC)
                 .build();
 
         assertThat(auditedEntityType.hasInternalFields(), is(true));
@@ -361,7 +340,7 @@ public class AuditedEntityTypeTest {
     public void hasInternalFields_WhenHasOnUpdateFields_ShouldReturnTrue() {
         final AuditedEntityType<AuditedType> auditedEntityType =
             builder(AuditedType.ID)
-                .withInternalFields(ON_UPDATE, AuditedType.NAME, AuditedType.DESC)
+                .withUnderlyingInternalFields(ON_UPDATE, AuditedType.NAME, AuditedType.DESC)
                 .build();
 
         assertThat(auditedEntityType.hasInternalFields(), is(true));
@@ -371,7 +350,7 @@ public class AuditedEntityTypeTest {
     public void hasInternalFields_WhenHasInternalMandatoryFields_ShouldReturnTrue() {
         final AuditedEntityType<AuditedType> auditedEntityType =
             builder(AuditedType.ID)
-                .withInternalFields(ALWAYS, AuditedType.NAME, AuditedType.DESC)
+                .withUnderlyingInternalFields(ALWAYS, AuditedType.NAME, AuditedType.DESC)
                 .build();
 
         assertThat(auditedEntityType.hasInternalFields(), is(true));
@@ -388,7 +367,7 @@ public class AuditedEntityTypeTest {
     public void hasInternalFields_WhenHasIdAndExternalMandatoryOnly_ShouldReturnFalse() {
         final AuditedEntityType<AuditedType> auditedEntityType =
             builder(AuditedType.ID)
-                .withExternalFields(NotAuditedAncestorType.NAME)
+                .withUnderlyingExternalFields(NotAuditedAncestorType.NAME)
                 .build();
 
         assertThat(auditedEntityType.hasInternalFields(), is(false));

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditedFieldTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditedFieldTest.java
@@ -1,0 +1,69 @@
+package com.kenshoo.pl.entity.internal.audit;
+
+import com.kenshoo.pl.entity.Entity;
+import com.kenshoo.pl.entity.Triptional;
+import com.kenshoo.pl.entity.internal.audit.entitytypes.AuditedType;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static com.kenshoo.pl.entity.internal.audit.entitytypes.AuditedType.DESC;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AuditedFieldTest {
+
+    private static final String DESC_FIELD_NAME = "desc";
+    private static final String DESC_VALUE = "A description";
+
+    @Mock
+    private Entity entity;
+
+    private final AuditedField<AuditedType, String> auditedDescField = new AuditedField<>(DESC, DESC_FIELD_NAME);
+
+    @Test
+    public void getUnderlying() {
+        assertThat(auditedDescField.getField(), is(DESC));
+    }
+
+    @Test
+    public void oneArgCtorAndGetName() {
+        assertThat(new AuditedField<>(DESC).getName(), is(DESC.toString()));
+    }
+
+    @Test
+    public void twoArgCtorAndGetName() {
+        assertThat(auditedDescField.getName(), is(DESC_FIELD_NAME));
+    }
+
+    @Test
+    public void getValueWhenNonNull() {
+        when(entity.safeGet(DESC)).thenReturn(Triptional.of(DESC_VALUE));
+        assertThat(auditedDescField.getValue(entity), is(Triptional.of(DESC_VALUE)));
+    }
+
+    @Test
+    public void getValueWhenNull() {
+        when(entity.safeGet(DESC)).thenReturn(Triptional.nullInstance());
+        assertThat(auditedDescField.getValue(entity), is(Triptional.nullInstance()));
+    }
+
+    @Test
+    public void getValueWhenAbsent() {
+        when(entity.safeGet(DESC)).thenReturn(Triptional.absent());
+        assertThat(auditedDescField.getValue(entity), is(Triptional.absent()));
+    }
+
+    @Test
+    public void valuesEqualWhenEqual() {
+        assertThat(auditedDescField.valuesEqual("abc", "abc"), is(true));
+    }
+
+    @Test
+    public void valuesEqualWhenNotEqual() {
+        assertThat(auditedDescField.valuesEqual("abc", "def"), is(false));
+    }
+}

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/ExternalMandatoryFieldsExtractorTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/ExternalMandatoryFieldsExtractorTest.java
@@ -1,15 +1,17 @@
 package com.kenshoo.pl.entity.internal.audit;
 
-import com.google.common.collect.ImmutableSet;
-import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.internal.audit.entitytypes.*;
 import org.junit.Test;
 
+import java.util.Set;
+import java.util.stream.Stream;
+
 import static java.util.stream.Collectors.toSet;
+import static java.util.stream.Collectors.toUnmodifiableSet;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
-import static org.junit.Assert.assertThat;
 
 public class ExternalMandatoryFieldsExtractorTest {
 
@@ -17,9 +19,13 @@ public class ExternalMandatoryFieldsExtractorTest {
 
     @Test
     public void resolve_WhenAudited_AndHasExternalMandatory_ShouldReturnThem() {
-        assertThat(EXTRACTOR.extract(AuditedWithAncestorMandatoryType.INSTANCE).collect(toSet()),
-                   equalTo(ImmutableSet.<EntityField<?, ?>>of(NotAuditedAncestorType.NAME,
-                                                              NotAuditedAncestorType.DESC)));
+        final Set<AuditedField<?, ?>> expectedAuditedFields = Stream.of(NotAuditedAncestorType.NAME,
+                                                                        NotAuditedAncestorType.DESC)
+                                                                    .map(AuditedField::new)
+                                                                    .collect(toUnmodifiableSet());
+
+        assertThat(EXTRACTOR.extract(AuditedWithAncestorMandatoryType.INSTANCE).collect(toUnmodifiableSet()),
+                   equalTo(expectedAuditedFields));
     }
 
     @Test


### PR DESCRIPTION
- Adding a new class `AuditedField` to contain a pair of field + name
- Refactoring `AuditedEntityType` to hold `AuditedField`-s instead of `EntityField`-s
- The name is _temporarily_ populated with the default which is the `toString()` value