### PR TITLE
PL-127: Don't audit virtual fields

### DIFF
--- a/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditIgnoreVirtualFieldsTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditIgnoreVirtualFieldsTest.java
@@ -1,0 +1,110 @@
+package com.kenshoo.pl.audit;
+
+import com.kenshoo.jooq.DataTableUtils;
+import com.kenshoo.jooq.TestJooqConfig;
+import com.kenshoo.pl.audit.commands.CreateAuditedWithVirtualCommand;
+import com.kenshoo.pl.audit.commands.CreateInclusiveAuditedWithVirtualCommand;
+import com.kenshoo.pl.entity.*;
+import com.kenshoo.pl.entity.audit.AuditRecord;
+import com.kenshoo.pl.entity.internal.audit.MainTable;
+import com.kenshoo.pl.entity.internal.audit.entitytypes.AuditedWithVirtualType;
+import com.kenshoo.pl.entity.internal.audit.entitytypes.InclusiveAuditedWithVirtualType;
+import org.jooq.DSLContext;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static com.kenshoo.pl.entity.matchers.audit.AuditRecordMatchers.hasFieldRecordFor;
+import static com.kenshoo.pl.entity.matchers.audit.AuditRecordMatchers.hasNoFieldRecordFor;
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+
+public class AuditIgnoreVirtualFieldsTest {
+
+    private PLContext plContext;
+    private InMemoryAuditRecordPublisher auditRecordPublisher;
+
+    private ChangeFlowConfig<AuditedWithVirtualType> auditedFlowConfig;
+    private ChangeFlowConfig<InclusiveAuditedWithVirtualType> inclusiveAuditedFlowConfig;
+
+    private PersistenceLayer<AuditedWithVirtualType> auditedPL;
+    private PersistenceLayer<InclusiveAuditedWithVirtualType> inclusiveAuditedPL;
+
+    @Before
+    public void setUp() {
+        final DSLContext dslContext = TestJooqConfig.create();
+        auditRecordPublisher = new InMemoryAuditRecordPublisher();
+        plContext = new PLContext.Builder(dslContext)
+            .withFeaturePredicate(__ -> true)
+            .withAuditRecordPublisher(auditRecordPublisher)
+            .build();
+
+        auditedFlowConfig = flowConfig(AuditedWithVirtualType.INSTANCE);
+        inclusiveAuditedFlowConfig = flowConfig(InclusiveAuditedWithVirtualType.INSTANCE);
+
+        auditedPL = persistenceLayer();
+        inclusiveAuditedPL = persistenceLayer();
+
+        Stream.of(MainTable.INSTANCE)
+              .forEach(table -> DataTableUtils.createTable(dslContext, table));
+
+    }
+
+    @After
+    public void tearDown() {
+        Stream.of(MainTable.INSTANCE)
+              .forEach(table -> plContext.dslContext().dropTable(table).execute());
+    }
+
+    @Test
+    public void auditedEntity_RealAndVirtualFields_ShouldCreateFieldRecordsForRealOnly() {
+        auditedPL.create(singletonList(new CreateAuditedWithVirtualCommand()
+                                           .with(AuditedWithVirtualType.NAME, "name")
+                                           .with(AuditedWithVirtualType.DESC, "desc")
+                                           .with(AuditedWithVirtualType.VIRTUAL_DESC_1, "name-desc")
+                                           .with(AuditedWithVirtualType.VIRTUAL_DESC_2, "name:desc")),
+                         auditedFlowConfig);
+
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+
+        assertThat("Incorrect number of published records",
+                   auditRecords, hasSize(1));
+        final AuditRecord auditRecord = auditRecords.get(0);
+        assertThat(auditRecord, allOf(hasFieldRecordFor(AuditedWithVirtualType.NAME),
+                                      hasFieldRecordFor(AuditedWithVirtualType.DESC),
+                                      hasNoFieldRecordFor(AuditedWithVirtualType.VIRTUAL_DESC_1),
+                                      hasNoFieldRecordFor(AuditedWithVirtualType.VIRTUAL_DESC_2)));
+    }
+
+    @Test
+    public void inclusiveAuditedEntity_RealAndVirtualFields_ShouldCreateFieldRecordsForRealOnly() {
+        inclusiveAuditedPL.create(singletonList(new CreateInclusiveAuditedWithVirtualCommand()
+                                                    .with(InclusiveAuditedWithVirtualType.NAME, "name")
+                                                    .with(InclusiveAuditedWithVirtualType.DESC, "desc")
+                                                    .with(InclusiveAuditedWithVirtualType.VIRTUAL_DESC, "name-desc")),
+                                                inclusiveAuditedFlowConfig);
+
+        final List<? extends AuditRecord> auditRecords = auditRecordPublisher.getAuditRecords().collect(toList());
+
+        assertThat("Incorrect number of published records",
+                   auditRecords, hasSize(1));
+        final AuditRecord auditRecord = auditRecords.get(0);
+        assertThat(auditRecord, allOf(hasFieldRecordFor(InclusiveAuditedWithVirtualType.NAME),
+                                      hasFieldRecordFor(InclusiveAuditedWithVirtualType.DESC),
+                                      hasNoFieldRecordFor(InclusiveAuditedWithVirtualType.VIRTUAL_DESC)));
+    }
+
+    private <E extends EntityType<E>> ChangeFlowConfig<E> flowConfig(final E entityType) {
+        return ChangeFlowConfigBuilderFactory.newInstance(plContext, entityType).build();
+    }
+
+    private <E extends EntityType<E>> PersistenceLayer<E> persistenceLayer() {
+        return new PersistenceLayer<>(plContext);
+    }
+}

