### PR TITLE
PL-111: Apply override to audit name of external mandatory field

### DIFF
--- a/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditWithFieldNameOverridesTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditWithFieldNameOverridesTest.java
@@ -5,13 +5,17 @@ import com.kenshoo.jooq.DataTableUtils;
 import com.kenshoo.jooq.TestJooqConfig;
 import com.kenshoo.pl.audit.commands.CreateAuditedChild1WithFieldNameOverridesCommand;
 import com.kenshoo.pl.audit.commands.CreateAuditedChild2WithFieldNameOverridesCommand;
+import com.kenshoo.pl.audit.commands.CreateAuditedWithAncestorFieldNameOverridesCommand;
 import com.kenshoo.pl.audit.commands.CreateAuditedWithFieldNameOverridesCommand;
 import com.kenshoo.pl.entity.*;
 import com.kenshoo.pl.entity.audit.AuditRecord;
+import com.kenshoo.pl.entity.internal.audit.AncestorTable;
 import com.kenshoo.pl.entity.internal.audit.ChildTable;
 import com.kenshoo.pl.entity.internal.audit.MainTable;
+import com.kenshoo.pl.entity.internal.audit.MainWithAncestorTable;
 import com.kenshoo.pl.entity.internal.audit.entitytypes.AuditedChild1WithFieldNameOverridesType;
 import com.kenshoo.pl.entity.internal.audit.entitytypes.AuditedChild2WithFieldNameOverridesType;
+import com.kenshoo.pl.entity.internal.audit.entitytypes.AuditedWithAncestorFieldNameOverridesType;
 import com.kenshoo.pl.entity.internal.audit.entitytypes.AuditedWithFieldNameOverridesType;
 import org.jooq.DSLContext;
 import org.junit.After;
@@ -21,8 +25,9 @@ import org.junit.Test;
 import java.util.List;
 import java.util.Set;
 
