### PR TITLE
DEVINF-366: Support auditing of an `EntityType` with no id

### DIFF
--- a/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForCreateTwoLevelsManualOrNoIdTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/audit/AuditForCreateTwoLevelsManualOrNoIdTest.java
@@ -11,7 +11,6 @@ import com.kenshoo.pl.entity.internal.audit.entitytypes.*;
 import org.jooq.DSLContext;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.List;
@@ -103,7 +102,6 @@ public class AuditForCreateTwoLevelsManualOrNoIdTest {
                 hasCreatedFieldRecord(AuditedChildManualIdType.NAME, CHILD_NAME))));
     }
 
-    @Ignore
     @Test
     public void oneParentWithManualId_OneChildWithoutId_ShouldCreateRecordsForParentAndChild() {
         final var childCmd = new CreateAuditedChildWithoutIdOfParentManualIdCommand()
@@ -131,12 +129,11 @@ public class AuditForCreateTwoLevelsManualOrNoIdTest {
                 hasCreatedFieldRecord(AuditedManualIdType.NAME, PARENT_NAME)));
 
         assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChildWithoutIdOfParentManualIdType.INSTANCE.getName()),
+                hasMandatoryFieldValue(AuditedChildWithoutIdOfParentWithoutIdType.NAME, CHILD_NAME),
                 hasOperator(CREATE),
-                hasMandatoryFieldValue(AuditedChildWithoutIdOfParentManualIdType.PARENT_ID, String.valueOf(PARENT_ID)),
                 hasCreatedFieldRecord(AuditedChildWithoutIdOfParentManualIdType.NAME, CHILD_NAME))));
     }
 
