### PR TITLE
PL-126: Don't audit a created field with a null value

### DIFF
--- a/main/src/main/java/com/kenshoo/pl/entity/Triptional.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/Triptional.java
@@ -458,6 +458,40 @@ public class Triptional<T> {
     }
 
     /**
+     * Indicates whether some other object is "equal to" this {@code Triptional}, while comparing them as {@code Optional}-s,
+     * and also using the input function to test equality.<br>
+     * The other object is considered equal if it is also a {@code Triptional}, and <i>also</i> one of the following applies:
+     * <ul>
+     * <li>Both instances have no value present
+     * <li>One of the instances has no value present and the other is {@code null}
+     * <li>Both instances have a value present (possibly {@code null}),
+     * and when the <i>valueEqualityFunction</i> is applied to both values - it returns {@code true}
+     * </ul>
+     *
+     * @param obj an object to be tested for equality
+     * @param valueEqualityFunction the function to use for testing equality of values, when present
+     * @return {@code true} if the other object is "equal to" this object
+     * otherwise {@code false}
+     * @throws NullPointerException if <i>valueEqualityFunction</i> is {@code null}
+     */
+    public boolean equalsAsOptional(final Object obj, final BiFunction<T, T, Boolean> valueEqualityFunction) {
+        requireNonNull(valueEqualityFunction, "A value equality function must be provided");
+
+        if (this == obj) {
+            return true;
+        }
+
+        if (!(obj instanceof Triptional)) {
+            return false;
+        }
+
+        //noinspection unchecked
+        final Triptional<T> other = (Triptional<T>) obj;
+
+        return valueEqualityFunction.apply(value, other.value);
+    }
+
+    /**
      * Returns a hash code value which is the combination of:
      * <ul>
      *     <li>The present value, if any, or 0 (zero) if no value is present.</li>

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditFieldChangeGenerator.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditFieldChangeGenerator.java
@@ -49,7 +49,7 @@ public class AuditFieldChangeGenerator {
                                                                     final AuditedField<E, T> field) {
         final var triptionalCurrentValue = auditFieldValueResolver.resolve(field, currentState);
         final var triptionalFinalValue = auditFieldValueResolver.resolve(field, finalState);
-        return triptionalCurrentValue.equals(triptionalFinalValue, field::valuesEqual);
+        return triptionalCurrentValue.equalsAsOptional(triptionalFinalValue, field::valuesEqual);
     }
 
     private <E extends EntityType<E>> FieldAuditRecord buildFieldRecord(final CurrentEntityState currentState,

--- a/main/src/test/java/com/kenshoo/pl/entity/TriptionalTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/TriptionalTest.java
@@ -493,6 +493,75 @@ public class TriptionalTest {
         assertThat(Triptional.nullInstance().equals(Triptional.absent(), Objects::equals),
                    is(false));
     }
+
+    @Test
+    public void equalsAsOptional_ForTwoDoublesCloseEnough_ShouldReturnTrue() {
+        assertThat(Triptional.of(2.001).equalsAsOptional(Triptional.of(2.0), (x, y) -> Math.abs(x - y) < 0.01),
+                   is(true));
+    }
+
+    @Test
+    public void equalsAsOptional_ForTwoDoublesNotCloseEnough_ShouldReturnFalse() {
+        assertThat(Triptional.of(2.1).equalsAsOptional(Triptional.of(2.0), (x, y) -> Math.abs(x - y) < 0.01),
+                   is(false));
+    }
+
+    @Test
+    public void equalsAsOptional_WhenThisNotNullAndOtherNull_AndEqualityFunctionTrue_ShouldReturnTrue() {
+        assertThat(Triptional.of(EMPTY).equalsAsOptional(Triptional.nullInstance(),
+                                                         (s1, s2) -> defaultIfEmpty(s1, "bla").equals(defaultIfEmpty(s2, "bla"))),
+                   is(true));
+    }
+
+    @Test
+    public void equalsAsOptional_WhenThisNotNullAndOtherNull_AndEqualityFunctionFalse_ShouldReturnFalse() {
+        assertThat(Triptional.of(2).equalsAsOptional(Triptional.nullInstance(), Objects::equals),
+                   is(false));
+    }
+
+    @Test
+    public void equalsAsOptional_WhenThisNotNullAndOtherAbsent_ShouldReturnFalse() {
+        assertThat(Triptional.of(2).equalsAsOptional(Triptional.absent(), Objects::equals),
+                   is(false));
+    }
+
+    @Test
+    public void equalsAsOptional_WhenThisNullAndOtherNotNull_AndEqualityFunctionTrue_ShouldReturnTrue() {
+        assertThat(Triptional.<String>nullInstance().equalsAsOptional(Triptional.of(EMPTY),
+                                                                      (s1, s2) -> defaultIfEmpty(s1, "bla").equals(defaultIfEmpty(s2, "bla"))),
+                   is(true));
+    }
+
+    @Test
+    public void equalsAsOptional_WhenThisNullAndOtherNotNull_AndEqualityFunctionFalse_ShouldReturnFalse() {
+        assertThat(Triptional.nullInstance().equalsAsOptional(Triptional.of(3), Objects::equals),
+                   is(false));
+    }
+    
+    @Test
+    public void equalsAsOptional_WhenBothNull_ShouldReturnTrue() {
+        assertThat(Triptional.nullInstance().equalsAsOptional(Triptional.of(null), Objects::equals),
+                   is(true));
+    }
+
+    @Test
+    public void equalsAsOptional_WhenThisNullAndOtherAbsent_ShouldReturnTrue() {
+        assertThat(Triptional.nullInstance().equalsAsOptional(Triptional.absent(), Objects::equals),
+                   is(true));
+    }
+
+    @Test
+    public void equalsAsOptional_WhenThisAbsentAndOtherNotNull_ShouldReturnFalse() {
+        assertThat(Triptional.absent().equalsAsOptional(Triptional.of(3), Objects::equals),
+                   is(false));
+    }
+
+    @Test
+    public void equalsAsOptional_WhenThisAbsentAndOtherNull_ShouldReturnTrue() {
+        assertThat(Triptional.absent().equalsAsOptional(Triptional.nullInstance(), Objects::equals),
+                   is(true));
+    }
+    
     private Triptional<String> toTriptionalString(final Object val) {
         return Triptional.of(String.valueOf(val));
     }

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditFieldChangeGeneratorTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditFieldChangeGeneratorTest.java
@@ -148,14 +148,11 @@ public class AuditFieldChangeGeneratorTest {
     }
 
     @Test
-    public void generate_CurrentAbsent_FinalNull_ShouldReturnFieldChangeWithEmptyContents() {
+    public void generate_CurrentAbsent_FinalNull_ShouldReturnEmpty() {
         when(auditFieldValueResolver.resolve(NAME_AUDITED_FIELD, currentState)).thenReturn(Triptional.absent());
         when(auditFieldValueResolver.resolve(NAME_AUDITED_FIELD, finalState)).thenReturn(Triptional.nullInstance());
 
-        when(auditFieldValueResolver.resolveToString(NAME_AUDITED_FIELD, currentState)).thenReturn(Triptional.absent());
-        when(auditFieldValueResolver.resolveToString(NAME_AUDITED_FIELD, finalState)).thenReturn(Triptional.nullInstance());
-
-        assertThat(generate(NAME_AUDITED_FIELD), isPresentAnd(is(FieldAuditRecord.builder(NAME_FIELD_NAME).build())));
+        assertThat(generate(NAME_AUDITED_FIELD), isEmpty());
     }
 
     @Test

--- a/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordFieldRecordMissingMatcher.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordFieldRecordMissingMatcher.java
@@ -1,0 +1,30 @@
+package com.kenshoo.pl.entity.matchers.audit;
+
+import com.kenshoo.pl.entity.audit.AuditRecord;
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+
+class AuditRecordFieldRecordMissingMatcher extends TypeSafeMatcher<AuditRecord> {
+
+    private final String field;
+
+    AuditRecordFieldRecordMissingMatcher(final String field) {
+        this.field = field;
+    }
+
+    @Override
+    protected boolean matchesSafely(final AuditRecord actualAuditRecord) {
+        return hasNoFieldRecordFor(actualAuditRecord, field);
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("an AuditRecord WITHOUT a field record for " + field);
+    }
+
+
+    private boolean hasNoFieldRecordFor(final AuditRecord auditRecord, final String field) {
+        return auditRecord.getFieldRecords().stream()
+                          .noneMatch(fieldRecord -> fieldRecord.getField().equals(field));
+    }
+}

--- a/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordMatchers.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordMatchers.java
@@ -64,6 +64,10 @@ public class AuditRecordMatchers {
         return new AuditRecordFieldRecordExistsMatcher(expectedField.toString());
     }
 
+    public static Matcher<AuditRecord> hasNoFieldRecordFor(final EntityField<?, ?> field) {
+        return new AuditRecordFieldRecordMissingMatcher(field.toString());
+    }
+
     public static Matcher<AuditRecord> hasNoFieldRecords() {
         return new AuditRecordNoFieldRecordsMatcher();
     }


### PR DESCRIPTION
In the current audit logic, for a `CREATE` operation - if a field was not populated (has a `null` value), it will still be included in the field changes of the record, with the field name only. However this adds no useful information - since we can omit it altogether, and it will be understood that the value is `null`.

So in this PR I am changing the logic to omit these fields from the record.