### PR TITLE
PL-123: Add the ability to disable auditing for a specific flow

### DIFF
--- a/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditDisabledTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditDisabledTest.java
@@ -1,0 +1,68 @@
+package com.kenshoo.pl.audit;
+
+import com.kenshoo.jooq.DataTableUtils;
+import com.kenshoo.jooq.TestJooqConfig;
+import com.kenshoo.pl.audit.commands.CreateAuditedCommand;
+import com.kenshoo.pl.entity.ChangeFlowConfigBuilderFactory;
+import com.kenshoo.pl.entity.PLContext;
+import com.kenshoo.pl.entity.PersistenceLayer;
+import com.kenshoo.pl.entity.audit.AuditRecord;
+import com.kenshoo.pl.entity.internal.audit.MainTable;
+import com.kenshoo.pl.entity.internal.audit.entitytypes.AuditedType;
+import com.kenshoo.pl.simulation.internal.FakeAutoIncGenerator;
+import org.jooq.DSLContext;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
+import static org.hamcrest.Matchers.empty;
+import static org.junit.Assert.assertThat;
+
+public class AuditDisabledTest {
+
+    private PLContext plContext;
+
+    private InMemoryAuditRecordPublisher auditRecordPublisher;
+
+    private PersistenceLayer<AuditedType> pl;
+
+    @Before
+    public void setUp() {
+        final DSLContext dslContext = TestJooqConfig.create();
+        auditRecordPublisher = new InMemoryAuditRecordPublisher();
+        plContext = new PLContext.Builder(dslContext)
+            .withFeaturePredicate(__ -> true)
+            .withAuditRecordPublisher(auditRecordPublisher)
+            .build();
+
+        pl = new PersistenceLayer<>(plContext);
+
+        DataTableUtils.createTable(dslContext, MainTable.INSTANCE);
+    }
+
+    @After
+    public void tearDown() {
+        plContext.dslContext().dropTable(MainTable.INSTANCE).execute();
+    }
+
+    @Test
+    public void shouldNotGenerateAuditRecordWhenNoDbCommandsOutputGenerator() {
+        var flowConfig = ChangeFlowConfigBuilderFactory.newInstance(plContext, AuditedType.INSTANCE)
+                                                       .withoutOutputGenerators()
+                                                       .withOutputGenerator(new FakeAutoIncGenerator<>(AuditedType.INSTANCE))
+                                                       .build();
+
+        pl.create(singletonList(new CreateAuditedCommand()
+                                    .with(AuditedType.NAME, "name")),
+                  flowConfig);
+
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+
+        assertThat("There should be no published records",
+                   auditRecords, empty());
+    }
+}

--- a/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditDisabledTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditDisabledTest.java
@@ -9,7 +9,6 @@ import com.kenshoo.pl.entity.PersistenceLayer;
 import com.kenshoo.pl.entity.audit.AuditRecord;
 import com.kenshoo.pl.entity.internal.audit.MainTable;
 import com.kenshoo.pl.entity.internal.audit.entitytypes.AuditedType;
-import com.kenshoo.pl.simulation.internal.FakeAutoIncGenerator;
 import org.jooq.DSLContext;
 import org.junit.After;
 import org.junit.Before;
@@ -50,10 +49,9 @@ public class AuditDisabledTest {
     }
 
     @Test