--- a/integration-tests/src/test/java/com/kenshoo/pl/audit/commands/CreateAuditedWithVirtualCommand.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/audit/commands/CreateAuditedWithVirtualCommand.java
@@ -1,0 +1,13 @@
+package com.kenshoo.pl.audit.commands;
+
+import com.kenshoo.pl.entity.CreateEntityCommand;
+import com.kenshoo.pl.entity.EntityCommandExt;
+import com.kenshoo.pl.entity.internal.audit.entitytypes.AuditedWithVirtualType;
+
+public class CreateAuditedWithVirtualCommand extends CreateEntityCommand<AuditedWithVirtualType>
+    implements EntityCommandExt<AuditedWithVirtualType, CreateAuditedWithVirtualCommand> {
+
+    public CreateAuditedWithVirtualCommand() {
+        super(AuditedWithVirtualType.INSTANCE);
+    }
+}

--- a/integration-tests/src/test/java/com/kenshoo/pl/audit/commands/CreateInclusiveAuditedWithVirtualCommand.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/audit/commands/CreateInclusiveAuditedWithVirtualCommand.java
@@ -1,0 +1,13 @@
+package com.kenshoo.pl.audit.commands;
+
+import com.kenshoo.pl.entity.CreateEntityCommand;
+import com.kenshoo.pl.entity.EntityCommandExt;
+import com.kenshoo.pl.entity.internal.audit.entitytypes.InclusiveAuditedWithVirtualType;
+
+public class CreateInclusiveAuditedWithVirtualCommand extends CreateEntityCommand<InclusiveAuditedWithVirtualType>
+    implements EntityCommandExt<InclusiveAuditedWithVirtualType, CreateInclusiveAuditedWithVirtualCommand> {
+
+    public CreateInclusiveAuditedWithVirtualCommand() {
+        super(InclusiveAuditedWithVirtualType.INSTANCE);
+    }
+}

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditedFieldResolver.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditedFieldResolver.java
@@ -13,6 +13,7 @@ import static com.kenshoo.pl.entity.internal.EntityTypeReflectionUtil.getFieldAn
 import static com.kenshoo.pl.entity.internal.EntityTypeReflectionUtil.isAnnotatedWith;
 import static com.kenshoo.pl.entity.internal.audit.AuditIndicator.AUDITED;
 import static java.util.Objects.requireNonNull;
