### PR TITLE
Migrate to new sonatype repositories site

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -66,11 +66,11 @@ uploadArchives {
 
             beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
 
-            repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2") {
+            repository(url: "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2") {
                 authentication(userName: username, password: password)
             }
 
-            snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots") {
+            snapshotRepository(url: "https://s01.oss.sonatype.org/content/repositories/snapshots") {
                 authentication(userName: username, password: password)
             }
 


### PR DESCRIPTION
Last week Sonatype had an incident that prevented us from releasing PL.
This has been resolved, but anyway according to their recommendation they have migrated us to the new site.

This PR changes the publishing URL to the new site.