-import static com.kenshoo.pl.entity.matchers.audit.AuditRecordMatchers.hasChildRecordThat;
-import static com.kenshoo.pl.entity.matchers.audit.AuditRecordMatchers.hasCreatedFieldRecord;
+import static com.kenshoo.pl.entity.internal.audit.ancestorfieldsproviders.AncestorWithFieldNameOverridesAuditExtensions.DESC_FIELD_NAME_OVERRIDE;
+import static com.kenshoo.pl.entity.internal.audit.ancestorfieldsproviders.AncestorWithFieldNameOverridesAuditExtensions.NAME_FIELD_NAME_OVERRIDE;
+import static com.kenshoo.pl.entity.matchers.audit.AuditRecordMatchers.*;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.Matchers.hasSize;
@@ -30,14 +35,24 @@ import static org.junit.Assert.assertThat;
 
 public class AuditWithFieldNameOverridesTest {
 
-    private static final Set<DataTable> ALL_TABLES = Set.of(MainTable.INSTANCE, ChildTable.INSTANCE);
+    private static final Set<DataTable> ALL_TABLES = Set.of(AncestorTable.INSTANCE,
+                                                            MainWithAncestorTable.INSTANCE,
+                                                            MainTable.INSTANCE,
+                                                            ChildTable.INSTANCE);
+
+    private static final String ANCESTOR_NAME_VALUE = "ancestorNameValue";
+    private static final String ANCESTOR_DESC_VALUE = "ancestorDescValue";
+    private static final long ANCESTOR_ID = 123;
+
 
     private PLContext plContext;
     private InMemoryAuditRecordPublisher auditRecordPublisher;
 
-    private ChangeFlowConfig<AuditedWithFieldNameOverridesType> flowConfig;
+    private ChangeFlowConfig<AuditedWithFieldNameOverridesType> mainFlowConfig;
+    private ChangeFlowConfig<AuditedWithAncestorFieldNameOverridesType> mainWithAncestorFlowConfig;
 
-    private PersistenceLayer<AuditedWithFieldNameOverridesType> pl;
+    private PersistenceLayer<AuditedWithFieldNameOverridesType> mainPL;
+    private PersistenceLayer<AuditedWithAncestorFieldNameOverridesType> mainWithAncestorPL;
 
     @Before
     public void setUp() {
@@ -48,14 +63,22 @@ public class AuditWithFieldNameOverridesTest {
             .withAuditRecordPublisher(auditRecordPublisher)
             .build();
 
-        flowConfig = flowConfigBuilder(AuditedWithFieldNameOverridesType.INSTANCE)
+        mainFlowConfig = flowConfigBuilder(AuditedWithFieldNameOverridesType.INSTANCE)
             .withChildFlowBuilder(flowConfigBuilder(AuditedChild1WithFieldNameOverridesType.INSTANCE))
             .withChildFlowBuilder(flowConfigBuilder(AuditedChild2WithFieldNameOverridesType.INSTANCE))
             .build();
+        mainWithAncestorFlowConfig = flowConfigBuilder(AuditedWithAncestorFieldNameOverridesType.INSTANCE).build();
 
-        pl = persistenceLayer();
+        mainPL = persistenceLayer();
+        mainWithAncestorPL = persistenceLayer();
 
         ALL_TABLES.forEach(table -> DataTableUtils.createTable(dslContext, table));
+
+        dslContext.insertInto(AncestorTable.INSTANCE)
+                  .set(AncestorTable.INSTANCE.id, ANCESTOR_ID)
+                  .set(AncestorTable.INSTANCE.name, ANCESTOR_NAME_VALUE)
+                  .set(AncestorTable.INSTANCE.desc, ANCESTOR_DESC_VALUE)
+                  .execute();
     }
 
     @After
@@ -67,8 +90,8 @@ public class AuditWithFieldNameOverridesTest {
     public void overrideFieldNameInStandalone() {
         final String descValue = "descValue";
 
-        pl.create(singletonList(parentCreateCmd()
-                                    .with(AuditedWithFieldNameOverridesType.DESC, descValue)), flowConfig);
+        mainPL.create(singletonList(parentCreateCmd()
+                                        .with(AuditedWithFieldNameOverridesType.DESC, descValue)), mainFlowConfig);
 
         final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
@@ -79,15 +102,15 @@ public class AuditWithFieldNameOverridesTest {
     }
 
     @Test
-    public void overrideNameInParentAndChildren() {
+    public void overrideFieldNameInParentAndChildren() {
         final String parentDescValue = "parentDescValue";
         final String child1DescValue = "child1DescValue";
         final String child2DescValue = "child2DescValue";
 
-        pl.create(singletonList(parentCreateCmd().with(AuditedWithFieldNameOverridesType.DESC, parentDescValue)
-                                          .with(child1CreateCmd().with(AuditedChild1WithFieldNameOverridesType.DESC, child1DescValue))
-                                          .with(child2CreateCmd().with(AuditedChild2WithFieldNameOverridesType.DESC, child2DescValue))),
-                  flowConfig);
+        mainPL.create(singletonList(parentCreateCmd().with(AuditedWithFieldNameOverridesType.DESC, parentDescValue)
+                                                     .with(child1CreateCmd().with(AuditedChild1WithFieldNameOverridesType.DESC, child1DescValue))
+                                                     .with(child2CreateCmd().with(AuditedChild2WithFieldNameOverridesType.DESC, child2DescValue))),
+                      mainFlowConfig);
 
         final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
 
@@ -100,6 +123,28 @@ public class AuditWithFieldNameOverridesTest {
                                                                           child1DescValue)));
         assertThat(parentRecord, hasChildRecordThat(hasCreatedFieldRecord(AuditedChild2WithFieldNameOverridesType.DESC_FIELD_NAME_OVERRIDE,
                                                                           child2DescValue)));
+    }
+
+    @Test
+    public void overrideFieldNamesInAncestor() {
+        final String nameValue = "nameValue";
+        final String ancestorNameValue = "ancestorNameValue";
+        final String ancestorDescValue = "ancestorDescValue";
+
+        mainWithAncestorPL.create(singletonList(entityWithAncestorCreateCmd()
+                                                    .with(AuditedWithAncestorFieldNameOverridesType.ANCESTOR_ID, ANCESTOR_ID)
+                                                    .with(AuditedWithAncestorFieldNameOverridesType.NAME, nameValue)),
+                                  mainWithAncestorFlowConfig);
+
+
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+
+        assertThat("Incorrect number of published records",
+                   auditRecords, hasSize(1));
+        assertThat(auditRecords.get(0), hasMandatoryFieldValue(NAME_FIELD_NAME_OVERRIDE,
+                                                               ancestorNameValue));
+        assertThat(auditRecords.get(0), hasMandatoryFieldValue(DESC_FIELD_NAME_OVERRIDE,
+                                                               ancestorDescValue));
     }
 
     private <E extends EntityType<E>> PersistenceLayer<E> persistenceLayer() {
@@ -120,5 +165,9 @@ public class AuditWithFieldNameOverridesTest {
 
     private CreateAuditedChild2WithFieldNameOverridesCommand child2CreateCmd() {
         return new CreateAuditedChild2WithFieldNameOverridesCommand();
+    }
+
+    private CreateAuditedWithAncestorFieldNameOverridesCommand entityWithAncestorCreateCmd() {
+        return new CreateAuditedWithAncestorFieldNameOverridesCommand();
     }
 }

--- a/integration-tests/src/test/java/com/kenshoo/pl/audit/commands/CreateAuditedWithAncestorFieldNameOverridesCommand.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/audit/commands/CreateAuditedWithAncestorFieldNameOverridesCommand.java
@@ -1,0 +1,13 @@
+package com.kenshoo.pl.audit.commands;
+
+import com.kenshoo.pl.entity.CreateEntityCommand;
+import com.kenshoo.pl.entity.EntityCommandExt;
+import com.kenshoo.pl.entity.internal.audit.entitytypes.AuditedWithAncestorFieldNameOverridesType;
+
+public class CreateAuditedWithAncestorFieldNameOverridesCommand extends CreateEntityCommand<AuditedWithAncestorFieldNameOverridesType>
+    implements EntityCommandExt<AuditedWithAncestorFieldNameOverridesType, CreateAuditedWithAncestorFieldNameOverridesCommand> {
+
+    public CreateAuditedWithAncestorFieldNameOverridesCommand() {
+        super(AuditedWithAncestorFieldNameOverridesType.INSTANCE);
+    }
+}

--- a/main/src/main/java/com/kenshoo/pl/entity/audit/ExternalAuditedField.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/audit/ExternalAuditedField.java
@@ -1,0 +1,58 @@
+package com.kenshoo.pl.entity.audit;
+
+import com.kenshoo.pl.entity.EntityField;
+import com.kenshoo.pl.entity.EntityType;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import static java.util.Objects.requireNonNull;
+
+public class ExternalAuditedField<E extends EntityType<E>, T> {
+
+    private final EntityField<E, T> field;
+    private final String name;
+
+    public ExternalAuditedField(final EntityField<E, T> field) {
+        this(requireNonNull(field, "An underlying field must be provided"),
+             field.toString());
+    }
+
+    public ExternalAuditedField(final EntityField<E, T> field,
+                                final String name) {
+        this.field = requireNonNull(field, "An underlying field must be provided");
+        this.name = requireNonNull(name, "A name must be provided");
+    }
+
+    public EntityField<E, T> getField() {
+        return field;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ExternalAuditedField<?, ?> that = (ExternalAuditedField<?, ?>) o;
+
+        return new EqualsBuilder().append(field, that.field).append(name, that.name).isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37).append(field).append(name).toHashCode();
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+            .append("field", field)
+            .append("name", name)
+            .toString();
+    }
+}

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/audit/ExternalMandatoryFieldsExtractor.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/audit/ExternalMandatoryFieldsExtractor.java
@@ -1,8 +1,8 @@
 package com.kenshoo.pl.entity.internal.audit;
 
-import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.EntityType;
 import com.kenshoo.pl.entity.annotation.audit.Audited;
+import com.kenshoo.pl.entity.audit.ExternalAuditedField;
 import com.kenshoo.pl.entity.spi.audit.AuditExtensions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -10,8 +10,6 @@ import org.slf4j.LoggerFactory;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Optional;
 import java.util.stream.Stream;
-
-import static com.kenshoo.pl.entity.audit.AuditTrigger.ALWAYS;
 
 public class ExternalMandatoryFieldsExtractor {
 
@@ -39,9 +37,9 @@ public class ExternalMandatoryFieldsExtractor {
         }
     }
 
-    private AuditedField<?, ?> toAuditedField(final EntityField<?, ?> field) {
-        return AuditedField.builder(field)
-                           .withTrigger(ALWAYS)
+    private AuditedField<?, ?> toAuditedField(final ExternalAuditedField<?, ?> externalAuditedField) {
+        return AuditedField.builder(externalAuditedField.getField())
+                           .withName(externalAuditedField.getName())
                            .build();
     }
 }

--- a/main/src/main/java/com/kenshoo/pl/entity/spi/audit/AuditExtensions.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/spi/audit/AuditExtensions.java
@@ -1,6 +1,6 @@
 package com.kenshoo.pl.entity.spi.audit;
 
-import com.kenshoo.pl.entity.EntityField;
+import com.kenshoo.pl.entity.audit.ExternalAuditedField;
 
 import java.util.stream.Stream;
 
@@ -14,7 +14,7 @@ public interface AuditExtensions {
      * @return fields from different entity types, which must always be added to {@link com.kenshoo.pl.entity.audit.AuditRecord}-s of the current type.<br>
      *     These fields can be used (for example) to filter / group audit records in queries later on.
      */
-    Stream<? extends EntityField<?, ?>> externalMandatoryFields();
+    Stream<? extends ExternalAuditedField<?, ?>> externalMandatoryFields();
 
 
     /**
@@ -23,7 +23,7 @@ public interface AuditExtensions {
     final class EmptyAuditExtensions implements AuditExtensions {
 
         @Override
-        public Stream<? extends EntityField<?, ?>> externalMandatoryFields() {
+        public Stream<? extends ExternalAuditedField<?, ?>> externalMandatoryFields() {
             return Stream.empty();
         }
     }

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AncestorTable.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AncestorTable.java
@@ -12,6 +12,9 @@ public class AncestorTable extends AbstractDataTable<AncestorTable> {
     public final TableField<Record, Long> id = createPKField("id", SQLDataType.BIGINT.identity(true));
     public final TableField<Record, String> name = createField("name", SQLDataType.VARCHAR(50));
     public final TableField<Record, String> desc = createField("desc", SQLDataType.VARCHAR(50));
+    public final TableField<Record, String> desc2 = createField("desc2", SQLDataType.VARCHAR(50));
+    public final TableField<Record, Double> amount = createField("amount", SQLDataType.DOUBLE);
+    public final TableField<Record, Double> amount2 = createField("amount2", SQLDataType.DOUBLE);
 
     private AncestorTable(final String name) {
         super(name);

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/ExternalMandatoryFieldsExtractorTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/ExternalMandatoryFieldsExtractorTest.java
@@ -2,11 +2,14 @@ package com.kenshoo.pl.entity.internal.audit;
 
 import com.kenshoo.pl.entity.internal.audit.entitytypes.*;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Set;
-import java.util.stream.Stream;
 
-import static com.kenshoo.pl.entity.audit.AuditTrigger.ALWAYS;
+import static com.kenshoo.pl.entity.internal.audit.ancestorfieldsproviders.AncestorWithFieldNameOverridesAuditExtensions.DESC_FIELD_NAME_OVERRIDE;
+import static com.kenshoo.pl.entity.internal.audit.ancestorfieldsproviders.AncestorWithFieldNameOverridesAuditExtensions.NAME_FIELD_NAME_OVERRIDE;
 import static java.util.stream.Collectors.toSet;
 import static java.util.stream.Collectors.toUnmodifiableSet;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -14,35 +17,44 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 
+@RunWith(MockitoJUnitRunner.class)
 public class ExternalMandatoryFieldsExtractorTest {
 
-    private static final ExternalMandatoryFieldsExtractor EXTRACTOR = ExternalMandatoryFieldsExtractor.INSTANCE;
+    @InjectMocks
+    private ExternalMandatoryFieldsExtractor extractor;
 
     @Test
-    public void resolve_WhenAudited_AndHasExternalMandatory_ShouldReturnThem() {
-        final Set<AuditedField<?, ?>> expectedAuditedFields = Stream.of(NotAuditedAncestorType.NAME,
-                                                                        NotAuditedAncestorType.DESC)
-                                                                    .map(f -> AuditedField.builder(f)
-                                                                                          .withTrigger(ALWAYS)
-                                                                                          .build())
-                                                                    .collect(toUnmodifiableSet());
+    public void resolve_WhenAudited_AndHasExternalMandatory_WithNameOverrides_ShouldReturnThem() {
+        final Set<AuditedField<?, ?>> expectedAuditedFields =
+            Set.of(AuditedField.builder(NotAuditedAncestorType.NAME).withName(NAME_FIELD_NAME_OVERRIDE).build(),
+                   AuditedField.builder(NotAuditedAncestorType.DESC).withName(DESC_FIELD_NAME_OVERRIDE).build());
 
-        assertThat(EXTRACTOR.extract(AuditedWithAncestorMandatoryType.INSTANCE).collect(toUnmodifiableSet()),
+        assertThat(extractor.extract(AuditedWithAncestorFieldNameOverridesType.INSTANCE).collect(toUnmodifiableSet()),
+                   equalTo(expectedAuditedFields));
+    }
+
+    @Test
+    public void resolve_WhenAudited_AndHasExternalMandatory_WithDefaultNames_ShouldReturnThem() {
+        final Set<AuditedField<?, ?>> expectedAuditedFields =
+            Set.of(AuditedField.builder(NotAuditedAncestorType.NAME).build(),
+                   AuditedField.builder(NotAuditedAncestorType.DESC).build());
+
+        assertThat(extractor.extract(AuditedWithAncestorMandatoryType.INSTANCE).collect(toUnmodifiableSet()),
                    equalTo(expectedAuditedFields));
     }
 
     @Test
     public void resolve_WhenAudited_AndHasNoExtensions_ShouldReturnEmpty() {
-        assertThat(EXTRACTOR.extract(AuditedType.INSTANCE).collect(toSet()), is(empty()));
+        assertThat(extractor.extract(AuditedType.INSTANCE).collect(toSet()), is(empty()));
     }
 
     @Test
     public void resolve_WhenAudited_AndHasInvalidExtensions_ShouldReturnEmpty() {
-        assertThat(EXTRACTOR.extract(AuditedWithInvalidExtensionsType.INSTANCE).collect(toSet()), is(empty()));
+        assertThat(extractor.extract(AuditedWithInvalidExtensionsType.INSTANCE).collect(toSet()), is(empty()));
     }
 
     @Test
     public void resolve_WhenNotAudited_ShouldReturnEmpty() {
-        assertThat(EXTRACTOR.extract(NotAuditedType.INSTANCE).collect(toSet()), is(empty()));
+        assertThat(extractor.extract(NotAuditedType.INSTANCE).collect(toSet()), is(empty()));
     }
 }

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/ancestorfieldsproviders/AncestorAuditExtensions.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/ancestorfieldsproviders/AncestorAuditExtensions.java
@@ -1,6 +1,6 @@
 package com.kenshoo.pl.entity.internal.audit.ancestorfieldsproviders;
 
-import com.kenshoo.pl.entity.EntityField;
+import com.kenshoo.pl.entity.audit.ExternalAuditedField;
 import com.kenshoo.pl.entity.internal.audit.entitytypes.NotAuditedAncestorType;
 import com.kenshoo.pl.entity.spi.audit.AuditExtensions;
 
@@ -9,7 +9,8 @@ import java.util.stream.Stream;
 public class AncestorAuditExtensions implements AuditExtensions {
 
     @Override
-    public Stream<? extends EntityField<?, ?>> externalMandatoryFields() {
-        return Stream.of(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC);
+    public Stream<? extends ExternalAuditedField<?, ?>> externalMandatoryFields() {
+        return Stream.of(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC)
+            .map(ExternalAuditedField::new);
     }
 }

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/ancestorfieldsproviders/AncestorWithFieldNameOverridesAuditExtensions.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/ancestorfieldsproviders/AncestorWithFieldNameOverridesAuditExtensions.java
@@ -1,0 +1,19 @@
+package com.kenshoo.pl.entity.internal.audit.ancestorfieldsproviders;
+
+import com.kenshoo.pl.entity.audit.ExternalAuditedField;
+import com.kenshoo.pl.entity.internal.audit.entitytypes.NotAuditedAncestorType;
+import com.kenshoo.pl.entity.spi.audit.AuditExtensions;
+
+import java.util.stream.Stream;
+
+public class AncestorWithFieldNameOverridesAuditExtensions implements AuditExtensions {
+
+    public static final String NAME_FIELD_NAME_OVERRIDE = "nameOverride";
+    public static final String DESC_FIELD_NAME_OVERRIDE = "descOverride";
+
+    @Override
+    public Stream<? extends ExternalAuditedField<?, ?>> externalMandatoryFields() {
+        return Stream.of(new ExternalAuditedField<>(NotAuditedAncestorType.NAME, NAME_FIELD_NAME_OVERRIDE),
+                         new ExternalAuditedField<>(NotAuditedAncestorType.DESC, DESC_FIELD_NAME_OVERRIDE));
+    }
+}

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/ancestorfieldsproviders/InvalidAuditExtensions.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/ancestorfieldsproviders/InvalidAuditExtensions.java
@@ -1,6 +1,6 @@
 package com.kenshoo.pl.entity.internal.audit.ancestorfieldsproviders;
 
-import com.kenshoo.pl.entity.EntityField;
+import com.kenshoo.pl.entity.audit.ExternalAuditedField;
 import com.kenshoo.pl.entity.internal.audit.entitytypes.NotAuditedAncestorType;
 import com.kenshoo.pl.entity.spi.audit.AuditExtensions;
 
@@ -13,7 +13,8 @@ public class InvalidAuditExtensions implements AuditExtensions {
     }
 
     @Override
-    public Stream<? extends EntityField<?, ?>> externalMandatoryFields() {
-        return Stream.of(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC);
+    public Stream<? extends ExternalAuditedField<?, ?>> externalMandatoryFields() {
+        return Stream.of(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC)
+            .map(ExternalAuditedField::new);
     }
 }

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/entitytypes/AuditedWithAncestorFieldNameOverridesType.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/entitytypes/AuditedWithAncestorFieldNameOverridesType.java
@@ -1,0 +1,35 @@
+package com.kenshoo.pl.entity.internal.audit.entitytypes;
+
+import com.kenshoo.jooq.DataTable;
+import com.kenshoo.pl.entity.AbstractEntityType;
+import com.kenshoo.pl.entity.EntityField;
+import com.kenshoo.pl.entity.annotation.Id;
+import com.kenshoo.pl.entity.annotation.Required;
+import com.kenshoo.pl.entity.annotation.audit.Audited;
+import com.kenshoo.pl.entity.annotation.audit.NotAudited;
+import com.kenshoo.pl.entity.internal.audit.MainWithAncestorTable;
+import com.kenshoo.pl.entity.internal.audit.ancestorfieldsproviders.AncestorWithFieldNameOverridesAuditExtensions;
+
+import static com.kenshoo.pl.entity.annotation.RequiredFieldType.RELATION;
+
+@Audited(extensions = AncestorWithFieldNameOverridesAuditExtensions.class)
+public class AuditedWithAncestorFieldNameOverridesType extends AbstractEntityType<AuditedWithAncestorFieldNameOverridesType> {
+
+    public static final AuditedWithAncestorFieldNameOverridesType INSTANCE = new AuditedWithAncestorFieldNameOverridesType();
+
+    @Id
+    public static final EntityField<AuditedWithAncestorFieldNameOverridesType, Long> ID = INSTANCE.field(MainWithAncestorTable.INSTANCE.id);
+    @NotAudited
+    @Required(RELATION)
+    public static final EntityField<AuditedWithAncestorFieldNameOverridesType, Long> ANCESTOR_ID = INSTANCE.field(MainWithAncestorTable.INSTANCE.ancestor_id);
+    public static final EntityField<AuditedWithAncestorFieldNameOverridesType, String> NAME = INSTANCE.field(MainWithAncestorTable.INSTANCE.name);
+
+    private AuditedWithAncestorFieldNameOverridesType() {
+        super("AuditedWithAncestorFieldNameOverrides");
+    }
+
+    @Override
+    public DataTable getPrimaryTable() {
+        return MainWithAncestorTable.INSTANCE;
+    }
+}

--- a/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordMatchers.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordMatchers.java
@@ -26,6 +26,10 @@ public class AuditRecordMatchers {
         return new AuditRecordMandatoryFieldValueMatcher(entry(field.toString(), value));
     }
 
+    public static Matcher<AuditRecord> hasMandatoryFieldValue(final String fieldName, final Object value) {
+        return new AuditRecordMandatoryFieldValueMatcher(entry(fieldName, value));
+    }
+
     public static Matcher<AuditRecord> hasNoMandatoryFieldValues() {
         return new AuditRecordNoMandatoryFieldsMatcher();
     }


### PR DESCRIPTION
- Added a new API class `ExternalAuditedField` containing a field and an optional name (but no trigger!)
- Using the class above instead of `EntityField` for specifying **external** mandatory fields for auditing.
- Refactored `ExternalMandatoryFieldsExtractor` to use the name from the new class if exists