### PR TITLE
get first unique row when duplicates already exists in the db

### DIFF
--- a/integration-tests/src/test/java/com/kenshoo/pl/entity/spi/helpers/UniquenessValidatorTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/entity/spi/helpers/UniquenessValidatorTest.java
@@ -344,12 +344,11 @@ public class UniquenessValidatorTest {
                 .build();
 
         create(new CreateParent().with(ParentEntity.ID, 99)
-                .with(ParentEntity.NAME, UNIQUE_NAME)
-                .with(ParentEntity.ID_IN_TARGET, 333));
+                .with(ParentEntity.NAME, UNIQUE_NAME) .with(ParentEntity.ID_IN_TARGET, 333),
 
-        create(new CreateParent().with(ParentEntity.ID, 98)
-                .with(ParentEntity.NAME, UNIQUE_NAME)
-                .with(ParentEntity.ID_IN_TARGET, 4444));
+                new CreateParent().with(ParentEntity.ID, 98)
+                .with(ParentEntity.NAME, UNIQUE_NAME).with(ParentEntity.ID_IN_TARGET, 4444));
+
 
 
         final var commands = List.of(

--- a/integration-tests/src/test/java/com/kenshoo/pl/entity/spi/helpers/UniquenessValidatorTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/entity/spi/helpers/UniquenessValidatorTest.java
@@ -35,6 +35,7 @@ public class UniquenessValidatorTest {
     private static final ParentTable parentTable = ParentTable.INSTANCE;
     private static final ChildTable childTable = ChildTable.INSTANCE;
     private static final Set<DataTable> ALL_TABLES = ImmutableSet.of(parentTable, childTable);
+    private static final String UNIQUE_NAME = "Moshe";
 
     private static boolean tablesCreated;
 
@@ -44,6 +45,8 @@ public class UniquenessValidatorTest {
     private EntitiesFetcher entitiesFetcher = new EntitiesFetcher(dslContext);
     private PersistenceLayer<ParentEntity> parentPersistence = new PersistenceLayer<>(plContext);
     private PersistenceLayer<ChildEntity> childPersistence = new PersistenceLayer<>(plContext);
+
+
     @Before
     public void setup() {
         if (!tablesCreated) {
@@ -325,6 +328,33 @@ public class UniquenessValidatorTest {
         final var commands = List.of(
                 new CreateParent().with(ParentEntity.ID, 1)
                         .with(ParentEntity.NAME, "moshe")
+                        .with(ParentEntity.ID_IN_TARGET, 12345)
+        );
+
+        final var results = parentPersistence.create(commands, parentFlow(validator).build());
+
+        assertThat(results.hasErrors(), is(true));
+    }
+
+    @Test
+    public void testFailCommandWhenSameUniqueKeyInDBExistsMoreAndAlreadyDuplicateAndConditionIsMatched() {
+        final var validator = new UniquenessValidator
+                .Builder<>(entitiesFetcher, new UniqueKey<>(List.of(ParentEntity.NAME)))
+                .setCondition(PLCondition.not(ParentEntity.ID_IN_TARGET.isNull()))
+                .build();
+
+        create(new CreateParent().with(ParentEntity.ID, 99)
+                .with(ParentEntity.NAME, UNIQUE_NAME)
+                .with(ParentEntity.ID_IN_TARGET, 333));
+
+        create(new CreateParent().with(ParentEntity.ID, 98)
+                .with(ParentEntity.NAME, UNIQUE_NAME)
+                .with(ParentEntity.ID_IN_TARGET, 4444));
+
+
+        final var commands = List.of(
+                new CreateParent().with(ParentEntity.ID, 1)
+                        .with(ParentEntity.NAME, UNIQUE_NAME)
                         .with(ParentEntity.ID_IN_TARGET, 12345)
         );
 

--- a/main/src/main/java/com/kenshoo/pl/entity/spi/helpers/UniquenessValidator.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/spi/helpers/UniquenessValidator.java
@@ -56,7 +56,7 @@ public class UniquenessValidator<E extends EntityType<E>> implements ChangesVali
 
         Map<Identifier<E>, CurrentEntityState> duplicates = fetcher.fetch(uniqueKey.getEntityType(), commandsByIds.keySet(), condition, uniqueKeyAndPK)
                 .stream()
-                .collect(toMap(e -> createKeyValue(e, uniqueKey), identity()));
+                .collect(toMap(e -> createKeyValue(e, uniqueKey), identity() , (a,b)-> {return a;}));
 
         duplicates.forEach((dupKey, dupEntity) -> ctx.addValidationError(commandsByIds.get(dupKey), errorForDatabaseConflict(dupEntity, pk)));
     }


### PR DESCRIPTION
When validate unique entity , and the entity already duplicate and not unique in the db - we failed on :

(attempted merging values {ADGROUP_ID=1} and {ADGROUP_ID=1})
	at java.base/java.util.stream.Collectors.duplicateKeyException

On this case - it is ok just to take the first entity from the db 

@galkoren @dimagorelik  Please review.