-    public void shouldNotGenerateAuditRecordWhenNoDbCommandsOutputGenerator() {
+    public void shouldNotGenerateAuditRecordWhenAuditingDisabled() {
         var flowConfig = ChangeFlowConfigBuilderFactory.newInstance(plContext, AuditedType.INSTANCE)
-                                                       .withoutOutputGenerators()
-                                                       .withOutputGenerator(new FakeAutoIncGenerator<>(AuditedType.INSTANCE))
+                                                       .disableAuditing()
                                                        .build();
 
         pl.create(singletonList(new CreateAuditedCommand()

--- a/main/src/main/java/com/kenshoo/pl/entity/ChangeFlowConfig.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/ChangeFlowConfig.java
@@ -280,11 +280,13 @@ public class ChangeFlowConfig<E extends EntityType<E>> {
             validators.forEach(validator -> validatorList.add(validator.element()));
             falseUpdatesPurger.ifPresent(enrichers::add);
 
-            final Optional<AuditedEntityType<E>> optionalAuditedEntityType = auditedEntityTypeResolver.resolve(entityType);
-            final AuditRequiredFieldsCalculator<E> auditRequiredFieldsCalculator =
-                optionalAuditedEntityType.map(AuditRequiredFieldsCalculator::new).orElse(null);
-            final AuditRecordGenerator<E> auditRecordGenerator =
-                optionalAuditedEntityType.map(this::createAuditRecordGenerator).orElse(null);
+            boolean hasDbOutputGenerator = outputGenerators.stream()
+                                                           .anyMatch(outputGenerator -> outputGenerator instanceof DbCommandsOutputGenerator);
+
+            final var optionalAuditedEntityType =
+                hasDbOutputGenerator ? auditedEntityTypeResolver.resolve(entityType) : Optional.<AuditedEntityType<E>>empty();
+            final var auditRequiredFieldsCalculator = optionalAuditedEntityType.map(AuditRequiredFieldsCalculator::new).orElse(null);
+            final var auditRecordGenerator = optionalAuditedEntityType.map(this::createAuditRecordGenerator).orElse(null);
 
             return new ChangeFlowConfig<>(entityType,
                                           enrichers.build(),

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditedEntityTypeResolver.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditedEntityTypeResolver.java
@@ -1,73 +1,17 @@
 package com.kenshoo.pl.entity.internal.audit;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.EntityType;
-import com.kenshoo.pl.entity.annotation.audit.Audited;
-import com.kenshoo.pl.entity.audit.AuditTrigger;
 
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
-import static com.kenshoo.pl.entity.internal.audit.AuditIndicator.AUDITED;
-import static com.kenshoo.pl.entity.internal.audit.AuditIndicator.NOT_AUDITED;
-import static java.util.Objects.requireNonNull;
-import static java.util.Optional.empty;
-import static java.util.stream.Collectors.groupingBy;
-import static java.util.stream.Collectors.toUnmodifiableList;
+public interface AuditedEntityTypeResolver {
 
-public class AuditedEntityTypeResolver {
+    <E extends EntityType<E>> Optional<AuditedEntityType<E>> resolve(final E entityType);
 
-    public static final AuditedEntityTypeResolver INSTANCE = new AuditedEntityTypeResolver(AuditedEntityTypeNameResolver.INSTANCE,
-                                                                                           AuditedFieldResolver.INSTANCE,
-                                                                                           ExternalMandatoryFieldsExtractor.INSTANCE);
-
-    private final AuditedEntityTypeNameResolver auditedEntityTypeNameResolver;
-    private final AuditedFieldResolver auditedFieldResolver;
-    private final ExternalMandatoryFieldsExtractor externalMandatoryFieldsExtractor;
-
-    @VisibleForTesting
-    AuditedEntityTypeResolver(final AuditedEntityTypeNameResolver auditedEntityTypeNameResolver,
-                              final AuditedFieldResolver auditedFieldResolver,
-                              final ExternalMandatoryFieldsExtractor externalMandatoryFieldsExtractor) {
-        this.auditedEntityTypeNameResolver = auditedEntityTypeNameResolver;
-        this.auditedFieldResolver = auditedFieldResolver;
-        this.externalMandatoryFieldsExtractor = externalMandatoryFieldsExtractor;
-    }
-
-    public <E extends EntityType<E>> Optional<AuditedEntityType<E>> resolve(final E entityType) {
-        requireNonNull(entityType, "entityType is required");
-        return entityType.getIdField()
-                         .flatMap(idField -> resolve(entityType, idField));
-    }
-
-    private <E extends EntityType<E>> Optional<AuditedEntityType<E>> resolve(final E entityType, final EntityField<E, ? extends Number> idField) {
-        final var entityAuditIndicator = entityType.getClass().isAnnotationPresent(Audited.class) ? AUDITED : NOT_AUDITED;
-
-        final var externalFields = externalMandatoryFieldsExtractor.extract(entityType);
-
-        final var internalFields = resolveInternalFields(entityType, idField, entityAuditIndicator);
-
-        final var auditedEntityType = AuditedEntityType.builder(idField)
-                                                       .withName(auditedEntityTypeNameResolver.resolve(entityType))
-                                                       .withExternalFields(externalFields)
-                                                       .withInternalFields(internalFields)
-                                                       .build();
-
-        if (entityAuditIndicator == AUDITED || auditedEntityType.hasInternalFields()) {
-            return Optional.of(auditedEntityType);
+    AuditedEntityTypeResolver EMPTY = new AuditedEntityTypeResolver() {
+        @Override
+        public <E extends EntityType<E>> Optional<AuditedEntityType<E>> resolve(E entityType) {
+            return Optional.empty();
         }
-        return empty();
-    }
-
-    private <E extends EntityType<E>> Map<AuditTrigger, List<AuditedField<E, ?>>> resolveInternalFields(final E entityType,
-                                                                                                        final EntityField<E, ? extends Number> idField,
-                                                                                                        final AuditIndicator entityAuditIndicator) {
-        return entityType.getFields()
-                         .filter(field -> !idField.equals(field))
-                         .map(field -> auditedFieldResolver.resolve(field, entityAuditIndicator))
-                         .flatMap(Optional::stream)
-                         .collect(groupingBy(AuditedField::getTrigger, toUnmodifiableList()));
-    }
+    };
 }

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditedEntityTypeResolverImpl.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditedEntityTypeResolverImpl.java
@@ -1,0 +1,74 @@
+package com.kenshoo.pl.entity.internal.audit;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.kenshoo.pl.entity.EntityField;
+import com.kenshoo.pl.entity.EntityType;
+import com.kenshoo.pl.entity.annotation.audit.Audited;
+import com.kenshoo.pl.entity.audit.AuditTrigger;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.kenshoo.pl.entity.internal.audit.AuditIndicator.AUDITED;
+import static com.kenshoo.pl.entity.internal.audit.AuditIndicator.NOT_AUDITED;
+import static java.util.Objects.requireNonNull;
+import static java.util.Optional.empty;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toUnmodifiableList;
+
+public class AuditedEntityTypeResolverImpl implements AuditedEntityTypeResolver {
+
+    public static final AuditedEntityTypeResolverImpl INSTANCE = new AuditedEntityTypeResolverImpl(AuditedEntityTypeNameResolver.INSTANCE,
+                                                                                                   AuditedFieldResolver.INSTANCE,
+                                                                                                   ExternalMandatoryFieldsExtractor.INSTANCE);
+
+    private final AuditedEntityTypeNameResolver auditedEntityTypeNameResolver;
+    private final AuditedFieldResolver auditedFieldResolver;
+    private final ExternalMandatoryFieldsExtractor externalMandatoryFieldsExtractor;
+
+    @VisibleForTesting
+    AuditedEntityTypeResolverImpl(final AuditedEntityTypeNameResolver auditedEntityTypeNameResolver,
+                                  final AuditedFieldResolver auditedFieldResolver,
+                                  final ExternalMandatoryFieldsExtractor externalMandatoryFieldsExtractor) {
+        this.auditedEntityTypeNameResolver = auditedEntityTypeNameResolver;
+        this.auditedFieldResolver = auditedFieldResolver;
+        this.externalMandatoryFieldsExtractor = externalMandatoryFieldsExtractor;
+    }
+
+    @Override
+    public <E extends EntityType<E>> Optional<AuditedEntityType<E>> resolve(final E entityType) {
+        requireNonNull(entityType, "entityType is required");
+        return entityType.getIdField()
+                         .flatMap(idField -> resolve(entityType, idField));
+    }
+
+    private <E extends EntityType<E>> Optional<AuditedEntityType<E>> resolve(final E entityType, final EntityField<E, ? extends Number> idField) {
+        final var entityAuditIndicator = entityType.getClass().isAnnotationPresent(Audited.class) ? AUDITED : NOT_AUDITED;
+
+        final var externalFields = externalMandatoryFieldsExtractor.extract(entityType);
+
+        final var internalFields = resolveInternalFields(entityType, idField, entityAuditIndicator);
+
+        final var auditedEntityType = AuditedEntityType.builder(idField)
+                                                       .withName(auditedEntityTypeNameResolver.resolve(entityType))
+                                                       .withExternalFields(externalFields)
+                                                       .withInternalFields(internalFields)
+                                                       .build();
+
+        if (entityAuditIndicator == AUDITED || auditedEntityType.hasInternalFields()) {
+            return Optional.of(auditedEntityType);
+        }
+        return empty();
+    }
+
+    private <E extends EntityType<E>> Map<AuditTrigger, List<AuditedField<E, ?>>> resolveInternalFields(final E entityType,
+                                                                                                        final EntityField<E, ? extends Number> idField,
+                                                                                                        final AuditIndicator entityAuditIndicator) {
+        return entityType.getFields()
+                         .filter(field -> !idField.equals(field))
+                         .map(field -> auditedFieldResolver.resolve(field, entityAuditIndicator))
+                         .flatMap(Optional::stream)
+                         .collect(groupingBy(AuditedField::getTrigger, toUnmodifiableList()));
+    }
+}

--- a/main/src/test/java/com/kenshoo/pl/entity/ChangeFlowConfigTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/ChangeFlowConfigTest.java
@@ -2,7 +2,6 @@ package com.kenshoo.pl.entity;
 
 
 import com.google.common.collect.ImmutableList;
-import com.kenshoo.pl.entity.internal.DbCommandsOutputGenerator;
 import com.kenshoo.pl.entity.internal.FalseUpdatesPurger;
 import com.kenshoo.pl.entity.internal.audit.AuditRequiredFieldsCalculator;
 import com.kenshoo.pl.entity.internal.audit.AuditedEntityType;
@@ -36,14 +35,11 @@ public class ChangeFlowConfigTest {
     @Mock
     private AuditedEntityTypeResolver auditedEntityTypeResolver;
 
-    @Mock
-    private DbCommandsOutputGenerator<TestEntity> dbCommandsOutputGenerator;
-
     @Test
     public void add_single_enricher_to_flow_config() {
         PostFetchCommandEnricher<TestEntity> enricher = mock(PostFetchCommandEnricher.class);
         ChangeFlowConfig<TestEntity> flow =
-                ChangeFlowConfig.builder(TestEntity.INSTANCE).
+                changeFlowConfigBuilder(TestEntity.INSTANCE).
                 withPostFetchCommandEnricher(enricher).
                 build();
         Assert.assertEquals(flow.getPostFetchCommandEnrichers(), ImmutableList.of(enricher));
@@ -54,7 +50,7 @@ public class ChangeFlowConfigTest {
         PostFetchCommandEnricher<TestEntity> enricher1 = mock(PostFetchCommandEnricher.class);
         PostFetchCommandEnricher<TestEntity> enricher2 = mock(PostFetchCommandEnricher.class);
         ChangeFlowConfig<TestEntity> flow =
-                ChangeFlowConfig.builder(TestEntity.INSTANCE).
+                changeFlowConfigBuilder(TestEntity.INSTANCE).
                         withPostFetchCommandEnrichers(ImmutableList.of(enricher1, enricher2)).
                         build();
         Assert.assertEquals(flow.getPostFetchCommandEnrichers(), ImmutableList.of(enricher1, enricher2));
@@ -65,7 +61,7 @@ public class ChangeFlowConfigTest {
     public void add_excludable_enricher_to_flow_config() {
         PostFetchCommandEnricher<TestEntity> enricher = mock(PostFetchCommandEnricher.class);
         ChangeFlowConfig<TestEntity> flow =
-                ChangeFlowConfig.builder(TestEntity.INSTANCE).
+                changeFlowConfigBuilder(TestEntity.INSTANCE).
                         withLabeledPostFetchCommandEnricher(enricher, EXCLUDABLE_LABEL_1).
                         build();
         Assert.assertEquals(flow.getPostFetchCommandEnrichers(), ImmutableList.of(enricher));
@@ -76,7 +72,7 @@ public class ChangeFlowConfigTest {
         PostFetchCommandEnricher<TestEntity> enricher1 = mock(PostFetchCommandEnricher.class);
         PostFetchCommandEnricher<TestEntity> enricher2 = mock(PostFetchCommandEnricher.class);
         ChangeFlowConfig<TestEntity> flow =
-                ChangeFlowConfig.builder(TestEntity.INSTANCE).
+                changeFlowConfigBuilder(TestEntity.INSTANCE).
                         withLabeledPostFetchCommandEnrichers(ImmutableList.of(enricher1, enricher2), EXCLUDABLE_LABEL_1).
                         build();
         Assert.assertEquals(flow.getPostFetchCommandEnrichers(), ImmutableList.of(enricher1, enricher2));
@@ -86,7 +82,7 @@ public class ChangeFlowConfigTest {
     public void add_excludable_validator_to_flow_config() {
         ChangesValidator validator = mock(ChangesValidator.class);
         ChangeFlowConfig<TestEntity> flow =
-                ChangeFlowConfig.builder(TestEntity.INSTANCE).
+                changeFlowConfigBuilder(TestEntity.INSTANCE).
                         withLabeledValidator(validator, EXCLUDABLE_LABEL_1).
                         build();
         Assert.assertEquals(flow.getValidators(), ImmutableList.of(validator));
@@ -97,7 +93,7 @@ public class ChangeFlowConfigTest {
         ChangesValidator validator1 = mock(ChangesValidator.class);
         ChangesValidator validator2 = mock(ChangesValidator.class);
         ChangeFlowConfig<TestEntity> flow =
-                ChangeFlowConfig.builder(TestEntity.INSTANCE).
+                changeFlowConfigBuilder(TestEntity.INSTANCE).
                         withLabeledValidators(ImmutableList.of(validator1, validator2), EXCLUDABLE_LABEL_1).
                         build();
         Assert.assertEquals(flow.getValidators(), ImmutableList.of(validator1, validator2));
@@ -110,7 +106,7 @@ public class ChangeFlowConfigTest {
         ChangesValidator nonExcludableValidator = mock(ChangesValidator.class);
         PostFetchCommandEnricher<TestEntity> nonExcludableEnricher = mock(PostFetchCommandEnricher.class);
         ChangeFlowConfig<TestEntity> flow =
-                ChangeFlowConfig.builder(TestEntity.INSTANCE).
+                changeFlowConfigBuilder(TestEntity.INSTANCE).
                         withLabeledValidator(excludableValidator, EXCLUDABLE_LABEL_1).
                         withLabeledPostFetchCommandEnricher(excludableEnricher, EXCLUDABLE_LABEL_1).
                         withValidator(nonExcludableValidator).
@@ -126,7 +122,7 @@ public class ChangeFlowConfigTest {
         ChangesValidator excludableValidator= mock(ChangesValidator.class);
         PostFetchCommandEnricher<TestEntity> excludableEnricher = mock(PostFetchCommandEnricher.class);
         ChangeFlowConfig<TestEntity> flow =
-                ChangeFlowConfig.builder(TestEntity.INSTANCE).
+                changeFlowConfigBuilder(TestEntity.INSTANCE).
                         withLabeledValidator(excludableValidator, EXCLUDABLE_LABEL_1).
                         withLabeledPostFetchCommandEnricher(excludableEnricher, EXCLUDABLE_LABEL_2).
                         withoutLabeledElements(ImmutableList.of(EXCLUDABLE_LABEL_1, EXCLUDABLE_LABEL_2)).
@@ -140,7 +136,7 @@ public class ChangeFlowConfigTest {
     public void add_false_update_purger_to_flow_config() {
         FalseUpdatesPurger<TestEntity> purger = new FalseUpdatesPurger.Builder<TestEntity>().build();
         ChangeFlowConfig.Builder<TestEntity> flowBuilder =
-                ChangeFlowConfig.builder(TestEntity.INSTANCE);
+            changeFlowConfigBuilder(TestEntity.INSTANCE);
         flowBuilder.withFalseUpdatesPurger(purger);
         ChangeFlowConfig<TestEntity> flow = flowBuilder.build();
         Assert.assertEquals(flow.getPostFetchCommandEnrichers(), ImmutableList.of(purger));
@@ -151,7 +147,7 @@ public class ChangeFlowConfigTest {
         FalseUpdatesPurger<TestEntity> purger = new FalseUpdatesPurger.Builder<TestEntity>().build();
         PostFetchCommandEnricher<TestEntity> enricher = mock(PostFetchCommandEnricher.class);
         ChangeFlowConfig.Builder<TestEntity> flowBuilder =
-                ChangeFlowConfig.builder(TestEntity.INSTANCE);
+            changeFlowConfigBuilder(TestEntity.INSTANCE);
         flowBuilder.withFalseUpdatesPurger(purger);
         flowBuilder.withPostFetchCommandEnricher(enricher);
         ChangeFlowConfig<TestEntity> flow = flowBuilder.build();
@@ -162,7 +158,7 @@ public class ChangeFlowConfigTest {
     public void get_primary_identity_field_returns_it_when_exists() {
 
         final ChangeFlowConfig.Builder<TestEntityAutoInc> flowBuilder =
-            ChangeFlowConfig.builder(TestEntityAutoInc.INSTANCE);
+            changeFlowConfigBuilder(TestEntityAutoInc.INSTANCE);
 
         final ChangeFlowConfig<TestEntityAutoInc> flow = flowBuilder.build();
 
@@ -172,7 +168,7 @@ public class ChangeFlowConfigTest {
     @Test
     public void get_primary_identity_field_returns_empty_when_doesnt_exist() {
         final ChangeFlowConfig.Builder<TestEntity> flowBuilder =
-            ChangeFlowConfig.builder(TestEntity.INSTANCE);
+            changeFlowConfigBuilder(TestEntity.INSTANCE);
 
         final ChangeFlowConfig<TestEntity> flow = flowBuilder.build();
 
@@ -188,8 +184,7 @@ public class ChangeFlowConfigTest {
                                                        .build();
         doReturn(Optional.of(auditedEntityType)).when(auditedEntityTypeResolver).resolve(TestEntity.INSTANCE);
 
-        final var flowConfig = new ChangeFlowConfig.Builder<>(TestEntity.INSTANCE,
-                                                              auditedEntityTypeResolver).build();
+        final var flowConfig = changeFlowConfigBuilder(TestEntity.INSTANCE).build();
 
         final Set<Class<?>> currentStateConsumerTypes = flowConfig.currentStateConsumers()
                                                                   .map(Object::getClass)
@@ -205,8 +200,7 @@ public class ChangeFlowConfigTest {
 
         when(auditedEntityTypeResolver.resolve(TestEntity.INSTANCE)).thenReturn(Optional.empty());
 
-        final var flowConfig = new ChangeFlowConfig.Builder<>(TestEntity.INSTANCE,
-                                                              auditedEntityTypeResolver).build();
+        final var flowConfig = changeFlowConfigBuilder(TestEntity.INSTANCE).build();
 
         final Set<Class<?>> currentStateConsumerTypes = flowConfig.currentStateConsumers()
                                                                   .map(Object::getClass)
@@ -220,8 +214,7 @@ public class ChangeFlowConfigTest {
     @Test
     public void audit_required_fields_calculator_should_not_be_in_state_consumers_if_auditing_disabled() {
 
-        final var flowConfig = new ChangeFlowConfig.Builder<>(TestEntity.INSTANCE,
-                                                              auditedEntityTypeResolver)
+        final var flowConfig = changeFlowConfigBuilder(TestEntity.INSTANCE)
             .disableAuditing()
             .build();
 
@@ -235,6 +228,45 @@ public class ChangeFlowConfigTest {
     }
 
     @Test
+    public void audit_required_fields_calculator_should_not_be_in_state_consumers_if_output_generators_removed() {
+
+        final var flowConfig = changeFlowConfigBuilder(TestEntity.INSTANCE)
+            .withoutOutputGenerators()
+            .build();
+
+        final Set<Class<?>> currentStateConsumerTypes = flowConfig.currentStateConsumers()
+                                                                  .map(Object::getClass)
+                                                                  .collect(Collectors.toSet());
+
+        assertThat("AuditRequiredFieldsCalculator should NOT be included in state consumers",
+                   currentStateConsumerTypes,
+                   not(hasItem(AuditRequiredFieldsCalculator.class)));
+    }
+
+    @Test
+    public void audit_required_fields_calculator_should_be_in_state_consumers_if_reenabled_and_audited_fields_defined() {
+
+        final var auditedEntityType = AuditedEntityType.builder(TestEntity.ID)
+                                                       .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE,
+                                                                                     TestEntity.FIELD_1, TestEntity.FIELD_2)
+                                                       .build();
+
+        doReturn(Optional.of(auditedEntityType)).when(auditedEntityTypeResolver).resolve(TestEntity.INSTANCE);
+        final var flowConfig = changeFlowConfigBuilder(TestEntity.INSTANCE)
+            .withoutOutputGenerators()
+            .enableAuditing()
+            .build();
+
+        final Set<Class<?>> currentStateConsumerTypes = flowConfig.currentStateConsumers()
+                                                                  .map(Object::getClass)
+                                                                  .collect(Collectors.toSet());
+
+        assertThat("AuditRequiredFieldsCalculator should be included in state consumers",
+                   currentStateConsumerTypes,
+                   hasItem(AuditRequiredFieldsCalculator.class));
+    }
+
+    @Test
     public void should_create_audit_record_generator_if_audited_fields_defined() {
 
         final var auditedEntityType = AuditedEntityType.builder(TestEntity.ID)
@@ -244,8 +276,7 @@ public class ChangeFlowConfigTest {
                                                        .build();
         doReturn(Optional.of(auditedEntityType)).when(auditedEntityTypeResolver).resolve(TestEntity.INSTANCE);
 
-        final var flowConfig = new ChangeFlowConfig.Builder<>(TestEntity.INSTANCE,
-                                                              auditedEntityTypeResolver).build();
+        final var flowConfig = changeFlowConfigBuilder(TestEntity.INSTANCE).build();
 
         assertThat("Audit record generator should exist",
                    flowConfig.auditRecordGenerator().isPresent(), is(true));
@@ -258,8 +289,7 @@ public class ChangeFlowConfigTest {
 
         doReturn(Optional.empty()).when(auditedEntityTypeResolver).resolve(TestEntity.INSTANCE);
 
-        final var flowConfig = new ChangeFlowConfig.Builder<>(TestEntity.INSTANCE,
-                                                              auditedEntityTypeResolver).build();
+        final var flowConfig = changeFlowConfigBuilder(TestEntity.INSTANCE).build();
 
         assertThat("Audit record generator should not exist",
                    flowConfig.auditRecordGenerator().isPresent(), is(false));
@@ -268,12 +298,53 @@ public class ChangeFlowConfigTest {
     @Test
     public void should_not_create_audit_record_generator_if_auditing_is_disabled() {
 
-        final var flowConfig = new ChangeFlowConfig.Builder<>(TestEntity.INSTANCE,
-                                                              auditedEntityTypeResolver)
+        final var flowConfig = changeFlowConfigBuilder(TestEntity.INSTANCE)
             .disableAuditing()
             .build();
 
         assertThat("Audit record generator should not exist",
                    flowConfig.auditRecordGenerator().isPresent(), is(false));
+    }
+
+    @Test
+    public void should_not_create_audit_record_generator_if_output_generators_removed() {
+
+        final var flowConfig = changeFlowConfigBuilder(TestEntity.INSTANCE)
+            .withoutOutputGenerators()
+            .build();
+
+        assertThat("Audit record generator should not exist",
+                   flowConfig.auditRecordGenerator().isPresent(), is(false));
+    }
+
+    @Test
+    public void should_create_audit_record_generator_if_reenabled_and_audited_fields_defined() {
+
+        final var auditedEntityType = AuditedEntityType.builder(TestEntity.ID)
+                                                       .withName(AUDITED_ENTITY_TYPE_NAME)
+                                                       .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE,
+                                                                                     TestEntity.FIELD_1, TestEntity.FIELD_2)
+                                                       .build();
+        doReturn(Optional.of(auditedEntityType)).when(auditedEntityTypeResolver).resolve(TestEntity.INSTANCE);
+
+        final var flowConfig = changeFlowConfigBuilder(TestEntity.INSTANCE)
+            .withoutOutputGenerators()
+            .enableAuditing()
+            .build();
+
+        assertThat("Audit record generator should exist",
+                   flowConfig.auditRecordGenerator().isPresent(), is(true));
+        assertThat("Audit record generator should have correct entity type name: ",
+                   flowConfig.auditRecordGenerator().get().getEntityTypeName(), is(AUDITED_ENTITY_TYPE_NAME));
+    }
+
+    private <E extends EntityType<E>> ChangeFlowConfig.Builder<E> changeFlowConfigBuilder(final E entityType) {
+        return new ChangeFlowConfig.Builder<>(entityType) {
+
+            @Override
+            AuditedEntityTypeResolver regularAuditedEntityTypeResolver() {
+                return auditedEntityTypeResolver;
+            }
+        };
     }
 }

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditedEntityTypeResolverImplTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditedEntityTypeResolverImplTest.java
@@ -26,7 +26,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class AuditedEntityTypeResolverTest {
+public class AuditedEntityTypeResolverImplTest {
 
     private static final String ENTITY_TYPE_NAME = "SomeEntity";
 
@@ -40,7 +40,7 @@ public class AuditedEntityTypeResolverTest {
     private ExternalMandatoryFieldsExtractor externalMandatoryFieldsExtractor;
 
     @InjectMocks
-    private AuditedEntityTypeResolver auditedEntityTypeResolver;
+    private AuditedEntityTypeResolverImpl auditedEntityTypeResolver;
 
     @Test
     public void resolve_WhenAudited_AndHasId_AndOneInternalType_ShouldReturnAllFields() {


### PR DESCRIPTION
If there is no `DbCommandsOutputGenerator` in the flow (as in simulation mode), then no DB changes will occur and therefore it is likely that the client will not want to perform auditing either.
To support this:
1) Added methods to the flow builder to enable/disable auditing.
2) Auditing is disabled whenever `withoutOutputGenerators()` is called (this is to make migration easier in Kenshoo. Later on we can separate the two calls)