-    @Ignore
     @Test
     public void oneParentWithoutId_OneChildWithoutId_ShouldCreateRecordsForParentAndChild() {
         final var childCmd = new CreateAuditedChildWithoutIdOfParentWithoutIdCommand()
@@ -164,7 +161,7 @@ public class AuditForCreateTwoLevelsManualOrNoIdTest {
 
         assertThat(auditRecord, hasChildRecordThat(allOf(hasEntityType(AuditedChildWithoutIdOfParentWithoutIdType.INSTANCE.getName()),
                 hasOperator(CREATE),
-                hasMandatoryFieldValue(AuditedChildWithoutIdOfParentWithoutIdType.PARENT_NAME, String.valueOf(PARENT_NAME)),
+                hasMandatoryFieldValue(AuditedChildWithoutIdOfParentWithoutIdType.NAME, CHILD_NAME),
                 hasCreatedFieldRecord(AuditedChildWithoutIdOfParentWithoutIdType.NAME, CHILD_NAME))));
     }
 

--- a/main/src/main/java/com/kenshoo/pl/entity/audit/AuditRecord.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/audit/AuditRecord.java
@@ -30,7 +30,7 @@ public class AuditRecord {
                         final Collection<? extends FieldAuditRecord> fieldRecords,
                         final Collection<? extends AuditRecord> childRecords) {
         this.entityType = requireNonNull(entityType, "entityType is required");
-        this.entityId = requireNonNull(entityId, "entityId is required");
+        this.entityId = entityId;
         this.mandatoryFieldValues = mandatoryFieldValues;
         this.operator = requireNonNull(operator, "operator is required");
         this.entityChangeDescription = entityChangeDescription;
@@ -42,8 +42,16 @@ public class AuditRecord {
         return entityType;
     }
 
+    /**
+     * @deprecated replaced by {@link #safeGetEntityId()} since the entity id is no longer mandatory
+     */
+    @Deprecated
     public String getEntityId() {
         return entityId;
+    }
+
+    public Optional<String> safeGetEntityId() {
+        return Optional.ofNullable(entityId);
     }
 
     public Collection<? extends FieldValue> getMandatoryFieldValues() {

--- a/main/src/main/java/com/kenshoo/pl/entity/audit/AuditRecord.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/audit/AuditRecord.java
@@ -42,15 +42,7 @@ public class AuditRecord {
         return entityType;
     }
 
-    /**
-     * @deprecated replaced by {@link #safeGetEntityId()} since the entity id is no longer mandatory
-     */
-    @Deprecated
-    public String getEntityId() {
-        return entityId;
-    }
-
-    public Optional<String> safeGetEntityId() {
+    public Optional<String> getEntityId() {
         return Optional.ofNullable(entityId);
     }
 

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditRequiredFieldsCalculator.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditRequiredFieldsCalculator.java
@@ -7,11 +7,10 @@ import com.kenshoo.pl.entity.spi.CurrentStateConsumer;
 import org.jooq.lambda.Seq;
 
 import java.util.Collection;
-import java.util.Set;
 import java.util.stream.Stream;
 
 import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.toSet;
+import static java.util.stream.Collectors.toUnmodifiableSet;
 import static org.jooq.lambda.Seq.seq;
 
 public class AuditRequiredFieldsCalculator<E extends EntityType<E>> implements CurrentStateConsumer<E> {
@@ -26,13 +25,12 @@ public class AuditRequiredFieldsCalculator<E extends EntityType<E>> implements C
     public Stream<? extends EntityField<?, ?>> requiredFields(final Collection<? extends EntityField<E, ?>> fieldsToChange,
                                                               final ChangeOperation changeOperation) {
 
-        final Set<? extends EntityField<E, ?>> onChangeFields = auditedEntityType.getUnderlyingOnChangeFields().collect(toSet());
+        final var onChangeFields = auditedEntityType.getUnderlyingOnChangeFields().collect(toUnmodifiableSet());
 
-        final Seq<? extends EntityField<E, ?>> intersectedChangeFields =
-            seq(fieldsToChange).filter(onChangeFields::contains);
+        final var intersectedChangeFields = seq(fieldsToChange).filter(onChangeFields::contains);
 
-        return Seq.<EntityField<?, ?>>of(auditedEntityType.getIdField())
-            .append(auditedEntityType.getUnderlyingMandatoryFields())
-            .append(intersectedChangeFields);
+        return Seq.<EntityField<?, ?>>seq(auditedEntityType.getUnderlyingMandatoryFields())
+                .append(intersectedChangeFields)
+                .append(auditedEntityType.getIdField());
     }
 }

--- a/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditedEntityType.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/internal/audit/AuditedEntityType.java
@@ -9,10 +9,7 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Stream;
 
 import static com.kenshoo.pl.entity.audit.AuditTrigger.*;
@@ -43,8 +40,8 @@ public class AuditedEntityType<E extends EntityType<E>> {
         this.internalFields = internalFields;
     }
 
-    public EntityField<E, ? extends Number> getIdField() {
-        return idField;
+    public Optional<EntityField<E, ? extends Number>> getIdField() {
+        return Optional.ofNullable(idField);
     }
 
     public String getName() {
@@ -78,8 +75,8 @@ public class AuditedEntityType<E extends EntityType<E>> {
         return !internalFields.isEmpty();
     }
 
-    public static <E extends EntityType<E>> Builder<E> builder(final EntityField<E, ? extends Number> idField) {
-        return new Builder<>(idField);
+    public static <E extends EntityType<E>> Builder<E> builder(final E entityType) {
+        return new Builder<>(entityType);
     }
 
     public static class Builder<E extends EntityType<E>> {
@@ -88,9 +85,10 @@ public class AuditedEntityType<E extends EntityType<E>> {
         private Set<? extends AuditedField<?, ?>> externalFields = emptySet();
         private final SetMultimap<AuditTrigger, AuditedField<E, ?>> internalFields = HashMultimap.create();
 
-        public Builder(final EntityField<E, ? extends Number> idField) {
-            this.idField = requireNonNull(idField, "idField is required");
-            this.name = idField.getEntityType().getName();
+        public Builder(final E entityType) {
+            requireNonNull(entityType, "entityType is required");
+            this.idField = entityType.getIdField().orElse(null);
+            this.name = entityType.getName();
             Stream.of(ALWAYS, ON_CREATE_OR_UPDATE, ON_UPDATE)
                   .forEach(trigger -> internalFields.putAll(trigger, emptySet()));
         }

--- a/main/src/test/java/com/kenshoo/pl/entity/AuditRecordTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/AuditRecordTest.java
@@ -42,7 +42,7 @@ public class AuditRecordTest {
                 .withEntityChangeDescription(ENTITY_CHANGE_DESCRIPTION)
                 .build();
 
-        assertThat(auditRecord.safeGetEntityId(), is(Optional.of(ENTITY_ID_1)));
+        assertThat(auditRecord.getEntityId(), is(Optional.of(ENTITY_ID_1)));
     }
 
     @Test
@@ -52,7 +52,7 @@ public class AuditRecordTest {
                 .withOperator(CREATE)
                 .build();
 
-        assertThat(auditRecord.safeGetEntityId(), is(Optional.empty()));
+        assertThat(auditRecord.getEntityId(), is(Optional.empty()));
     }
 
     @Test

--- a/main/src/test/java/com/kenshoo/pl/entity/AuditRecordTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/AuditRecordTest.java
@@ -32,6 +32,29 @@ public class AuditRecordTest {
     @Mock
     private AuditRecord childRecord;
 
+
+    @Test
+    public void safeGetEntityIdWhenExistsShouldReturnIt() {
+        final var auditRecord = new AuditRecord.Builder()
+                .withEntityType(ENTITY_TYPE)
+                .withEntityId(ENTITY_ID_1)
+                .withOperator(CREATE)
+                .withEntityChangeDescription(ENTITY_CHANGE_DESCRIPTION)
+                .build();
+
+        assertThat(auditRecord.safeGetEntityId(), is(Optional.of(ENTITY_ID_1)));
+    }
+
+    @Test
+    public void safeGetEntityIdWhenWhenDoesntExistShouldReturnEmpty() {
+        final var auditRecord = new AuditRecord.Builder()
+                .withEntityType(ENTITY_TYPE)
+                .withOperator(CREATE)
+                .build();
+
+        assertThat(auditRecord.safeGetEntityId(), is(Optional.empty()));
+    }
+
     @Test
     public void getEntityChangeDescriptionWhenExistsShouldReturnIt() {
         final var auditRecord = new AuditRecord.Builder()

--- a/main/src/test/java/com/kenshoo/pl/entity/ChangeFlowConfigTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/ChangeFlowConfigTest.java
@@ -178,7 +178,7 @@ public class ChangeFlowConfigTest {
     @Test
     public void audit_required_fields_calculator_should_be_in_state_consumers_if_audited_fields_defined() {
 
-        final var auditedEntityType = AuditedEntityType.builder(TestEntity.ID)
+        final var auditedEntityType = AuditedEntityType.builder(TestEntity.INSTANCE)
                                                        .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE,
                                                                                      TestEntity.FIELD_1, TestEntity.FIELD_2)
                                                        .build();
@@ -246,7 +246,7 @@ public class ChangeFlowConfigTest {
     @Test
     public void audit_required_fields_calculator_should_be_in_state_consumers_if_reenabled_and_audited_fields_defined() {
 
-        final var auditedEntityType = AuditedEntityType.builder(TestEntity.ID)
+        final var auditedEntityType = AuditedEntityType.builder(TestEntity.INSTANCE)
                                                        .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE,
                                                                                      TestEntity.FIELD_1, TestEntity.FIELD_2)
                                                        .build();
@@ -269,7 +269,7 @@ public class ChangeFlowConfigTest {
     @Test
     public void should_create_audit_record_generator_if_audited_fields_defined() {
 
-        final var auditedEntityType = AuditedEntityType.builder(TestEntity.ID)
+        final var auditedEntityType = AuditedEntityType.builder(TestEntity.INSTANCE)
                                                        .withName(AUDITED_ENTITY_TYPE_NAME)
                                                        .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE,
                                                                                      TestEntity.FIELD_1, TestEntity.FIELD_2)
@@ -320,7 +320,7 @@ public class ChangeFlowConfigTest {
     @Test
     public void should_create_audit_record_generator_if_reenabled_and_audited_fields_defined() {
 
-        final var auditedEntityType = AuditedEntityType.builder(TestEntity.ID)
+        final var auditedEntityType = AuditedEntityType.builder(TestEntity.INSTANCE)
                                                        .withName(AUDITED_ENTITY_TYPE_NAME)
                                                        .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE,
                                                                                      TestEntity.FIELD_1, TestEntity.FIELD_2)

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRequiredFieldsCalculatorTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditRequiredFieldsCalculatorTest.java
@@ -1,10 +1,12 @@
 package com.kenshoo.pl.entity.internal.audit;
 
-import com.google.common.collect.ImmutableSet;
 import com.kenshoo.pl.entity.ChangeOperation;
 import com.kenshoo.pl.entity.EntityField;
+import com.kenshoo.pl.entity.EntityType;
 import com.kenshoo.pl.entity.internal.audit.entitytypes.AuditedAutoIncIdType;
+import com.kenshoo.pl.entity.internal.audit.entitytypes.AuditedWithoutIdType;
 import com.kenshoo.pl.entity.internal.audit.entitytypes.NotAuditedAncestorType;
+import org.jooq.lambda.Seq;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -14,9 +16,8 @@ import java.util.stream.Stream;
 
 import static com.kenshoo.pl.entity.audit.AuditTrigger.*;
 import static com.kenshoo.pl.entity.internal.audit.AuditedEntityType.builder;
+import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
-import static java.util.function.Function.identity;
-import static java.util.stream.Collectors.toSet;
 import static java.util.stream.Collectors.toUnmodifiableSet;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
@@ -26,340 +27,481 @@ public class AuditRequiredFieldsCalculatorTest {
     private static final ChangeOperation OPERATOR = ChangeOperation.UPDATE;
 
     @Test
-    public void requiredFields_FieldSetHasIdOnly_FieldsToChangeAreDifferent_ShouldReturnIdOnly() {
-        final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType =
-            builder(AuditedAutoIncIdType.ID).build();
+    public void requiredFields_TypeHasIdOnly_ToChangeAreDifferent_ShouldReturnIdOnly() {
+        final var auditedEntityType = builder(AuditedAutoIncIdType.INSTANCE).build();
 
-        final Set<? extends EntityField<AuditedAutoIncIdType, ?>> fieldsToChange = ImmutableSet.of(AuditedAutoIncIdType.NAME,
-                                                                                          AuditedAutoIncIdType.DESC,
-                                                                                          AuditedAutoIncIdType.DESC2);
+        final var fieldsToChange = Set.of(AuditedAutoIncIdType.NAME,
+                AuditedAutoIncIdType.DESC,
+                AuditedAutoIncIdType.DESC2);
 
-        final Stream<? extends EntityField<?, ?>> actualRequiredFields = calculate(auditedEntityType, fieldsToChange);
+        final var actualRequiredFields = calculate(auditedEntityType, fieldsToChange);
 
-        assertThat(actualRequiredFields.collect(toSet()),
-                   is(Collections.<EntityField<?, ?>>singleton(AuditedAutoIncIdType.ID)));
+        assertThat(actualRequiredFields.collect(toUnmodifiableSet()),
+                is(Collections.<EntityField<?, ?>>singleton(AuditedAutoIncIdType.ID)));
     }
 
     @Test
-    public void requiredFields_FieldSetHasIdOnly_FieldsToChangeIncludeIdAndOthers_ShouldReturnIdOnly() {
-        final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType =
-            builder(AuditedAutoIncIdType.ID).build();
+    public void requiredFields_TypeHasIdOnly_ToChangeIncludeIdAndOthers_ShouldReturnIdOnly() {
+        final var auditedEntityType = builder(AuditedAutoIncIdType.INSTANCE).build();
 
-        final Set<? extends EntityField<AuditedAutoIncIdType, ?>> fieldsToChange = ImmutableSet.of(AuditedAutoIncIdType.ID,
-                                                                                          AuditedAutoIncIdType.NAME,
-                                                                                          AuditedAutoIncIdType.DESC,
-                                                                                          AuditedAutoIncIdType.DESC2);
+        final var fieldsToChange = Set.of(AuditedAutoIncIdType.ID,
+                AuditedAutoIncIdType.NAME,
+                AuditedAutoIncIdType.DESC,
+                AuditedAutoIncIdType.DESC2);
 
-        final Stream<? extends EntityField<?, ?>> actualRequiredFields = calculate(auditedEntityType, fieldsToChange);
+        final var actualRequiredFields = calculate(auditedEntityType, fieldsToChange);
 
-        assertThat(actualRequiredFields.collect(toSet()),
-                   is(Collections.<EntityField<?, ?>>singleton(AuditedAutoIncIdType.ID)));
+        assertThat(actualRequiredFields.collect(toUnmodifiableSet()),
+                is(Collections.<EntityField<?, ?>>singleton(AuditedAutoIncIdType.ID)));
     }
 
     @Test
-    public void requiredFields_FieldSetHasIdAndExternalMandatoryOnly_FieldsToChangeNotEmpty_ShouldReturnFieldSet() {
-        final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType =
-            builder(AuditedAutoIncIdType.ID)
+    public void requiredFields_TypeHasIdAndExternalMandatoryOnly_ToChangeNotEmpty_ShouldReturnFieldsOfType() {
+        final var auditedEntityType = builder(AuditedAutoIncIdType.INSTANCE)
                 .withUnderlyingExternalFields(NotAuditedAncestorType.NAME,
-                                              NotAuditedAncestorType.DESC)
+                        NotAuditedAncestorType.DESC)
                 .build();
 
-        final Set<? extends EntityField<AuditedAutoIncIdType, ?>> fieldsToChange = singleton(AuditedAutoIncIdType.NAME);
+        final var fieldsToChange = singleton(AuditedAutoIncIdType.NAME);
 
-        final Set<? extends EntityField<?, ?>> expectedFieldsToFetch = toEntityFields(auditedEntityType);
+        final var expectedRequiredFields = toEntityFields(auditedEntityType);
 
-        final Stream<? extends EntityField<?, ?>> actualRequiredFields = calculate(auditedEntityType, fieldsToChange);
+        final var actualRequiredFields = calculate(auditedEntityType, fieldsToChange);
 
-        assertThat(actualRequiredFields.collect(Collectors.<EntityField<?, ?>>toSet()), is(expectedFieldsToFetch));
+        assertThat(actualRequiredFields.collect(Collectors.<EntityField<?, ?>>toUnmodifiableSet()), is(expectedRequiredFields));
     }
 
     @Test
-    public void requiredFields_FieldSetHasIdAndSelfMandatoryOnly_FieldsToChangeAreDifferent_ShouldReturnFieldSet() {
-        final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType =
-            builder(AuditedAutoIncIdType.ID)
+    public void requiredFields_TypeHasIdAndSelfMandatoryOnly_ToChangeAreDifferent_ShouldReturnFieldsOfType() {
+        final var auditedEntityType = builder(AuditedAutoIncIdType.INSTANCE)
                 .withUnderlyingInternalFields(ALWAYS, AuditedAutoIncIdType.NAME, AuditedAutoIncIdType.DESC)
                 .build();
 
-        final Set<? extends EntityField<AuditedAutoIncIdType, ?>> fieldsToChange = singleton(AuditedAutoIncIdType.DESC2);
+        final var fieldsToChange = singleton(AuditedAutoIncIdType.DESC2);
 
-        final Set<? extends EntityField<?, ?>> expectedFieldsToFetch = toEntityFields(auditedEntityType);
+        final var expectedRequiredFields = toEntityFields(auditedEntityType);
 
-        final Stream<? extends EntityField<?, ?>> actualRequiredFields = calculate(auditedEntityType, fieldsToChange);
+        final var actualRequiredFields = calculate(auditedEntityType, fieldsToChange);
 
-        assertThat(actualRequiredFields.collect(Collectors.<EntityField<?, ?>>toSet()), is(expectedFieldsToFetch));
+        assertThat(actualRequiredFields.collect(Collectors.<EntityField<?, ?>>toUnmodifiableSet()), is(expectedRequiredFields));
     }
 
     @Test
-    public void requiredFields_FieldSetHasIdAndSelfMandatoryOnly_FieldsToChangeAreTheSame_ShouldReturnFieldsToChange() {
-        final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType =
-            builder(AuditedAutoIncIdType.ID)
-                .withUnderlyingInternalFields(ALWAYS, AuditedAutoIncIdType.NAME, AuditedAutoIncIdType.DESC)
-                .build();
+    public void requiredFields_TypeHasIdAndSelfMandatoryOnly_ToChangeAreTheSame_ShouldReturnFieldsToChange() {
+        final var auditedEntityType =
+                builder(AuditedAutoIncIdType.INSTANCE)
+                        .withUnderlyingInternalFields(ALWAYS, AuditedAutoIncIdType.NAME, AuditedAutoIncIdType.DESC)
+                        .build();
 
-        final Set<? extends EntityField<AuditedAutoIncIdType, ?>> fieldsToChange = ImmutableSet.of(AuditedAutoIncIdType.ID,
-                                                                                          AuditedAutoIncIdType.NAME,
-                                                                                          AuditedAutoIncIdType.DESC);
+        final var fieldsToChange = Set.of(AuditedAutoIncIdType.ID,
+                AuditedAutoIncIdType.NAME,
+                AuditedAutoIncIdType.DESC);
 
-        final Stream<? extends EntityField<?, ?>> actualRequiredFields = calculate(auditedEntityType, fieldsToChange);
+        final var actualRequiredFields = calculate(auditedEntityType, fieldsToChange);
 
-        assertThat(actualRequiredFields.collect(Collectors.<EntityField<?, ?>>toSet()), is(fieldsToChange));
+        assertThat(actualRequiredFields.collect(Collectors.<EntityField<?, ?>>toUnmodifiableSet()), is(fieldsToChange));
     }
 
     @Test
-    public void requiredFields_FieldSetHasIdAndSelfMandatoryOnly_FieldsToChangePartiallyIntersect_ShouldReturnFieldSet() {
-        final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType =
-            builder(AuditedAutoIncIdType.ID)
-                .withUnderlyingInternalFields(ALWAYS, AuditedAutoIncIdType.NAME, AuditedAutoIncIdType.DESC)
-                .build();
+    public void requiredFields_TypeHasIdAndSelfMandatoryOnly_ToChangePartiallyIntersect_ShouldReturnFieldsOfType() {
+        final var auditedEntityType =
+                builder(AuditedAutoIncIdType.INSTANCE)
+                        .withUnderlyingInternalFields(ALWAYS, AuditedAutoIncIdType.NAME, AuditedAutoIncIdType.DESC)
+                        .build();
 
-        final Set<? extends EntityField<AuditedAutoIncIdType, ?>> fieldsToChange = ImmutableSet.of(AuditedAutoIncIdType.DESC,
-                                                                                          AuditedAutoIncIdType.DESC2);
+        final var fieldsToChange = Set.of(AuditedAutoIncIdType.DESC,
+                AuditedAutoIncIdType.DESC2);
 
-        final Set<? extends EntityField<?, ?>> expectedFieldsToFetch = toEntityFields(auditedEntityType);
+        final var expectedRequiredFields = toEntityFields(auditedEntityType);
 
-        final Stream<? extends EntityField<?, ?>> actualRequiredFields = calculate(auditedEntityType, fieldsToChange);
+        final var actualRequiredFields = calculate(auditedEntityType, fieldsToChange);
 
-        assertThat(actualRequiredFields.collect(Collectors.<EntityField<?, ?>>toSet()), is(expectedFieldsToFetch));
+        assertThat(actualRequiredFields.collect(Collectors.<EntityField<?, ?>>toUnmodifiableSet()), is(expectedRequiredFields));
     }
 
     @Test
-    public void requiredFields_FieldSetHasIdAndOnCreateOrUpdateOnly_FieldsToChangeAreDifferent_ShouldReturnIdOnly() {
-        final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType =
-            builder(AuditedAutoIncIdType.ID)
-                .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE, AuditedAutoIncIdType.NAME, AuditedAutoIncIdType.DESC)
-                .build();
+    public void requiredFields_TypeHasIdAndOnCreateOrUpdateOnly_ToChangeAreDifferent_ShouldReturnIdOnly() {
+        final var auditedEntityType =
+                builder(AuditedAutoIncIdType.INSTANCE)
+                        .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE, AuditedAutoIncIdType.NAME, AuditedAutoIncIdType.DESC)
+                        .build();
 
-        final Set<? extends EntityField<AuditedAutoIncIdType, ?>> fieldsToChange = singleton(AuditedAutoIncIdType.DESC2);
+        final var fieldsToChange = singleton(AuditedAutoIncIdType.DESC2);
 
-        final Set<? extends EntityField<?, ?>> expectedFieldsToFetch = singleton(AuditedAutoIncIdType.ID);
+        final var expectedRequiredFields = singleton(AuditedAutoIncIdType.ID);
 
-        final Stream<? extends EntityField<?, ?>> actualRequiredFields = calculate(auditedEntityType, fieldsToChange);
+        final var actualRequiredFields = calculate(auditedEntityType, fieldsToChange);
 
-        assertThat(actualRequiredFields.collect(Collectors.<EntityField<?, ?>>toSet()), is(expectedFieldsToFetch));
+        assertThat(actualRequiredFields.collect(Collectors.<EntityField<?, ?>>toUnmodifiableSet()), is(expectedRequiredFields));
     }
 
     @Test
-    public void requiredFields_FieldSetHasIdAndOnCreateOrUpdateOnly_FieldsToChangeAreSame_ShouldReturnFieldsToChange() {
-        final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType =
-            builder(AuditedAutoIncIdType.ID)
-                .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE, AuditedAutoIncIdType.NAME, AuditedAutoIncIdType.DESC)
-                .build();
+    public void requiredFields_TypeHasIdAndOnCreateOrUpdateOnly_ToChangeAreSame_ShouldReturnFieldsToChange() {
+        final var auditedEntityType =
+                builder(AuditedAutoIncIdType.INSTANCE)
+                        .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE, AuditedAutoIncIdType.NAME, AuditedAutoIncIdType.DESC)
+                        .build();
 
-        final Set<? extends EntityField<AuditedAutoIncIdType, ?>> fieldsToChange = ImmutableSet.of(AuditedAutoIncIdType.ID,
-                                                                                          AuditedAutoIncIdType.NAME,
-                                                                                          AuditedAutoIncIdType.DESC);
+        final var fieldsToChange = Set.of(AuditedAutoIncIdType.ID,
+                AuditedAutoIncIdType.NAME,
+                AuditedAutoIncIdType.DESC);
 
-        final Set<? extends EntityField<?, ?>> expectedFieldsToFetch = toEntityFields(auditedEntityType);
+        final var expectedRequiredFields = toEntityFields(auditedEntityType);
 
-        final Stream<? extends EntityField<?, ?>> actualRequiredFields = calculate(auditedEntityType, fieldsToChange);
+        final var actualRequiredFields = calculate(auditedEntityType, fieldsToChange);
 
-        assertThat(actualRequiredFields.collect(Collectors.<EntityField<?, ?>>toSet()), is(expectedFieldsToFetch));
+        assertThat(actualRequiredFields.collect(Collectors.<EntityField<?, ?>>toUnmodifiableSet()), is(expectedRequiredFields));
     }
 
     @Test
-    public void requiredFields_FieldSetHasIdAndOnCreateOrUpdateOnly_FieldsToChangeIncludedInOnCreateOrUpdate_ShouldReturnIdAndFieldsToChange() {
-        final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType =
-            builder(AuditedAutoIncIdType.ID)
-                .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE,
-                                              AuditedAutoIncIdType.NAME, AuditedAutoIncIdType.DESC, AuditedAutoIncIdType.DESC2)
-                .build();
+    public void requiredFields_TypeHasIdAndOnCreateOrUpdateOnly_ToChangeIncludedInOnCreateOrUpdate_ShouldReturnIdAndFieldsToChange() {
+        final var auditedEntityType =
+                builder(AuditedAutoIncIdType.INSTANCE)
+                        .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE,
+                                AuditedAutoIncIdType.NAME, AuditedAutoIncIdType.DESC, AuditedAutoIncIdType.DESC2)
+                        .build();
 
-        final Set<? extends EntityField<AuditedAutoIncIdType, ?>> fieldsToChange = ImmutableSet.of(AuditedAutoIncIdType.DESC,
-                                                                                          AuditedAutoIncIdType.DESC2);
+        final var fieldsToChange = Set.of(AuditedAutoIncIdType.DESC,
+                AuditedAutoIncIdType.DESC2);
 
-        final Set<? extends EntityField<?, ?>> expectedFieldsToFetch = ImmutableSet.of(AuditedAutoIncIdType.ID,
-                                                                                       AuditedAutoIncIdType.DESC,
-                                                                                       AuditedAutoIncIdType.DESC2);
+        final var expectedRequiredFields = Set.of(AuditedAutoIncIdType.ID,
+                AuditedAutoIncIdType.DESC,
+                AuditedAutoIncIdType.DESC2);
 
-        final Stream<? extends EntityField<?, ?>> actualRequiredFields = calculate(auditedEntityType, fieldsToChange);
+        final var actualRequiredFields = calculate(auditedEntityType, fieldsToChange);
 
-        assertThat(actualRequiredFields.collect(Collectors.<EntityField<?, ?>>toSet()), is(expectedFieldsToFetch));
+        assertThat(actualRequiredFields.collect(Collectors.<EntityField<?, ?>>toUnmodifiableSet()), is(expectedRequiredFields));
     }
 
     @Test
-    public void requiredFields_FieldSetHasIdAndOnCreateOrUpdateOnly_FieldsToChangeContainOnCreateOrUpdate_ShouldReturnFieldSet() {
-        final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType =
-            builder(AuditedAutoIncIdType.ID)
-                .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE,
-                                              AuditedAutoIncIdType.NAME, AuditedAutoIncIdType.DESC)
-                .build();
+    public void requiredFields_TypeHasIdAndOnCreateOrUpdateOnly_ToChangeContainOnCreateOrUpdate_ShouldReturnFieldsOfType() {
+        final var auditedEntityType =
+                builder(AuditedAutoIncIdType.INSTANCE)
+                        .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE,
+                                AuditedAutoIncIdType.NAME, AuditedAutoIncIdType.DESC)
+                        .build();
 
-        final Set<? extends EntityField<AuditedAutoIncIdType, ?>> fieldsToChange = ImmutableSet.of(AuditedAutoIncIdType.NAME,
-                                                                                          AuditedAutoIncIdType.DESC,
-                                                                                          AuditedAutoIncIdType.DESC2);
+        final var fieldsToChange = Set.of(AuditedAutoIncIdType.NAME,
+                AuditedAutoIncIdType.DESC,
+                AuditedAutoIncIdType.DESC2);
 
-        final Set<? extends EntityField<?, ?>> expectedFieldsToFetch = toEntityFields(auditedEntityType);
+        final var expectedRequiredFields = toEntityFields(auditedEntityType);
 
-        final Stream<? extends EntityField<?, ?>> actualRequiredFields = calculate(auditedEntityType, fieldsToChange);
+        final var actualRequiredFields = calculate(auditedEntityType, fieldsToChange);
 
-        assertThat(actualRequiredFields.collect(Collectors.<EntityField<?, ?>>toSet()), is(expectedFieldsToFetch));
+        assertThat(actualRequiredFields.collect(Collectors.<EntityField<?, ?>>toUnmodifiableSet()), is(expectedRequiredFields));
     }
 
     @Test
-    public void requiredFields_FieldSetHasIdAndOnCreateOrUpdateOnly_FieldsToChangePartiallyIntersectOnCreateOrUpdate_ShouldReturnIdAndIntersection() {
-        final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType =
-            builder(AuditedAutoIncIdType.ID)
-                .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE, AuditedAutoIncIdType.NAME, AuditedAutoIncIdType.DESC)
-                .build();
+    public void requiredFields_TypeHasIdAndOnCreateOrUpdateOnly_ToChangePartiallyIntersectOnCreateOrUpdate_ShouldReturnIdAndIntersection() {
+        final var auditedEntityType =
+                builder(AuditedAutoIncIdType.INSTANCE)
+                        .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE, AuditedAutoIncIdType.NAME, AuditedAutoIncIdType.DESC)
+                        .build();
 
-        final Set<? extends EntityField<AuditedAutoIncIdType, ?>> fieldsToChange = ImmutableSet.of(AuditedAutoIncIdType.DESC,
-                                                                                          AuditedAutoIncIdType.DESC2);
+        final var fieldsToChange = Set.of(AuditedAutoIncIdType.DESC,
+                AuditedAutoIncIdType.DESC2);
 
-        final Set<? extends EntityField<?, ?>> expectedFieldsToFetch = ImmutableSet.of(AuditedAutoIncIdType.ID,
-                                                                                       AuditedAutoIncIdType.DESC);
+        final var expectedRequiredFields = Set.of(AuditedAutoIncIdType.ID,
+                AuditedAutoIncIdType.DESC);
 
-        final Stream<? extends EntityField<?, ?>> actualRequiredFields = calculate(auditedEntityType, fieldsToChange);
+        final var actualRequiredFields = calculate(auditedEntityType, fieldsToChange);
 
-        assertThat(actualRequiredFields.collect(Collectors.<EntityField<?, ?>>toSet()), is(expectedFieldsToFetch));
+        assertThat(actualRequiredFields.collect(Collectors.<EntityField<?, ?>>toUnmodifiableSet()), is(expectedRequiredFields));
     }
 
     @Test
-    public void requiredFields_FieldSetHasIdAndOnUpdateOnly_FieldsToChangeAreDifferent_ShouldReturnIdOnly() {
-        final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType =
-            builder(AuditedAutoIncIdType.ID)
-                .withUnderlyingInternalFields(ON_UPDATE, AuditedAutoIncIdType.NAME, AuditedAutoIncIdType.DESC)
-                .build();
+    public void requiredFields_TypeHasIdAndOnUpdateOnly_ToChangeAreDifferent_ShouldReturnIdOnly() {
+        final var auditedEntityType =
+                builder(AuditedAutoIncIdType.INSTANCE)
+                        .withUnderlyingInternalFields(ON_UPDATE, AuditedAutoIncIdType.NAME, AuditedAutoIncIdType.DESC)
+                        .build();
 
-        final Set<? extends EntityField<AuditedAutoIncIdType, ?>> fieldsToChange = singleton(AuditedAutoIncIdType.DESC2);
+        final var fieldsToChange = singleton(AuditedAutoIncIdType.DESC2);
 
-        final Set<? extends EntityField<?, ?>> expectedFieldsToFetch = singleton(AuditedAutoIncIdType.ID);
+        final var expectedRequiredFields = singleton(AuditedAutoIncIdType.ID);
 
-        final Stream<? extends EntityField<?, ?>> actualRequiredFields = calculate(auditedEntityType, fieldsToChange);
+        final var actualRequiredFields = calculate(auditedEntityType, fieldsToChange);
 
-        assertThat(actualRequiredFields.collect(Collectors.<EntityField<?, ?>>toSet()), is(expectedFieldsToFetch));
+        assertThat(actualRequiredFields.collect(Collectors.<EntityField<?, ?>>toUnmodifiableSet()), is(expectedRequiredFields));
     }
 
     @Test
-    public void requiredFields_FieldSetHasIdAndOnUpdateOnly_FieldsToChangeAreSame_ShouldReturnFieldsToChange() {
-        final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType =
-            builder(AuditedAutoIncIdType.ID)
-                .withUnderlyingInternalFields(ON_UPDATE, AuditedAutoIncIdType.NAME, AuditedAutoIncIdType.DESC)
-                .build();
+    public void requiredFields_TypeHasIdAndOnUpdateOnly_ToChangeAreSame_ShouldReturnFieldsToChange() {
+        final var auditedEntityType =
+                builder(AuditedAutoIncIdType.INSTANCE)
+                        .withUnderlyingInternalFields(ON_UPDATE, AuditedAutoIncIdType.NAME, AuditedAutoIncIdType.DESC)
+                        .build();
 
-        final Set<? extends EntityField<AuditedAutoIncIdType, ?>> fieldsToChange = ImmutableSet.of(AuditedAutoIncIdType.ID,
-                                                                                          AuditedAutoIncIdType.NAME,
-                                                                                          AuditedAutoIncIdType.DESC);
+        final var fieldsToChange = Set.of(AuditedAutoIncIdType.ID,
+                AuditedAutoIncIdType.NAME,
+                AuditedAutoIncIdType.DESC);
 
-        final Set<? extends EntityField<?, ?>> expectedFieldsToFetch = toEntityFields(auditedEntityType);
+        final var expectedRequiredFields = toEntityFields(auditedEntityType);
 
-        final Stream<? extends EntityField<?, ?>> actualRequiredFields = calculate(auditedEntityType, fieldsToChange);
+        final var actualRequiredFields = calculate(auditedEntityType, fieldsToChange);
 
-        assertThat(actualRequiredFields.collect(Collectors.<EntityField<?, ?>>toSet()), is(expectedFieldsToFetch));
+        assertThat(actualRequiredFields.collect(Collectors.<EntityField<?, ?>>toUnmodifiableSet()), is(expectedRequiredFields));
     }
 
     @Test
-    public void requiredFields_FieldSetHasIdAndOnUpdateOnly_FieldsToChangeIncludedInOnCreateOrUpdate_ShouldReturnIdAndFieldsToChange() {
-        final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType =
-            builder(AuditedAutoIncIdType.ID)
-                .withUnderlyingInternalFields(ON_UPDATE,
-                                              AuditedAutoIncIdType.NAME, AuditedAutoIncIdType.DESC, AuditedAutoIncIdType.DESC2)
-                .build();
+    public void requiredFields_TypeHasIdAndOnUpdateOnly_ToChangeIncludedInOnCreateOrUpdate_ShouldReturnIdAndFieldsToChange() {
+        final var auditedEntityType =
+                builder(AuditedAutoIncIdType.INSTANCE)
+                        .withUnderlyingInternalFields(ON_UPDATE,
+                                AuditedAutoIncIdType.NAME, AuditedAutoIncIdType.DESC, AuditedAutoIncIdType.DESC2)
+                        .build();
 
-        final Set<? extends EntityField<AuditedAutoIncIdType, ?>> fieldsToChange = ImmutableSet.of(AuditedAutoIncIdType.DESC,
-                                                                                          AuditedAutoIncIdType.DESC2);
+        final var fieldsToChange = Set.of(AuditedAutoIncIdType.DESC,
+                AuditedAutoIncIdType.DESC2);
 
-        final Set<? extends EntityField<?, ?>> expectedFieldsToFetch = ImmutableSet.of(AuditedAutoIncIdType.ID,
-                                                                                       AuditedAutoIncIdType.DESC,
-                                                                                       AuditedAutoIncIdType.DESC2);
+        final var expectedRequiredFields = Set.of(AuditedAutoIncIdType.ID,
+                AuditedAutoIncIdType.DESC,
+                AuditedAutoIncIdType.DESC2);
 
-        final Stream<? extends EntityField<?, ?>> actualRequiredFields = calculate(auditedEntityType, fieldsToChange);
+        final var actualRequiredFields = calculate(auditedEntityType, fieldsToChange);
 
-        assertThat(actualRequiredFields.collect(Collectors.<EntityField<?, ?>>toSet()), is(expectedFieldsToFetch));
+        assertThat(actualRequiredFields.collect(Collectors.<EntityField<?, ?>>toUnmodifiableSet()), is(expectedRequiredFields));
     }
 
     @Test
-    public void requiredFields_FieldSetHasIdAndOnUpdateOnly_FieldsToChangeContainOnCreateOrUpdate_ShouldReturnFieldSet() {
-        final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType =
-            builder(AuditedAutoIncIdType.ID)
-                .withUnderlyingInternalFields(ON_UPDATE, AuditedAutoIncIdType.NAME, AuditedAutoIncIdType.DESC)
-                .build();
+    public void requiredFields_TypeHasIdAndOnUpdateOnly_ToChangeContainOnCreateOrUpdate_ShouldReturnType() {
+        final var auditedEntityType =
+                builder(AuditedAutoIncIdType.INSTANCE)
+                        .withUnderlyingInternalFields(ON_UPDATE, AuditedAutoIncIdType.NAME, AuditedAutoIncIdType.DESC)
+                        .build();
 
-        final Set<? extends EntityField<AuditedAutoIncIdType, ?>> fieldsToChange = ImmutableSet.of(AuditedAutoIncIdType.NAME,
-                                                                                          AuditedAutoIncIdType.DESC,
-                                                                                          AuditedAutoIncIdType.DESC2);
+        final var fieldsToChange = Set.of(AuditedAutoIncIdType.NAME,
+                AuditedAutoIncIdType.DESC,
+                AuditedAutoIncIdType.DESC2);
 
-        final Set<? extends EntityField<?, ?>> expectedFieldsToFetch = toEntityFields(auditedEntityType);
+        final var expectedRequiredFields = toEntityFields(auditedEntityType);
 
-        final Stream<? extends EntityField<?, ?>> actualRequiredFields = calculate(auditedEntityType, fieldsToChange);
+        final var actualRequiredFields = calculate(auditedEntityType, fieldsToChange);
 
-        assertThat(actualRequiredFields.collect(Collectors.<EntityField<?, ?>>toSet()), is(expectedFieldsToFetch));
+        assertThat(actualRequiredFields.collect(Collectors.<EntityField<?, ?>>toUnmodifiableSet()), is(expectedRequiredFields));
     }
 
     @Test
-    public void requiredFields_FieldSetHasIdAndOnUpdateOnly_FieldsToChangePartiallyIntersectOnCreateOrUpdate_ShouldReturnIdAndIntersection() {
-        final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType =
-            builder(AuditedAutoIncIdType.ID)
-                .withUnderlyingInternalFields(ON_UPDATE, AuditedAutoIncIdType.NAME, AuditedAutoIncIdType.DESC)
-                .build();
+    public void requiredFields_TypeHasIdAndOnUpdateOnly_ToChangePartiallyIntersectOnCreateOrUpdate_ShouldReturnIdAndIntersection() {
+        final var auditedEntityType =
+                builder(AuditedAutoIncIdType.INSTANCE)
+                        .withUnderlyingInternalFields(ON_UPDATE, AuditedAutoIncIdType.NAME, AuditedAutoIncIdType.DESC)
+                        .build();
 
-        final Set<? extends EntityField<AuditedAutoIncIdType, ?>> fieldsToChange = ImmutableSet.of(AuditedAutoIncIdType.DESC,
-                                                                                          AuditedAutoIncIdType.DESC2);
+        final var fieldsToChange = Set.of(AuditedAutoIncIdType.DESC,
+                AuditedAutoIncIdType.DESC2);
 
-        final Set<? extends EntityField<?, ?>> expectedFieldsToFetch = ImmutableSet.of(AuditedAutoIncIdType.ID,
-                                                                                       AuditedAutoIncIdType.DESC);
+        final var expectedRequiredFields = Set.of(AuditedAutoIncIdType.ID,
+                AuditedAutoIncIdType.DESC);
 
-        final Stream<? extends EntityField<?, ?>> actualRequiredFields = calculate(auditedEntityType, fieldsToChange);
+        final var actualRequiredFields = calculate(auditedEntityType, fieldsToChange);
 
-        assertThat(actualRequiredFields.collect(Collectors.<EntityField<?, ?>>toSet()), is(expectedFieldsToFetch));
+        assertThat(actualRequiredFields.collect(Collectors.<EntityField<?, ?>>toUnmodifiableSet()), is(expectedRequiredFields));
     }
 
     @Test
-    public void requiredFields_FieldSetHasEverything_FieldsToChangePartiallyIntersectOnCreateOrUpdate_ShouldReturnIdAndMandatoriesAndIntersection() {
-        final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType =
-            builder(AuditedAutoIncIdType.ID)
+    public void requiredFields_TypeHasEverything_ToChangePartiallyIntersectOnCreateOrUpdate_ShouldReturnIdAndMandatoriesAndIntersection() {
+        final var auditedEntityType =
+                builder(AuditedAutoIncIdType.INSTANCE)
+                        .withUnderlyingExternalFields(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC)
+                        .withUnderlyingInternalFields(ALWAYS, AuditedAutoIncIdType.NAME)
+                        .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE, AuditedAutoIncIdType.DESC)
+                        .withUnderlyingInternalFields(ON_UPDATE, AuditedAutoIncIdType.DESC2)
+                        .build();
+
+        final var fieldsToChange = singleton(AuditedAutoIncIdType.DESC);
+
+        final var expectedRequiredFields = Set.of(AuditedAutoIncIdType.ID,
+                NotAuditedAncestorType.NAME,
+                NotAuditedAncestorType.DESC,
+                AuditedAutoIncIdType.NAME,
+                AuditedAutoIncIdType.DESC);
+
+        final var actualRequiredFields = calculate(auditedEntityType, fieldsToChange);
+
+        assertThat(actualRequiredFields.collect(Collectors.<EntityField<?, ?>>toUnmodifiableSet()), is(expectedRequiredFields));
+    }
+
+    @Test
+    public void requiredFields_TypeHasEverything_ToChangePartiallyIntersectOnUpdate_ShouldReturnIdAndMandatoriesAndIntersection() {
+        final var auditedEntityType =
+                builder(AuditedAutoIncIdType.INSTANCE)
+                        .withUnderlyingExternalFields(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC)
+                        .withUnderlyingInternalFields(ALWAYS, AuditedAutoIncIdType.NAME)
+                        .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE, AuditedAutoIncIdType.DESC)
+                        .withUnderlyingInternalFields(ON_UPDATE, AuditedAutoIncIdType.DESC2)
+                        .build();
+
+        final var fieldsToChange = singleton(AuditedAutoIncIdType.DESC);
+
+        final var expectedRequiredFields = Set.of(AuditedAutoIncIdType.ID,
+                NotAuditedAncestorType.NAME,
+                NotAuditedAncestorType.DESC,
+                AuditedAutoIncIdType.NAME,
+                AuditedAutoIncIdType.DESC);
+
+        final var actualRequiredFields = calculate(auditedEntityType, fieldsToChange);
+
+        assertThat(actualRequiredFields.collect(Collectors.<EntityField<?, ?>>toUnmodifiableSet()), is(expectedRequiredFields));
+    }
+
+    @Test
+    public void requiredFields_TypeIsEmpty_ToChangeNotEmpty_ShouldReturnEmpty() {
+        final var auditedEntityType = builder(AuditedWithoutIdType.INSTANCE).build();
+
+        final var fieldsToChange = Set.of(AuditedWithoutIdType.NAME, AuditedWithoutIdType.DESC);
+
+        final var actualRequiredFields = calculate(auditedEntityType, fieldsToChange);
+
+        assertThat(actualRequiredFields.collect(toUnmodifiableSet()), is(emptySet()));
+    }
+
+    @Test
+    public void requiredFields_TypeHasExternalMandatoryOnly_ToChangeNotEmpty_ShouldReturnFieldsOfType() {
+        final var auditedEntityType = builder(AuditedWithoutIdType.INSTANCE)
                 .withUnderlyingExternalFields(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC)
-                .withUnderlyingInternalFields(ALWAYS, AuditedAutoIncIdType.NAME)
-                .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE, AuditedAutoIncIdType.DESC)
-                .withUnderlyingInternalFields(ON_UPDATE, AuditedAutoIncIdType.DESC2)
                 .build();
 
-        final Set<? extends EntityField<AuditedAutoIncIdType, ?>> fieldsToChange = singleton(AuditedAutoIncIdType.DESC);
+        final var fieldsToChange = singleton(AuditedWithoutIdType.NAME);
 
-        final Set<? extends EntityField<?, ?>> expectedFieldsToFetch = ImmutableSet.of(AuditedAutoIncIdType.ID,
-                                                                                       NotAuditedAncestorType.NAME,
-                                                                                       NotAuditedAncestorType.DESC,
-                                                                                       AuditedAutoIncIdType.NAME,
-                                                                                       AuditedAutoIncIdType.DESC);
+        final var expectedRequiredFields = toEntityFields(auditedEntityType);
 
-        final Stream<? extends EntityField<?, ?>> actualRequiredFields = calculate(auditedEntityType, fieldsToChange);
+        final var actualRequiredFields = calculate(auditedEntityType, fieldsToChange);
 
-        assertThat(actualRequiredFields.collect(Collectors.<EntityField<?, ?>>toSet()), is(expectedFieldsToFetch));
+        assertThat(actualRequiredFields.collect(Collectors.<EntityField<?, ?>>toUnmodifiableSet()), is(expectedRequiredFields));
     }
 
     @Test
-    public void requiredFields_FieldSetHasEverything_FieldsToChangePartiallyIntersectOnUpdate_ShouldReturnIdAndMandatoriesAndIntersection() {
-        final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType =
-            builder(AuditedAutoIncIdType.ID)
-                .withUnderlyingExternalFields(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC)
-                .withUnderlyingInternalFields(ALWAYS, AuditedAutoIncIdType.NAME)
-                .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE, AuditedAutoIncIdType.DESC)
-                .withUnderlyingInternalFields(ON_UPDATE, AuditedAutoIncIdType.DESC2)
+    public void requiredFields_TypeHasSelfMandatoryOnly_ToChangeAreDifferent_ShouldReturnFieldsOfType() {
+        final var auditedEntityType = builder(AuditedWithoutIdType.INSTANCE)
+                .withUnderlyingInternalFields(ALWAYS, AuditedWithoutIdType.NAME, AuditedWithoutIdType.DESC)
                 .build();
 
-        final Set<? extends EntityField<AuditedAutoIncIdType, ?>> fieldsToChange = singleton(AuditedAutoIncIdType.DESC);
+        final var fieldsToChange = singleton(AuditedWithoutIdType.DESC2);
 
-        final Set<? extends EntityField<?, ?>> expectedFieldsToFetch = ImmutableSet.of(AuditedAutoIncIdType.ID,
-                                                                                       NotAuditedAncestorType.NAME,
-                                                                                       NotAuditedAncestorType.DESC,
-                                                                                       AuditedAutoIncIdType.NAME,
-                                                                                       AuditedAutoIncIdType.DESC);
+        final var expectedRequiredFields = toEntityFields(auditedEntityType);
 
-        final Stream<? extends EntityField<?, ?>> actualRequiredFields = calculate(auditedEntityType, fieldsToChange);
+        final var actualRequiredFields = calculate(auditedEntityType, fieldsToChange);
 
-        assertThat(actualRequiredFields.collect(Collectors.<EntityField<?, ?>>toSet()), is(expectedFieldsToFetch));
+        assertThat(actualRequiredFields.collect(Collectors.<EntityField<?, ?>>toUnmodifiableSet()), is(expectedRequiredFields));
     }
 
-    private Stream<? extends EntityField<?, ?>> calculate(final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType,
-                                                          Set<? extends EntityField<AuditedAutoIncIdType, ?>> fieldsToChange) {
+    @Test
+    public void requiredFields_TypeHasSelfMandatoryOnly_ToChangeAreTheSame_ShouldReturnFieldsToChange() {
+        final var auditedEntityType = builder(AuditedWithoutIdType.INSTANCE)
+                .withUnderlyingInternalFields(ALWAYS, AuditedWithoutIdType.NAME, AuditedWithoutIdType.DESC)
+                .build();
+
+        final var fieldsToChange = Set.of(AuditedWithoutIdType.NAME, AuditedWithoutIdType.DESC);
+
+        final var actualRequiredFields = calculate(auditedEntityType, fieldsToChange);
+
+        assertThat(actualRequiredFields.collect(Collectors.<EntityField<?, ?>>toUnmodifiableSet()), is(fieldsToChange));
+    }
+
+    @Test
+    public void requiredFields_TypeHasSelfMandatoryOnly_ToChangePartiallyIntersect_ShouldReturnFieldsOfType() {
+        final var auditedEntityType = builder(AuditedWithoutIdType.INSTANCE)
+                .withUnderlyingInternalFields(ALWAYS, AuditedWithoutIdType.NAME, AuditedWithoutIdType.DESC)
+                .build();
+
+        final var fieldsToChange = Set.of(AuditedWithoutIdType.DESC, AuditedWithoutIdType.DESC2);
+
+        final var expectedRequiredFields = toEntityFields(auditedEntityType);
+
+        final var actualRequiredFields = calculate(auditedEntityType, fieldsToChange);
+
+        assertThat(actualRequiredFields.collect(Collectors.<EntityField<?, ?>>toUnmodifiableSet()), is(expectedRequiredFields));
+    }
+
+    @Test
+    public void requiredFields_TypeHasOnCreateOrUpdateOnly_ToChangeAreDifferent_ShouldReturnEmpty() {
+        final var auditedEntityType = builder(AuditedWithoutIdType.INSTANCE)
+                .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE, AuditedWithoutIdType.NAME, AuditedWithoutIdType.DESC)
+                .build();
+
+        final var fieldsToChange = singleton(AuditedWithoutIdType.DESC2);
+
+        final var actualRequiredFields = calculate(auditedEntityType, fieldsToChange);
+
+        assertThat(actualRequiredFields.collect(Collectors.<EntityField<?, ?>>toUnmodifiableSet()), is(emptySet()));
+    }
+
+    @Test
+    public void requiredFields_TypeHasOnCreateOrUpdateOnly_ToChangeAreSame_ShouldReturnFieldsToChange() {
+        final var auditedEntityType = builder(AuditedWithoutIdType.INSTANCE)
+                .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE, AuditedWithoutIdType.NAME, AuditedWithoutIdType.DESC)
+                .build();
+
+        final var fieldsToChange = Set.of(AuditedWithoutIdType.NAME, AuditedWithoutIdType.DESC);
+
+        final var expectedRequiredFields = toEntityFields(auditedEntityType);
+
+        final var actualRequiredFields = calculate(auditedEntityType, fieldsToChange);
+
+        assertThat(actualRequiredFields.collect(Collectors.<EntityField<?, ?>>toUnmodifiableSet()), is(expectedRequiredFields));
+    }
+
+    @Test
+    public void requiredFields_TypeHasOnCreateOrUpdateOnly_ToChangeIncludedInOnCreateOrUpdate_ShouldReturnFieldsToChange() {
+        final var auditedEntityType =
+                builder(AuditedWithoutIdType.INSTANCE)
+                        .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE,
+                                AuditedWithoutIdType.NAME, AuditedWithoutIdType.DESC, AuditedWithoutIdType.DESC2)
+                        .build();
+
+        final var fieldsToChange = Set.of(AuditedWithoutIdType.DESC, AuditedWithoutIdType.DESC2);
+
+        final var actualRequiredFields = calculate(auditedEntityType, fieldsToChange);
+
+        assertThat(actualRequiredFields.collect(Collectors.<EntityField<?, ?>>toUnmodifiableSet()), is(fieldsToChange));
+    }
+
+    @Test
+    public void requiredFields_TypeHasOnCreateOrUpdateOnly_ToChangeContainOnCreateOrUpdate_ShouldReturnFieldsOfType() {
+        final var auditedEntityType =
+                builder(AuditedWithoutIdType.INSTANCE)
+                        .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE,
+                                AuditedWithoutIdType.NAME, AuditedWithoutIdType.DESC)
+                        .build();
+
+        final var fieldsToChange = Set.of(AuditedWithoutIdType.NAME,
+                AuditedWithoutIdType.DESC,
+                AuditedWithoutIdType.DESC2);
+
+        final var expectedRequiredFields = toEntityFields(auditedEntityType);
+
+        final var actualRequiredFields = calculate(auditedEntityType, fieldsToChange);
+
+        assertThat(actualRequiredFields.collect(Collectors.<EntityField<?, ?>>toUnmodifiableSet()), is(expectedRequiredFields));
+    }
+
+    @Test
+    public void requiredFields_TypeHasOnCreateOrUpdateOnly_ToChangePartiallyIntersectOnCreateOrUpdate_ShouldReturnIntersection() {
+        final var auditedEntityType =
+                builder(AuditedWithoutIdType.INSTANCE)
+                        .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE, AuditedWithoutIdType.NAME, AuditedWithoutIdType.DESC)
+                        .build();
+
+        final var fieldsToChange = Set.of(AuditedWithoutIdType.DESC, AuditedWithoutIdType.DESC2);
+
+        final var expectedRequiredFields = Set.of(AuditedWithoutIdType.DESC);
+
+        final var actualRequiredFields = calculate(auditedEntityType, fieldsToChange);
+
+        assertThat(actualRequiredFields.collect(Collectors.<EntityField<?, ?>>toUnmodifiableSet()), is(expectedRequiredFields));
+    }
+
+    private <E extends EntityType<E>> Stream<? extends EntityField<?, ?>> calculate(final AuditedEntityType<E> auditedEntityType,
+                                                                                    final Set<? extends EntityField<E, ?>> fieldsToChange) {
         return new AuditRequiredFieldsCalculator<>(auditedEntityType).requiredFields(fieldsToChange, OPERATOR);
     }
 
     private Set<? extends EntityField<?, ?>> toEntityFields(final AuditedEntityType<?> auditedEntityType) {
-        return Stream.<Stream<EntityField<?, ?>>>of(
-            Stream.of(auditedEntityType.getIdField()),
-            auditedEntityType.getExternalFields().stream().map(AuditedField::getField),
-            auditedEntityType.getInternalFields().map(AuditedField::getField))
-                     .flatMap(identity())
-                     .collect(toUnmodifiableSet());
+        return Seq.<EntityField<?, ?>>seq(auditedEntityType.getExternalFields().stream().map(AuditedField::getField))
+                .append(auditedEntityType.getInternalFields().map(AuditedField::getField))
+                .append(auditedEntityType.getIdField())
+                .collect(toUnmodifiableSet());
     }
 }

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditedEntityTypeTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/AuditedEntityTypeTest.java
@@ -3,9 +3,11 @@ package com.kenshoo.pl.entity.internal.audit;
 import com.google.common.collect.ImmutableSet;
 import com.kenshoo.pl.entity.EntityField;
 import com.kenshoo.pl.entity.internal.audit.entitytypes.AuditedAutoIncIdType;
+import com.kenshoo.pl.entity.internal.audit.entitytypes.AuditedWithoutIdType;
 import com.kenshoo.pl.entity.internal.audit.entitytypes.NotAuditedAncestorType;
 import org.junit.Test;
 
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -20,9 +22,21 @@ import static org.junit.Assert.assertThat;
 public class AuditedEntityTypeTest {
 
     @Test
+    public void getIdFieldWhenDoesntExist() {
+        final var auditedEntityType = builder(AuditedWithoutIdType.INSTANCE).build();
+        assertThat(auditedEntityType.getIdField(), is(Optional.empty()));
+    }
+
+    @Test
+    public void getIdFieldWhenExists() {
+        final var auditedEntityType = builder(AuditedAutoIncIdType.INSTANCE).build();
+        assertThat(auditedEntityType.getIdField(), is(Optional.of(AuditedAutoIncIdType.ID)));
+    }
+
+    @Test
     public void getName_Default() {
         final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType =
-            builder(AuditedAutoIncIdType.ID).build();
+            builder(AuditedAutoIncIdType.INSTANCE).build();
 
         assertThat(auditedEntityType.getName(), is(AuditedAutoIncIdType.INSTANCE.getName()));
     }
@@ -31,7 +45,7 @@ public class AuditedEntityTypeTest {
     public void setAndGetName() {
         final String name = "someName";
         final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType =
-            builder(AuditedAutoIncIdType.ID)
+            builder(AuditedAutoIncIdType.INSTANCE)
                 .withName(name)
                 .build();
 
@@ -41,7 +55,7 @@ public class AuditedEntityTypeTest {
     @Test
     public void getInternalFields_WhenHasOnCreateOrUpdate() {
         final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType =
-            builder(AuditedAutoIncIdType.ID)
+            builder(AuditedAutoIncIdType.INSTANCE)
                 .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE, AuditedAutoIncIdType.NAME, AuditedAutoIncIdType.DESC)
                 .build();
 
@@ -57,7 +71,7 @@ public class AuditedEntityTypeTest {
     @Test
     public void getInternalFields_WhenHasOnUpdate() {
         final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType =
-            builder(AuditedAutoIncIdType.ID)
+            builder(AuditedAutoIncIdType.INSTANCE)
                 .withUnderlyingInternalFields(ON_UPDATE, AuditedAutoIncIdType.NAME, AuditedAutoIncIdType.DESC)
                 .build();
 
@@ -73,7 +87,7 @@ public class AuditedEntityTypeTest {
     @Test
     public void getInternalFields_WhenHasInternalMandatory() {
         final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType =
-            builder(AuditedAutoIncIdType.ID)
+            builder(AuditedAutoIncIdType.INSTANCE)
                 .withUnderlyingInternalFields(ALWAYS, AuditedAutoIncIdType.NAME, AuditedAutoIncIdType.DESC)
                 .build();
 
@@ -89,7 +103,7 @@ public class AuditedEntityTypeTest {
     @Test
     public void getInternalFields_WhenHasOnCreateOrUpdateAndOnUpdate() {
         final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType =
-            builder(AuditedAutoIncIdType.ID)
+            builder(AuditedAutoIncIdType.INSTANCE)
                 .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE, AuditedAutoIncIdType.NAME, AuditedAutoIncIdType.DESC)
                 .withUnderlyingInternalFields(ON_UPDATE, AuditedAutoIncIdType.DESC2)
                 .build();
@@ -107,7 +121,7 @@ public class AuditedEntityTypeTest {
     @Test
     public void getInternalFields_WhenHasOnCreateOrUpdateAndInternalMandatory() {
         final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType =
-            builder(AuditedAutoIncIdType.ID)
+            builder(AuditedAutoIncIdType.INSTANCE)
                 .withUnderlyingInternalFields(ALWAYS, AuditedAutoIncIdType.NAME)
                 .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE, AuditedAutoIncIdType.DESC, AuditedAutoIncIdType.DESC2)
                 .build();
@@ -125,7 +139,7 @@ public class AuditedEntityTypeTest {
     @Test
     public void getInternalFields_WhenHasNone() {
         final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType =
-            builder(AuditedAutoIncIdType.ID).build();
+            builder(AuditedAutoIncIdType.INSTANCE).build();
 
         assertThat(auditedEntityType.getInternalFields().collect(toSet()), is(empty()));
     }
@@ -133,7 +147,7 @@ public class AuditedEntityTypeTest {
     @Test
     public void getUnderlyingOnChangeFields_WhenHasOnCreateOrUpdate() {
         final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType =
-            builder(AuditedAutoIncIdType.ID)
+            builder(AuditedAutoIncIdType.INSTANCE)
                 .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE, AuditedAutoIncIdType.NAME, AuditedAutoIncIdType.DESC)
                 .build();
 
@@ -146,7 +160,7 @@ public class AuditedEntityTypeTest {
     @Test
     public void getUnderlyingOnChangeFields_WhenHasOnUpdate() {
         final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType =
-            builder(AuditedAutoIncIdType.ID)
+            builder(AuditedAutoIncIdType.INSTANCE)
                 .withUnderlyingInternalFields(ON_UPDATE, AuditedAutoIncIdType.NAME, AuditedAutoIncIdType.DESC)
                 .build();
 
@@ -159,7 +173,7 @@ public class AuditedEntityTypeTest {
     @Test
     public void getUnderlyingOnChangeFields_WhenHasExternalMandatory() {
         final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType =
-            builder(AuditedAutoIncIdType.ID)
+            builder(AuditedAutoIncIdType.INSTANCE)
                 .withUnderlyingExternalFields(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC)
                 .build();
 
@@ -169,7 +183,7 @@ public class AuditedEntityTypeTest {
     @Test
     public void getUnderlyingOnChangeFields_WhenHasInternalMandatory() {
         final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType =
-            builder(AuditedAutoIncIdType.ID)
+            builder(AuditedAutoIncIdType.INSTANCE)
                 .withUnderlyingInternalFields(ALWAYS, AuditedAutoIncIdType.NAME, AuditedAutoIncIdType.DESC)
                 .build();
 
@@ -179,7 +193,7 @@ public class AuditedEntityTypeTest {
     @Test
     public void getUnderlyingOnChangeFields_WhenHasOnCreateOrUpdateAndOnUpdate() {
         final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType =
-            builder(AuditedAutoIncIdType.ID)
+            builder(AuditedAutoIncIdType.INSTANCE)
                 .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE, AuditedAutoIncIdType.NAME, AuditedAutoIncIdType.DESC)
                 .withUnderlyingInternalFields(ON_UPDATE, AuditedAutoIncIdType.DESC2)
                 .build();
@@ -195,7 +209,7 @@ public class AuditedEntityTypeTest {
     @Test
     public void getUnderlyingOnChangeFields_WhenHasOnCreateOrUpdateAndInternalMandatory() {
         final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType =
-            builder(AuditedAutoIncIdType.ID)
+            builder(AuditedAutoIncIdType.INSTANCE)
                 .withUnderlyingInternalFields(ALWAYS, AuditedAutoIncIdType.NAME)
                 .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE, AuditedAutoIncIdType.DESC, AuditedAutoIncIdType.DESC2)
                 .build();
@@ -209,7 +223,7 @@ public class AuditedEntityTypeTest {
     @Test
     public void getUnderlyingOnChangeFields_WhenHasNone() {
         final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType =
-            builder(AuditedAutoIncIdType.ID).build();
+            builder(AuditedAutoIncIdType.INSTANCE).build();
 
         assertThat(auditedEntityType.getUnderlyingOnChangeFields().collect(toSet()), is(empty()));
     }
@@ -217,7 +231,7 @@ public class AuditedEntityTypeTest {
     @Test
     public void getUnderlyingMandatoryFields_WhenHasExternalMandatory() {
         final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType =
-            builder(AuditedAutoIncIdType.ID)
+            builder(AuditedAutoIncIdType.INSTANCE)
                 .withUnderlyingExternalFields(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC)
                 .build();
 
@@ -230,7 +244,7 @@ public class AuditedEntityTypeTest {
     @Test
     public void getUnderlyingMandatoryFields_WhenHasInternalMandatory() {
         final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType =
-            builder(AuditedAutoIncIdType.ID)
+            builder(AuditedAutoIncIdType.INSTANCE)
                 .withUnderlyingInternalFields(ALWAYS, AuditedAutoIncIdType.NAME, AuditedAutoIncIdType.DESC)
                 .build();
 
@@ -243,7 +257,7 @@ public class AuditedEntityTypeTest {
     @Test
     public void getUnderlyingMandatoryFields_WhenHasExternalAndInternalMandatory() {
         final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType =
-            builder(AuditedAutoIncIdType.ID)
+            builder(AuditedAutoIncIdType.INSTANCE)
                 .withUnderlyingExternalFields(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC)
                 .withUnderlyingInternalFields(ALWAYS, AuditedAutoIncIdType.NAME, AuditedAutoIncIdType.DESC)
                 .build();
@@ -260,7 +274,7 @@ public class AuditedEntityTypeTest {
     @Test
     public void getUnderlyingMandatoryFields_WhenHasNoMandatory() {
         final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType =
-            builder(AuditedAutoIncIdType.ID)
+            builder(AuditedAutoIncIdType.INSTANCE)
                 .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE, AuditedAutoIncIdType.NAME, AuditedAutoIncIdType.DESC)
                 .build();
 
@@ -270,7 +284,7 @@ public class AuditedEntityTypeTest {
     @Test
     public void getMandatoryFields_WhenHasExternalMandatory() {
         final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType =
-            builder(AuditedAutoIncIdType.ID)
+            builder(AuditedAutoIncIdType.INSTANCE)
                 .withUnderlyingExternalFields(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC)
                 .build();
 
@@ -285,7 +299,7 @@ public class AuditedEntityTypeTest {
     @Test
     public void getMandatoryFields_WhenHasInternalMandatory() {
         final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType =
-            builder(AuditedAutoIncIdType.ID)
+            builder(AuditedAutoIncIdType.INSTANCE)
                 .withUnderlyingInternalFields(ALWAYS, AuditedAutoIncIdType.NAME, AuditedAutoIncIdType.DESC)
                 .build();
 
@@ -300,7 +314,7 @@ public class AuditedEntityTypeTest {
     @Test
     public void getMandatoryFields_WhenHasExternalAndInternalMandatory() {
         final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType =
-            builder(AuditedAutoIncIdType.ID)
+            builder(AuditedAutoIncIdType.INSTANCE)
                 .withUnderlyingExternalFields(NotAuditedAncestorType.NAME, NotAuditedAncestorType.DESC)
                 .withUnderlyingInternalFields(ALWAYS, AuditedAutoIncIdType.NAME, AuditedAutoIncIdType.DESC)
                 .build();
@@ -319,7 +333,7 @@ public class AuditedEntityTypeTest {
     @Test
     public void getMandatoryFields_WhenHasNoMandatory() {
         final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType =
-            builder(AuditedAutoIncIdType.ID)
+            builder(AuditedAutoIncIdType.INSTANCE)
                 .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE, AuditedAutoIncIdType.NAME, AuditedAutoIncIdType.DESC)
                 .build();
 
@@ -329,7 +343,7 @@ public class AuditedEntityTypeTest {
     @Test
     public void hasInternalFields_WhenHasOnCreateOrUpdateFields_ShouldReturnTrue() {
         final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType =
-            builder(AuditedAutoIncIdType.ID)
+            builder(AuditedAutoIncIdType.INSTANCE)
                 .withUnderlyingInternalFields(ON_CREATE_OR_UPDATE, AuditedAutoIncIdType.NAME, AuditedAutoIncIdType.DESC)
                 .build();
 
@@ -339,7 +353,7 @@ public class AuditedEntityTypeTest {
     @Test
     public void hasInternalFields_WhenHasOnUpdateFields_ShouldReturnTrue() {
         final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType =
-            builder(AuditedAutoIncIdType.ID)
+            builder(AuditedAutoIncIdType.INSTANCE)
                 .withUnderlyingInternalFields(ON_UPDATE, AuditedAutoIncIdType.NAME, AuditedAutoIncIdType.DESC)
                 .build();
 
@@ -349,7 +363,7 @@ public class AuditedEntityTypeTest {
     @Test
     public void hasInternalFields_WhenHasInternalMandatoryFields_ShouldReturnTrue() {
         final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType =
-            builder(AuditedAutoIncIdType.ID)
+            builder(AuditedAutoIncIdType.INSTANCE)
                 .withUnderlyingInternalFields(ALWAYS, AuditedAutoIncIdType.NAME, AuditedAutoIncIdType.DESC)
                 .build();
 
@@ -357,8 +371,14 @@ public class AuditedEntityTypeTest {
     }
 
     @Test
+    public void hasInternalFields_WhenEmpty_ShouldReturnFalse() {
+        final var auditedEntityType = builder(AuditedWithoutIdType.INSTANCE).build();
+        assertThat(auditedEntityType.hasInternalFields(), is(false));
+    }
+
+    @Test
     public void hasInternalFields_WhenHasIdOnly_ShouldReturnFalse() {
-        final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType = builder(AuditedAutoIncIdType.ID).build();
+        final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType = builder(AuditedAutoIncIdType.INSTANCE).build();
 
         assertThat(auditedEntityType.hasInternalFields(), is(false));
     }
@@ -366,7 +386,7 @@ public class AuditedEntityTypeTest {
     @Test
     public void hasInternalFields_WhenHasIdAndExternalMandatoryOnly_ShouldReturnFalse() {
         final AuditedEntityType<AuditedAutoIncIdType> auditedEntityType =
-            builder(AuditedAutoIncIdType.ID)
+            builder(AuditedAutoIncIdType.INSTANCE)
                 .withUnderlyingExternalFields(NotAuditedAncestorType.NAME)
                 .build();
 

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/MainWithoutIdTable.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/MainWithoutIdTable.java
@@ -5,12 +5,15 @@ import org.jooq.Record;
 import org.jooq.TableField;
 import org.jooq.impl.SQLDataType;
 
+import static org.jooq.impl.DSL.name;
+
 public class MainWithoutIdTable extends AbstractDataTable<MainWithoutIdTable> {
 
     public static final MainWithoutIdTable INSTANCE = new MainWithoutIdTable();
 
     public final TableField<Record, String> name = createPKField("name", SQLDataType.VARCHAR(50));
-    public final TableField<Record, String> desc = createField("desc", SQLDataType.VARCHAR(50));
+    public final TableField<Record, String> desc = createField(name("desc"), SQLDataType.VARCHAR(50));
+    public final TableField<Record, String> desc2 = createField(name("desc2"), SQLDataType.VARCHAR(50));
 
     private MainWithoutIdTable() {
         super("main_without_id");
@@ -20,6 +23,7 @@ public class MainWithoutIdTable extends AbstractDataTable<MainWithoutIdTable> {
         super(aliased, alias);
     }
 
+    @SuppressWarnings("NullableProblems")
     @Override
     public MainWithoutIdTable as(String alias) {
         return new MainWithoutIdTable(this, alias);

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/entitytypes/AuditedWithoutIdType.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/entitytypes/AuditedWithoutIdType.java
@@ -17,6 +17,7 @@ public class AuditedWithoutIdType extends AbstractEntityType<AuditedWithoutIdTyp
     @Audited(trigger = ALWAYS)
     public static final EntityField<AuditedWithoutIdType, String> NAME = INSTANCE.field(MainWithoutIdTable.INSTANCE.name);
     public static final EntityField<AuditedWithoutIdType, String> DESC = INSTANCE.field(MainWithoutIdTable.INSTANCE.desc);
+    public static final EntityField<AuditedWithoutIdType, String> DESC2 = INSTANCE.field(MainWithoutIdTable.INSTANCE.desc2);
 
     public DataTable getPrimaryTable() {
         return MainWithoutIdTable.INSTANCE;

--- a/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordEntityIdMatcher.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordEntityIdMatcher.java
@@ -4,9 +4,8 @@ import com.kenshoo.pl.entity.audit.AuditRecord;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
 
-import java.util.Objects;
-
 import static java.util.Objects.requireNonNull;
+import static java.util.Optional.ofNullable;
 
 class AuditRecordEntityIdMatcher extends TypeSafeMatcher<AuditRecord> {
 
@@ -21,7 +20,7 @@ class AuditRecordEntityIdMatcher extends TypeSafeMatcher<AuditRecord> {
         if (actualRecord == null) {
             return false;
         }
-        return Objects.equals(actualRecord.getEntityId(), expectedEntityId);
+        return actualRecord.safeGetEntityId().equals(ofNullable(expectedEntityId));
     }
 
     @Override

--- a/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordEntityIdMatcher.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/matchers/audit/AuditRecordEntityIdMatcher.java
@@ -20,7 +20,7 @@ class AuditRecordEntityIdMatcher extends TypeSafeMatcher<AuditRecord> {
         if (actualRecord == null) {
             return false;
         }
-        return actualRecord.safeGetEntityId().equals(ofNullable(expectedEntityId));
+        return actualRecord.getEntityId().equals(ofNullable(expectedEntityId));
     }
 
     @Override


### PR DESCRIPTION
In Skai we have a use-case for auditing of a one-to-many connection, in which the child entity has a primary key which is a _composite_ of two fields. The first of these is a foreign key to the parent id. 
Therefore, there is no single field that can be marked with `@Id`.
In addition , even if we were to choose the first one to be the `@Id`, it wouldn't work for `CREATE` because of how PL currently handles foreign keys during create.

We decided that we don't wish to change the behavior of `@Id` - it should be used only to mark a **single numeric** primary key, which is the best practice for all tables (a table could also have a unique "logical" key which is a composite). 
However since many tables in practice don't have such a primary key, especially child tables - we decided to support this case by making the `entityId` **optional** for auditing. It is assumed that in such a case, there will be a unique logical key and its fields will be marked as `@Audited(trigger = ALWAYS)` so that the entity can still be identified uniquely in the auditing storage through the mandatory fields.