### PR TITLE
Upgrade mysql connector to 8.0.22

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -18,7 +18,7 @@ project.ext.libraries = [
         jool: 'org.jooq:jool:0.9.11',
         guava: 'com.google.guava:guava:16.0.1',
         apacheCommons3: 'org.apache.commons:commons-lang3:3.4',
-        mysqlConnector: 'mysql:mysql-connector-java:5.1.35',
+        mysqlConnector: 'mysql:mysql-connector-java:8.0.22',
 
         guavaRetrying        : 'com.github.rholder:guava-retrying:2.0.0',
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     container_name: pl_test_db
     ports:
       - "33060:3306"
-    image: "mysql:5.6.36"
+    image: "mysql:8.0.23"
     volumes:
       - ./docker/app.cnf:/etc/mysql/conf.d/app.cnf
     environment:

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -7,6 +7,8 @@ dependencies {
     testCompile libraries.junit
     testCompile libraries.mockito
     testCompile libraries.hamcrest
+    testCompile libraries.mysqlConnector
+
 
 }
 

--- a/integration-tests/src/test/java/com/kenshoo/jooq/TestJooqConfig.java
+++ b/integration-tests/src/test/java/com/kenshoo/jooq/TestJooqConfig.java
@@ -1,6 +1,8 @@
 package com.kenshoo.jooq;
 
-import com.mysql.jdbc.ConnectionImpl;
+import com.mysql.cj.conf.HostInfo;
+import com.mysql.cj.conf.PropertyKey;
+import com.mysql.cj.jdbc.ConnectionImpl;
 import org.jooq.DSLContext;
 import org.jooq.SQLDialect;
 import org.jooq.impl.DSL;
@@ -8,6 +10,7 @@ import org.jooq.impl.DefaultConfiguration;
 import org.jooq.impl.ThreadLocalTransactionProvider;
 import org.jooq.lambda.Unchecked;
 import java.sql.SQLException;
+import java.util.Map;
 import java.util.Properties;
 
 import static java.lang.Integer.parseInt;
@@ -41,9 +44,15 @@ public class TestJooqConfig {
         }
     }
 
-    private static ConnectionImpl connection(Properties props)  {
+    private static ConnectionImpl connection(Properties props) {
         try {
-            return new ConnectionImpl(props.getProperty("server"), parseInt(props.getProperty("port")), props, props.getProperty("database"), null);
+            String host = props.getProperty("server");
+            int port = parseInt(props.getProperty("port"));
+            String user = props.getProperty("user");
+            String password = props.getProperty("password");
+            Map<String, String> properties = Map.of(PropertyKey.DBNAME.getKeyName(), props.getProperty("database"));
+            HostInfo hostInfo = new HostInfo(null, host, port, user, password, properties);
+            return new ConnectionImpl(hostInfo);
         } catch (SQLException e) {
             throw new RuntimeException(e);
         }

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -12,7 +12,6 @@ dependencies {
     compile libraries.guava
 
     compile libraries.apacheCommons3
-    compile libraries.mysqlConnector
     compile libraries.guavaRetrying
 
     testCompile libraries.junit
@@ -20,6 +19,7 @@ dependencies {
     testCompile libraries.shazamcrest
     testCompile libraries.hamcrest
     testCompile libraries.hamcrestOptional
+    testCompile libraries.mysqlConnector
 }
 
 jar {

--- a/main/src/test/java/com/kenshoo/pl/entity/DeadlockRetryerTest.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/DeadlockRetryerTest.java
@@ -2,7 +2,7 @@ package com.kenshoo.pl.entity;
 
 import com.kenshoo.pl.entity.mysql.MySqlDeadlockDetector;
 import com.kenshoo.pl.entity.spi.ThrowingAction;
-import com.mysql.jdbc.exceptions.jdbc4.MySQLTransactionRollbackException;
+import com.mysql.cj.jdbc.exceptions.MySQLTransactionRollbackException;
 import org.junit.Before;
 import org.junit.Test;
 


### PR DESCRIPTION
We need the 'mysql-connector-java' connector only for tests in this project. So in this PR update the dependency to be included only for tests and upgrade it's version