### PR TITLE
PL-119: In AuditRecord replace Entry<String, String> with FieldValue class

### DIFF
--- a/integration-tests/src/test/java/com/kenshoo/matcher/EntityHasFieldValuesMatcher.java
+++ b/integration-tests/src/test/java/com/kenshoo/matcher/EntityHasFieldValuesMatcher.java
@@ -1,10 +1,9 @@
 package com.kenshoo.matcher;
 
 import com.google.common.collect.ImmutableSet;
-import com.kenshoo.pl.entity.CurrentEntityState;
 import com.kenshoo.pl.entity.Entity;
 import com.kenshoo.pl.entity.EntityField;
-import com.kenshoo.pl.entity.EntityFieldValue;
+import com.kenshoo.pl.entity.internal.EntityFieldValue;
 import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;

--- a/main/src/main/java/com/kenshoo/pl/entity/FieldValue.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/FieldValue.java
@@ -1,0 +1,53 @@
+package com.kenshoo.pl.entity;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+public class FieldValue {
+    private final String field;
+    private final String value;
+
+    public FieldValue(final String field, final String value) {
+        this.field = field;
+        this.value = value;
+    }
+
+    public String getField() {
+        return field;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+
+        if (o == null || getClass() != o.getClass()) return false;
+
+        FieldValue that = (FieldValue) o;
+
+        return new EqualsBuilder()
+            .append(field, that.field)
+            .append(value, that.value)
+            .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37)
+            .append(field)
+            .append(value)
+            .toHashCode();
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+            .append("field", field)
+            .append("value", value)
+            .toString();
+    }
+}

--- a/main/src/main/java/com/kenshoo/pl/entity/audit/AuditRecord.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/audit/AuditRecord.java
@@ -1,12 +1,12 @@
 package com.kenshoo.pl.entity.audit;
 
 import com.kenshoo.pl.entity.ChangeOperation;
+import com.kenshoo.pl.entity.FieldValue;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
 import java.util.Collection;
-import java.util.Map.Entry;
 
 import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
