### PR TITLE
use thread local tx in makeChanges

### DIFF
--- a/main/src/main/java/com/kenshoo/pl/entity/PersistenceLayer.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/PersistenceLayer.java
@@ -123,7 +123,7 @@ public class PersistenceLayer<ROOT extends EntityType<ROOT>> {
         Collection<? extends ChangeEntityCommand<ROOT>> validCmds = seq(commands).filter(cmd -> !context.containsError(cmd)).toList();
         ChangeContext overridingCtx = new OverridingContext(context);
         if (!validCmds.isEmpty()) {
-            flowConfig.retryer().run((() -> dslContext().transaction((configuration) -> generateOutputRecursive(flowConfig, validCmds, overridingCtx))));
+            flowConfig.retryer().run((() -> dslContext().transaction(() -> generateOutputRecursive(flowConfig, validCmds, overridingCtx))));
         }
         final Stream<? extends AuditRecord> auditRecords =
             recursiveAuditRecordGenerator.generateMany(flowConfig,


### PR DESCRIPTION
TL;DR - the tx workaround was not working as expected.

Before this fix, when trying to use thread local tx lfailed with an exception:
```java
void myTest() {
    jooq.transaction(() -> pl.doSomething(...));
}
```
This test opens a tx on the local thread while PL is creating a different transaction on a derived DSL context.

As a workaround, we did something that did not throw an exception, but was wrong because PL still created a separate tx on a separate connection.
```java
var txProvider = jooq.configuration().transactionProvider();
var trx = new TransactionContextImpl(jooq.configuration(), jooq);
txProvider.begin(trx);

pl.doSomething(...);

txProvider.end(trx);
```
