### PR TITLE
Generate temporary table unique index instead of primary key

### DIFF
--- a/main/src/main/java/com/kenshoo/jooq/TempTable.java
+++ b/main/src/main/java/com/kenshoo/jooq/TempTable.java
@@ -49,7 +49,7 @@ class TempTable<T extends Table<Record>> {
         CreateTableFinalStep createTableFinalStep = createTableColumnStep;
         UniqueKey<Record> primaryKey = table.getPrimaryKey();
         if (primaryKey != null) {
-            createTableFinalStep = createTableColumnStep.constraint(DSL.constraint().primaryKey(primaryKey.getFields().toArray(new TableField[0])));
+            createTableFinalStep = createTableColumnStep.constraint(DSL.constraint().unique(primaryKey.getFields().toArray(new TableField[0])));
         }
         //noinspection ConstantConditions
         String tableCreateSql = createTableFinalStep.getSQL();


### PR DESCRIPTION
Generate temporary table unique index instead of the primary key.
The fix is done to support MySql 5.7

See this article: https://dev.mysql.com/doc/refman/5.7/en/create-table.html#create-table-indexes-keys

PRIMARY KEY
A unique index where all key columns must be defined as NOT NULL. If they are not explicitly declared as NOT NULL, MySQL declares them so implicitly (and silently). A table can have only one PRIMARY KEY. The name of a PRIMARY KEY is always PRIMARY, which thus cannot be used as the name for any other kind of index.