+import static java.util.function.Predicate.not;
 
 public class AuditedFieldResolver {
 
@@ -31,6 +32,7 @@ public class AuditedFieldResolver {
         requireNonNull(entityAuditIndicator, "entityAuditIndicator is required");
 
         return Optional.of(field)
+                       .filter(not(EntityField::isVirtual))
                        .filter(f -> !isAnnotatedWith(f.getEntityType(), NotAudited.class, f))
                        .filter(f -> isAnnotatedWith(f.getEntityType(), Audited.class, f) || entityAuditIndicator == AUDITED)
                        .map(this::toAuditedField);

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditedFieldResolverTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditedFieldResolverTest.java
@@ -1,6 +1,8 @@
 package com.kenshoo.pl.entity.internal.audit;
 
 import com.kenshoo.pl.entity.internal.audit.entitytypes.AuditedWithAllVariationsType;
+import com.kenshoo.pl.entity.internal.audit.entitytypes.AuditedWithVirtualType;
+import com.kenshoo.pl.entity.internal.audit.entitytypes.InclusiveAuditedWithVirtualType;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -131,4 +133,17 @@ public class AuditedFieldResolverTest {
         assertThat(maybeActualAuditedField, isPresentAndIs(expectedAuditedField));
     }
 
+    @Test
+    public void resolveWhenEntityAuditedAndFieldIsVirtualShouldReturnEmpty() {
+        final var maybeActualAuditedField = fieldResolver.resolve(AuditedWithVirtualType.VIRTUAL_DESC_1, AUDITED);
+
+        assertThat(maybeActualAuditedField, isEmpty());
+    }
+
+    @Test
+    public void resolveWhenEntityNotAuditedAndFieldIsVirtualAndAuditedShouldReturnEmpty() {
+        final var maybeActualAuditedField = fieldResolver.resolve(InclusiveAuditedWithVirtualType.VIRTUAL_DESC, AUDITED);
+
+        assertThat(maybeActualAuditedField, isEmpty());
+    }
 }

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/entitytypes/AuditedWithVirtualType.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/entitytypes/AuditedWithVirtualType.java
@@ -1,0 +1,34 @@
+package com.kenshoo.pl.entity.internal.audit.entitytypes;
+
+import com.kenshoo.pl.entity.EntityField;
+import com.kenshoo.pl.entity.annotation.Id;
+import com.kenshoo.pl.entity.annotation.audit.Audited;
+import com.kenshoo.pl.entity.converters.IdentityValueConverter;
+import com.kenshoo.pl.entity.internal.audit.MainTable;
+
+import java.util.Objects;
+
+@Audited
+public class AuditedWithVirtualType extends AbstractType<AuditedWithVirtualType> {
+
+    public static final AuditedWithVirtualType INSTANCE = new AuditedWithVirtualType();
+
+    @Id
+    public static final EntityField<AuditedWithVirtualType, Long> ID = INSTANCE.field(MainTable.INSTANCE.id);
+    public static final EntityField<AuditedWithVirtualType, String> NAME = INSTANCE.field(MainTable.INSTANCE.name);
+    public static final EntityField<AuditedWithVirtualType, String> DESC = INSTANCE.field(MainTable.INSTANCE.desc);
+    public static final EntityField<AuditedWithVirtualType, String> VIRTUAL_DESC_1 = INSTANCE.virtualField(NAME,
+                                                                                                           DESC,
+                                                                                                           (s1, s2) -> s1 + "-" + s2,
+                                                                                                           new IdentityValueConverter<>(String.class),
+                                                                                                           Objects::equals);
+    public static final EntityField<AuditedWithVirtualType, String> VIRTUAL_DESC_2 = INSTANCE.virtualField(NAME,
+                                                                                                           DESC,
+                                                                                                           (s1, s2) -> s1 + ":" + s2,
+                                                                                                           new IdentityValueConverter<>(String.class),
+                                                                                                           Objects::equals);
+
+    private AuditedWithVirtualType() {
+        super("AuditedWithVirtual");
+    }
+}

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/entitytypes/InclusiveAuditedWithVirtualType.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/entitytypes/InclusiveAuditedWithVirtualType.java
@@ -1,0 +1,31 @@
+package com.kenshoo.pl.entity.internal.audit.entitytypes;
+
+import com.kenshoo.pl.entity.EntityField;
+import com.kenshoo.pl.entity.annotation.Id;
+import com.kenshoo.pl.entity.annotation.audit.Audited;
+import com.kenshoo.pl.entity.converters.IdentityValueConverter;
+import com.kenshoo.pl.entity.internal.audit.MainTable;
+
+import java.util.Objects;
+
+public class InclusiveAuditedWithVirtualType extends AbstractType<InclusiveAuditedWithVirtualType> {
+
+    public static final InclusiveAuditedWithVirtualType INSTANCE = new InclusiveAuditedWithVirtualType();
+
+    @Id
+    public static final EntityField<InclusiveAuditedWithVirtualType, Long> ID = INSTANCE.field(MainTable.INSTANCE.id);
+    @Audited
+    public static final EntityField<InclusiveAuditedWithVirtualType, String> NAME = INSTANCE.field(MainTable.INSTANCE.name);
+    @Audited
+    public static final EntityField<InclusiveAuditedWithVirtualType, String> DESC = INSTANCE.field(MainTable.INSTANCE.desc);
+    @Audited
+    public static final EntityField<InclusiveAuditedWithVirtualType, String> VIRTUAL_DESC = INSTANCE.virtualField(NAME,
+                                                                                                                  DESC,
+                                                                                                                  (s1, s2) -> s1 + "-" + s2,
+                                                                                                                  new IdentityValueConverter<>(String.class),
+                                                                                                                  Objects::equals);
+
+    private InclusiveAuditedWithVirtualType() {
+        super("InclusiveAuditedWithVirtual");
+    }
+}


### PR DESCRIPTION
Virtual fields are fields calculated from the regular fields of an entity.
Since the regular fields can be audited and they will include all the necessary information about the changes, it's not necessary to audit virtual fields separately, as they will just add extra "noise" to the audit data. 
Therefore this PR disables them.

Should we receive a request in the future, we will add an optional toggle to enable this - but at the moment it doesn't seem likely.