@@ -15,14 +15,14 @@ import static java.util.stream.Collectors.toList;
 public class AuditRecord {
     private final String entityType;
     private final String entityId;
-    private final Collection<? extends Entry<String, String>> mandatoryFieldValues;
+    private final Collection<? extends FieldValue> mandatoryFieldValues;
     private final ChangeOperation operator;
     private final Collection<? extends FieldAuditRecord> fieldRecords;
     private final Collection<? extends AuditRecord> childRecords;
 
     private AuditRecord(final String entityType,
                         final String entityId,
-                        final Collection<? extends Entry<String, String>> mandatoryFieldValues,
+                        final Collection<? extends FieldValue> mandatoryFieldValues,
                         final ChangeOperation operator,
                         final Collection<? extends FieldAuditRecord> fieldRecords,
                         final Collection<? extends AuditRecord> childRecords) {
@@ -42,7 +42,7 @@ public class AuditRecord {
         return entityId;
     }
 
-    public Collection<? extends Entry<String, String>> getMandatoryFieldValues() {
+    public Collection<? extends FieldValue> getMandatoryFieldValues() {
         return mandatoryFieldValues;
     }
 
@@ -99,7 +99,7 @@ public class AuditRecord {
     public static class Builder {
         private String entityType;
         private String entityId;
-        private Collection<? extends Entry<String, String>> mandatoryFieldValues = emptyList();
+        private Collection<? extends FieldValue> mandatoryFieldValues = emptyList();
         private ChangeOperation operator;
         private Collection<? extends FieldAuditRecord> fieldRecords = emptyList();
         private Collection<? extends AuditRecord> childRecords = emptyList();
@@ -119,7 +119,7 @@ public class AuditRecord {
             return this;
         }
 
-        public Builder withMandatoryFieldValues(final Collection<? extends Entry<String, String>> fieldValues) {
+        public Builder withMandatoryFieldValues(final Collection<? extends FieldValue> fieldValues) {
             this.mandatoryFieldValues = fieldValues == null ? emptyList() : fieldValues;
             return this;
         }

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/EntityFieldValue.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/EntityFieldValue.java
@@ -1,5 +1,6 @@
-package com.kenshoo.pl.entity;
+package com.kenshoo.pl.entity.internal;
 
+import com.kenshoo.pl.entity.EntityField;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditMandatoryFieldValuesGenerator.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditMandatoryFieldValuesGenerator.java
@@ -1,14 +1,13 @@
 package com.kenshoo.pl.entity.internal.audit;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.kenshoo.pl.entity.FieldValue;
 import com.kenshoo.pl.entity.FinalEntityState;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
 import java.util.Collection;
-import java.util.Map.Entry;
 import java.util.stream.Stream;
 
-import static java.util.Map.entry;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 import static org.jooq.lambda.Seq.seq;
@@ -30,12 +29,12 @@ public class AuditMandatoryFieldValuesGenerator {
         this.auditFieldValueResolver = auditFieldValueResolver;
     }
 
-    Collection<Entry<String, String>> generate(final FinalEntityState finalState) {
+    Collection<FieldValue> generate(final FinalEntityState finalState) {
         requireNonNull(finalState, "finalState is required");
         return seq(mandatoryFields)
             .map(field -> ImmutablePair.of(field, auditFieldValueResolver.resolveToString(field, finalState)))
             .filter(pair -> pair.getValue().isNotNull())
-            .map(pair -> entry(pair.getKey().getName(), pair.getValue().get()))
+            .map(pair -> new FieldValue(pair.getKey().getName(), pair.getValue().get()))
             .collect(toList());
     }
 }

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorImpl.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorImpl.java
@@ -7,7 +7,6 @@ import com.kenshoo.pl.entity.audit.FieldAuditRecord;
 import com.kenshoo.pl.entity.internal.EntityIdExtractor;
 
 import java.util.Collection;
-import java.util.Map.Entry;
 import java.util.Optional;
 
 import static com.kenshoo.pl.entity.ChangeOperation.UPDATE;
@@ -66,7 +65,7 @@ public class AuditRecordGeneratorImpl<E extends EntityType<E>> implements AuditR
 
         final String entityId = extractEntityId(entityChange, currentState);
 
-        final Collection<? extends Entry<String, String>> mandatoryFieldValues = mandatoryFieldValuesGenerator.generate(finalState);
+        final Collection<? extends FieldValue> mandatoryFieldValues = mandatoryFieldValuesGenerator.generate(finalState);
 
         final Collection<FieldAuditRecord> fieldRecords = fieldChangesGenerator.generate(currentState, finalState);
 

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditMandatoryFieldValuesGeneratorTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditMandatoryFieldValuesGeneratorTest.java
@@ -1,6 +1,7 @@
 package com.kenshoo.pl.entity.internal.audit;
 
 import com.google.common.collect.ImmutableSet;
+import com.kenshoo.pl.entity.FieldValue;
 import com.kenshoo.pl.entity.FinalEntityState;
 import com.kenshoo.pl.entity.Triptional;
 import com.kenshoo.pl.entity.internal.audit.entitytypes.NotAuditedAncestorType;
@@ -10,12 +11,10 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Collection;
-import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Stream;
 
 import static java.util.Collections.singleton;
-import static java.util.Map.entry;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.junit.Assert.assertThat;
@@ -54,10 +53,10 @@ public class AuditMandatoryFieldValuesGeneratorTest {
         final AuditMandatoryFieldValuesGenerator generator = newGenerator(Stream.of(ANCESTOR_NAME_AUDITED_FIELD,
                                                                                     ANCESTOR_DESC_AUDITED_FIELD));
 
-        final Collection<? extends Entry<String, ?>> actualFieldValues = generator.generate(finalState);
+        final Collection<? extends FieldValue> actualFieldValues = generator.generate(finalState);
 
-        final Set<Entry<String, ?>> expectedFieldValues = Set.of(entry(ANCESTOR_NAME_FIELD_NAME, ANCESTOR_NAME),
-                                                                 entry(ANCESTOR_DESC_FIELD_NAME, ANCESTOR_DESC));
+        final Set<FieldValue> expectedFieldValues = Set.of(new FieldValue(ANCESTOR_NAME_FIELD_NAME, ANCESTOR_NAME),
+                                                           new FieldValue(ANCESTOR_DESC_FIELD_NAME, ANCESTOR_DESC));
 
         assertThat(ImmutableSet.copyOf(actualFieldValues), is(expectedFieldValues));
     }
@@ -70,7 +69,7 @@ public class AuditMandatoryFieldValuesGeneratorTest {
         final AuditMandatoryFieldValuesGenerator generator = newGenerator(Stream.of(ANCESTOR_NAME_AUDITED_FIELD,
                                                                                     ANCESTOR_DESC_AUDITED_FIELD));
 
-        final Collection<? extends Entry<String, ?>> actualFieldValues = generator.generate(finalState);
+        final Collection<? extends FieldValue> actualFieldValues = generator.generate(finalState);
 
         assertThat(ImmutableSet.copyOf(actualFieldValues), is(empty()));
     }
@@ -83,7 +82,7 @@ public class AuditMandatoryFieldValuesGeneratorTest {
         final AuditMandatoryFieldValuesGenerator generator = newGenerator(Stream.of(ANCESTOR_NAME_AUDITED_FIELD,
                                                                                     ANCESTOR_DESC_AUDITED_FIELD));
 
-        final Collection<? extends Entry<String, ?>> actualFieldValues = generator.generate(finalState);
+        final Collection<? extends FieldValue> actualFieldValues = generator.generate(finalState);
 
         assertThat(ImmutableSet.copyOf(actualFieldValues), is(empty()));
     }
@@ -97,9 +96,9 @@ public class AuditMandatoryFieldValuesGeneratorTest {
                                                                                     ANCESTOR_DESC_AUDITED_FIELD));
 
 
-        final Set<Entry<String, ?>> expectedFieldValues = singleton(entry(ANCESTOR_NAME_FIELD_NAME, ANCESTOR_NAME));
+        final Set<FieldValue> expectedFieldValues = singleton(new FieldValue(ANCESTOR_NAME_FIELD_NAME, ANCESTOR_NAME));
 
-        final Collection<? extends Entry<String, ?>> actualFieldValues = generator.generate(finalState);
+        final Collection<? extends FieldValue> actualFieldValues = generator.generate(finalState);
 
         assertThat(ImmutableSet.copyOf(actualFieldValues), is(expectedFieldValues));
     }
@@ -113,9 +112,9 @@ public class AuditMandatoryFieldValuesGeneratorTest {
                                                                                     ANCESTOR_DESC_AUDITED_FIELD));
 
 
-        final Set<Entry<String, ?>> expectedFieldValues = singleton(entry(ANCESTOR_DESC_FIELD_NAME, ANCESTOR_DESC));
+        final Set<FieldValue> expectedFieldValues = singleton(new FieldValue(ANCESTOR_DESC_FIELD_NAME, ANCESTOR_DESC));
 
-        final Collection<? extends Entry<String, ?>> actualFieldValues = generator.generate(finalState);
+        final Collection<? extends FieldValue> actualFieldValues = generator.generate(finalState);
 
         assertThat(ImmutableSet.copyOf(actualFieldValues), is(expectedFieldValues));
     }

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorImplForCreateTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorImplForCreateTest.java
@@ -1,10 +1,7 @@
 package com.kenshoo.pl.entity.internal.audit;
 
 import com.google.common.collect.ImmutableList;
-import com.kenshoo.pl.entity.ChangeContext;
-import com.kenshoo.pl.entity.CurrentEntityState;
-import com.kenshoo.pl.entity.EntityChange;
-import com.kenshoo.pl.entity.FinalEntityState;
+import com.kenshoo.pl.entity.*;
 import com.kenshoo.pl.entity.audit.AuditRecord;
 import com.kenshoo.pl.entity.audit.FieldAuditRecord;
 import com.kenshoo.pl.entity.internal.EntityIdExtractor;
@@ -18,14 +15,12 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Map.Entry;
 import java.util.Optional;
 
 import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresentAnd;
 import static com.kenshoo.pl.entity.ChangeOperation.CREATE;
 import static com.kenshoo.pl.entity.matchers.audit.AuditRecordMatchers.*;
 import static java.util.Collections.emptyList;
-import static java.util.Map.entry;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
@@ -94,9 +89,9 @@ public class AuditRecordGeneratorImplForCreateTest {
 
     @Test
     public void generate_WithMandatoryOnly_ShouldReturnMandatoryFieldValues() {
-        final Collection<Entry<String, String>> expectedMandatoryFieldValues =
-            List.of(entry(NotAuditedAncestorType.NAME.toString(), ANCESTOR_NAME),
-                    entry(NotAuditedAncestorType.DESC.toString(), ANCESTOR_DESC));
+        final Collection<FieldValue> expectedMandatoryFieldValues =
+            List.of(new FieldValue(NotAuditedAncestorType.NAME.toString(), ANCESTOR_NAME),
+                    new FieldValue(NotAuditedAncestorType.DESC.toString(), ANCESTOR_DESC));
 
         when(mandatoryFieldValuesGenerator.generate(finalState)).thenReturn(expectedMandatoryFieldValues);
         when(fieldChangesGenerator.generate(currentState, finalState)).thenReturn(emptyList());
@@ -147,9 +142,9 @@ public class AuditRecordGeneratorImplForCreateTest {
 
     @Test
     public void generate_WithMandatoryAndFieldChangesOnly_ShouldReturnMandatoryFieldValuesAndFieldChanges() {
-        final Collection<Entry<String, String>> expectedMandatoryFieldValues =
-            List.of(entry(NotAuditedAncestorType.NAME.toString(), ANCESTOR_NAME),
-                    entry(NotAuditedAncestorType.DESC.toString(), ANCESTOR_DESC));
+        final Collection<FieldValue> expectedMandatoryFieldValues =
+            List.of(new FieldValue(NotAuditedAncestorType.NAME.toString(), ANCESTOR_NAME),
+                    new FieldValue(NotAuditedAncestorType.DESC.toString(), ANCESTOR_DESC));
 
         final Collection<FieldAuditRecord> expectedFieldChanges =
             ImmutableList.of(FieldAuditRecord.builder(AuditedType.NAME)
@@ -174,9 +169,9 @@ public class AuditRecordGeneratorImplForCreateTest {
 
     @Test
     public void generate_WithEverything_ShouldReturnEverything() {
-        final Collection<Entry<String, String>> expectedMandatoryFieldValues =
-            List.of(entry(NotAuditedAncestorType.NAME.toString(), ANCESTOR_NAME),
-                    entry(NotAuditedAncestorType.DESC.toString(), ANCESTOR_DESC));
+        final Collection<FieldValue> expectedMandatoryFieldValues =
+            List.of(new FieldValue(NotAuditedAncestorType.NAME.toString(), ANCESTOR_NAME),
+                    new FieldValue(NotAuditedAncestorType.DESC.toString(), ANCESTOR_DESC));
 
         final Collection<FieldAuditRecord> expectedFieldChanges =
             ImmutableList.of(FieldAuditRecord.builder(AuditedType.NAME)

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorImplForDeleteTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorImplForDeleteTest.java
@@ -1,10 +1,7 @@
 package com.kenshoo.pl.entity.internal.audit;
 
 import com.google.common.collect.ImmutableList;
-import com.kenshoo.pl.entity.ChangeContext;
-import com.kenshoo.pl.entity.CurrentEntityState;
-import com.kenshoo.pl.entity.EntityChange;
-import com.kenshoo.pl.entity.FinalEntityState;
+import com.kenshoo.pl.entity.*;
 import com.kenshoo.pl.entity.audit.AuditRecord;
 import com.kenshoo.pl.entity.internal.EntityIdExtractor;
 import com.kenshoo.pl.entity.internal.audit.entitytypes.AuditedType;
@@ -17,14 +14,12 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Map.Entry;
 import java.util.Optional;
 
 import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresentAnd;
 import static com.kenshoo.pl.entity.ChangeOperation.DELETE;
 import static com.kenshoo.pl.entity.matchers.audit.AuditRecordMatchers.*;
 import static java.util.Collections.emptyList;
-import static java.util.Map.entry;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
@@ -98,9 +93,9 @@ public class AuditRecordGeneratorImplForDeleteTest {
 
     @Test
     public void generate_WithMandatoryOnly_ShouldGenerateMandatoryFieldValues() {
-        final Collection<Entry<String, String>> expectedMandatoryFieldValues =
-            List.of(entry(NotAuditedAncestorType.NAME.toString(), ANCESTOR_NAME),
-                    entry(NotAuditedAncestorType.DESC.toString(), ANCESTOR_DESC));
+        final Collection<FieldValue> expectedMandatoryFieldValues =
+            List.of(new FieldValue(NotAuditedAncestorType.NAME.toString(), ANCESTOR_NAME),
+                    new FieldValue(NotAuditedAncestorType.DESC.toString(), ANCESTOR_DESC));
 
         when(mandatoryFieldValuesGenerator.generate(finalState)).thenReturn(expectedMandatoryFieldValues);
 
@@ -128,9 +123,9 @@ public class AuditRecordGeneratorImplForDeleteTest {
 
     @Test
     public void generate_WithMandatoryAndChildRecords_ShouldGenerateMandatoryFieldValuesAndChildRecords() {
-        final Collection<Entry<String, String>> expectedMandatoryFieldValues =
-            List.of(entry(NotAuditedAncestorType.NAME.toString(), ANCESTOR_NAME),
-                    entry(NotAuditedAncestorType.DESC.toString(), ANCESTOR_DESC));
+        final Collection<FieldValue> expectedMandatoryFieldValues =
+            List.of(new FieldValue(NotAuditedAncestorType.NAME.toString(), ANCESTOR_NAME),
+                    new FieldValue(NotAuditedAncestorType.DESC.toString(), ANCESTOR_DESC));
 
         when(mandatoryFieldValuesGenerator.generate(finalState)).thenReturn(expectedMandatoryFieldValues);
 

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorImplForUpdateTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRecordGeneratorImplForUpdateTest.java
@@ -1,10 +1,7 @@
 package com.kenshoo.pl.entity.internal.audit;
 
 import com.google.common.collect.ImmutableList;
-import com.kenshoo.pl.entity.ChangeContext;
-import com.kenshoo.pl.entity.CurrentEntityState;
-import com.kenshoo.pl.entity.EntityChange;
-import com.kenshoo.pl.entity.FinalEntityState;
+import com.kenshoo.pl.entity.*;
 import com.kenshoo.pl.entity.audit.AuditRecord;
 import com.kenshoo.pl.entity.audit.FieldAuditRecord;
 import com.kenshoo.pl.entity.internal.EntityIdExtractor;
@@ -18,7 +15,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Map.Entry;
 import java.util.Optional;
 
 import static com.github.npathai.hamcrestopt.OptionalMatchers.isEmpty;
@@ -26,7 +22,6 @@ import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresentAnd;
 import static com.kenshoo.pl.entity.ChangeOperation.UPDATE;
 import static com.kenshoo.pl.entity.matchers.audit.AuditRecordMatchers.*;
 import static java.util.Collections.emptyList;
-import static java.util.Map.entry;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
@@ -94,9 +89,9 @@ public class AuditRecordGeneratorImplForUpdateTest {
 
     @Test
     public void generate_WithMandatoryOnly_ShouldReturnEmpty() {
-        final Collection<Entry<String, String>> expectedMandatoryFieldValues =
-            List.of(entry(NotAuditedAncestorType.NAME.toString(), ANCESTOR_NAME),
-                    entry(NotAuditedAncestorType.DESC.toString(), ANCESTOR_DESC));
+        final Collection<FieldValue> expectedMandatoryFieldValues =
+            List.of(new FieldValue(NotAuditedAncestorType.NAME.toString(), ANCESTOR_NAME),
+                    new FieldValue(NotAuditedAncestorType.DESC.toString(), ANCESTOR_DESC));
 
         when(mandatoryFieldValuesGenerator.generate(finalState)).thenReturn(expectedMandatoryFieldValues);
         when(fieldChangesGenerator.generate(currentState, finalState)).thenReturn(emptyList());
@@ -135,9 +130,9 @@ public class AuditRecordGeneratorImplForUpdateTest {
 
     @Test
     public void generate_WithChildRecordsOnly_ShouldReturnBasicDataAndChildRecords() {
-        final Collection<Entry<String, String>> expectedMandatoryFieldValues =
-            ImmutableList.of(entry(NotAuditedAncestorType.NAME.toString(), ANCESTOR_NAME),
-                             entry(NotAuditedAncestorType.DESC.toString(), ANCESTOR_DESC));
+        final Collection<FieldValue> expectedMandatoryFieldValues =
+            ImmutableList.of(new FieldValue(NotAuditedAncestorType.NAME.toString(), ANCESTOR_NAME),
+                             new FieldValue(NotAuditedAncestorType.DESC.toString(), ANCESTOR_DESC));
 
         when(mandatoryFieldValuesGenerator.generate(finalState)).thenReturn(expectedMandatoryFieldValues);
         when(fieldChangesGenerator.generate(currentState, finalState)).thenReturn(emptyList());
@@ -157,9 +152,9 @@ public class AuditRecordGeneratorImplForUpdateTest {
 
     @Test
     public void generate_WithEverything_ShouldGenerateEverything() {
-        final Collection<Entry<String, String>> expectedMandatoryFieldValues =
-            List.of(entry(NotAuditedAncestorType.NAME.toString(), ANCESTOR_NAME),
-                    entry(NotAuditedAncestorType.DESC.toString(), ANCESTOR_DESC));
+        final Collection<FieldValue> expectedMandatoryFieldValues =
+            List.of(new FieldValue(NotAuditedAncestorType.NAME.toString(), ANCESTOR_NAME),
+                    new FieldValue(NotAuditedAncestorType.DESC.toString(), ANCESTOR_DESC));
 
         final Collection<FieldAuditRecord> expectedFieldChanges =
             ImmutableList.of(FieldAuditRecord.builder(AuditedType.NAME)

--- a/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordMandatoryFieldValueMatcher.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordMandatoryFieldValueMatcher.java
@@ -1,18 +1,17 @@
 package com.kenshoo.pl.entity.matchers.audit;
 
+import com.kenshoo.pl.entity.FieldValue;
 import com.kenshoo.pl.entity.audit.AuditRecord;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
-
-import java.util.Map.Entry;
 
 import static java.util.Objects.requireNonNull;
 
 class AuditRecordMandatoryFieldValueMatcher extends TypeSafeMatcher<AuditRecord> {
 
-    private final Entry<String, ?> expectedFieldValue;
+    private final FieldValue expectedFieldValue;
 
-    AuditRecordMandatoryFieldValueMatcher(final Entry<String, ?> expectedFieldValue) {
+    AuditRecordMandatoryFieldValueMatcher(final FieldValue expectedFieldValue) {
         this.expectedFieldValue = requireNonNull(expectedFieldValue, "expectedFieldValue is required");
     }
 

--- a/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordMatchers.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordMatchers.java
@@ -2,11 +2,10 @@ package com.kenshoo.pl.entity.matchers.audit;
 
 import com.kenshoo.pl.entity.ChangeOperation;
 import com.kenshoo.pl.entity.EntityField;
+import com.kenshoo.pl.entity.FieldValue;
 import com.kenshoo.pl.entity.audit.AuditRecord;
 import com.kenshoo.pl.entity.audit.FieldAuditRecord;
 import org.hamcrest.Matcher;
-
-import static java.util.Map.entry;
 
 public class AuditRecordMatchers {
 
@@ -23,11 +22,11 @@ public class AuditRecordMatchers {
     }
 
     public static Matcher<AuditRecord> hasMandatoryFieldValue(final EntityField<?, ?> field, final String value) {
-        return new AuditRecordMandatoryFieldValueMatcher(entry(field.toString(), value));
+        return new AuditRecordMandatoryFieldValueMatcher(new FieldValue(field.toString(), value));
     }
 
     public static Matcher<AuditRecord> hasMandatoryFieldValue(final String fieldName, final String value) {
-        return new AuditRecordMandatoryFieldValueMatcher(entry(fieldName, value));
+        return new AuditRecordMandatoryFieldValueMatcher(new FieldValue(fieldName, value));
     }
 
     public static Matcher<AuditRecord> hasNoMandatoryFieldValues() {


### PR DESCRIPTION
Added a new `FieldValue` class which contains two strings and used it in `AuditRecord` instead of `Entry<String, String>`
