### PR TITLE
Revert usage of advanced Jooq version

### DIFF
--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/MainTable.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/MainTable.java
@@ -5,8 +5,6 @@ import org.jooq.Record;
 import org.jooq.TableField;
 import org.jooq.impl.SQLDataType;
 
-import static org.jooq.impl.DSL.name;
-
 public class MainTable extends AbstractDataTable<MainTable> {
 
     public static final MainTable INSTANCE = new MainTable("main");
@@ -17,7 +15,7 @@ public class MainTable extends AbstractDataTable<MainTable> {
     public final TableField<Record, String> desc2 = createField("desc2", SQLDataType.VARCHAR(50));
     public final TableField<Record, Double> amount = createField("amount", SQLDataType.DOUBLE);
     public final TableField<Record, Double> amount2 = createField("amount2", SQLDataType.DOUBLE);
-    public final TableField<Record, Integer> amount3 = createField(name("amount3"), SQLDataType.INTEGER);
+    public final TableField<Record, Integer> amount3 = createField("amount3", SQLDataType.INTEGER);
 
     private MainTable(final String name) {
         super(name);


### PR DESCRIPTION
In the [previous PR](https://github.com/kenshoo/persistence-layer/pull/60) I accidentally used a method which is only available since Jooq 3.15, but we have to be backwards compatible to older versions so the release build failed.
Fixing here by using the older version (which is deprecated but still available in 3.15)