### PR TITLE
Upgrade mysql connector to 8.0.22 - fix test table creation

### DIFF
--- a/integration-tests/src/test/java/com.kenshoo.pl/one2many/GreatGrandChildTable.java
+++ b/integration-tests/src/test/java/com.kenshoo.pl/one2many/GreatGrandChildTable.java
@@ -17,7 +17,7 @@ public class GreatGrandChildTable extends AbstractDataTable<GreatGrandChildTable
 
     public final TableField<Record, Integer> parent_id = createPKAndFKField("parent_id", SQLDataType.INTEGER, ParentTable.INSTANCE.id);
     public final TableField<Record, String> grandchild_color = createPKAndFKField("grandchild_color", SQLDataType.VARCHAR.length(10), GrandChildTable.INSTANCE.color);
-    public final TableField<Record, String>  name = createPKField("name", SQLDataType.VARCHAR.length(40));
+    public final TableField<Record, String>  name = createPKField("name", SQLDataType.VARCHAR.length(40).identity(true));
 
     @Override
     public GreatGrandChildTable as(String alias) {

--- a/integration-tests/src/test/java/com/kenshoo/pl/auto/inc/ChildTable.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/auto/inc/ChildTable.java
@@ -10,7 +10,7 @@ public class ChildTable extends AbstractDataTable<ChildTable> {
     public static final ChildTable INSTANCE = new ChildTable("ChildTable");
 
     final TableField<Record, Integer> parent_id = createPKAndFKField("parent_id", SQLDataType.INTEGER, ParentTable.INSTANCE.id);
-    final TableField<Record, Integer> ordinal = createPKField("ordinal", SQLDataType.INTEGER);
+    final TableField<Record, Integer> ordinal = createPKField("ordinal", SQLDataType.INTEGER.identity(true));
     final TableField<Record, String> field1 = createField("field1", SQLDataType.VARCHAR(64));
 
     public ChildTable(String name) {

--- a/integration-tests/src/test/java/com/kenshoo/pl/auto/inc/GrandParentTable.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/auto/inc/GrandParentTable.java
@@ -9,7 +9,7 @@ public class GrandParentTable extends AbstractDataTable<GrandParentTable> {
 
     public static final GrandParentTable INSTANCE = new GrandParentTable("GrandParentTable");
 
-    final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER);
+    final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER.identity(true));
 
     public GrandParentTable(String name) {
         super(name);

--- a/integration-tests/src/test/java/com/kenshoo/pl/data/VirtualPartitionTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/data/VirtualPartitionTest.java
@@ -74,8 +74,8 @@ public class VirtualPartitionTest {
 
     private static class TestTable extends AbstractDataTable<TestTable> {
 
-        private final TableField<Record, Integer> type = createPKField("type", SQLDataType.INTEGER);
-        private final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER);
+        private final TableField<Record, Integer> type = createPKField("type", SQLDataType.INTEGER.identity(true));
+        private final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER.identity(true));
         private final TableField<Record, String> field1 = createField("field1", SQLDataType.VARCHAR.length(50));
 
         public TestTable(String name) {

--- a/integration-tests/src/test/java/com/kenshoo/pl/entity/ChildForTestTable.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/entity/ChildForTestTable.java
@@ -9,8 +9,8 @@ public class ChildForTestTable extends AbstractDataTable<ChildForTestTable> {
 
     public static final ChildForTestTable INSTANCE = new ChildForTestTable("ChildForTest");
 
-    final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER);
-    final TableField<Record, String> field = createPKField("field", SQLDataType.VARCHAR(50));
+    final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER.identity(true));
+    final TableField<Record, String> field = createPKField("field", SQLDataType.VARCHAR(50).nullable(false));
     final TableField<Record, Integer> parent_id = createFKField("parent_id", EntityForTestTable.INSTANCE.id);
 
     public ChildForTestTable(String name) {

--- a/integration-tests/src/test/java/com/kenshoo/pl/entity/DeadlockTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/entity/DeadlockTest.java
@@ -135,7 +135,7 @@ public class DeadlockTest {
 
     private static class TestTable extends AbstractDataTable<TestTable> {
 
-        private final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER);
+        private final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER.identity(true));
         private final TableField<Record, String> field = createField("field", SQLDataType.VARCHAR.length(50));
 
         public TestTable(String name) {

--- a/integration-tests/src/test/java/com/kenshoo/pl/entity/EntitiesFetcherByPLConditionTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/entity/EntitiesFetcherByPLConditionTest.java
@@ -506,8 +506,8 @@ public class EntitiesFetcherByPLConditionTest {
     private static class TestTable extends AbstractDataTable<TestTable> {
         private static final TestTable INSTANCE = new TestTable("test");
 
-        private final TableField<Record, Integer> type = createPKField("type", SQLDataType.INTEGER);
-        private final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER);
+        private final TableField<Record, Integer> type = createPKField("type", SQLDataType.INTEGER.identity(true));
+        private final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER.identity(true));
         private final TableField<Record, String> field1 = createField("field1", SQLDataType.VARCHAR.length(50));
         private final TableField<Record, String> enum_field = createField("enum_field", SQLDataType.VARCHAR.length(50));
         private final TableField<Record, Integer> parent_id = createFKField("parent_id", TestParentTable.INSTANCE.id);
@@ -529,7 +529,7 @@ public class EntitiesFetcherByPLConditionTest {
     private static class TestParentTable extends AbstractDataTable<TestParentTable> {
         private static final TestParentTable INSTANCE = new TestParentTable("testParent");
 
-        private final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER);
+        private final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER.identity(true));
         private final TableField<Record, String> field1 = createField("field1", SQLDataType.VARCHAR.length(50));
         private final TableField<Record, String> field2 = createField("field2", SQLDataType.VARCHAR.length(50));
 
@@ -550,7 +550,7 @@ public class EntitiesFetcherByPLConditionTest {
     private static class TestParentSecondaryTable extends AbstractDataTable<TestParentSecondaryTable> {
         private static final TestParentSecondaryTable INSTANCE = new TestParentSecondaryTable("testParentSecondary");
 
-        private final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER);
+        private final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER.identity(true));
         private final TableField<Record, String> field1 = createField("field1", SQLDataType.VARCHAR.length(50));
         private final TableField<Record, String> field2 = createField("field2", SQLDataType.VARCHAR.length(50));
         private final TableField<Record, Integer> parent_id = createFKField("parent_id", TestParentTable.INSTANCE.id);

--- a/integration-tests/src/test/java/com/kenshoo/pl/entity/EntitiesFetcherByPLConditionWithVirtualPartitionTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/entity/EntitiesFetcherByPLConditionWithVirtualPartitionTest.java
@@ -180,9 +180,9 @@ public class EntitiesFetcherByPLConditionWithVirtualPartitionTest {
     private static class TestTable extends AbstractDataTable<TestTable> {
         private static final TestTable INSTANCE = new TestTable("test");
 
-        private final TableField<Record, Integer> id1 = createPKField("id1", SQLDataType.INTEGER);
-        private final TableField<Record, Integer> id2 = createPKField("id2", SQLDataType.INTEGER);
-        private final TableField<Record, Integer> id3 = createPKField("id3", SQLDataType.INTEGER);
+        private final TableField<Record, Integer> id1 = createPKField("id1", SQLDataType.INTEGER.identity(true));
+        private final TableField<Record, Integer> id2 = createPKField("id2", SQLDataType.INTEGER.identity(true));
+        private final TableField<Record, Integer> id3 = createPKField("id3", SQLDataType.INTEGER.identity(true));
         private final TableField<Record, String> field1 = createField("field1", SQLDataType.VARCHAR.length(50));
 
         public TestTable(String name) {

--- a/integration-tests/src/test/java/com/kenshoo/pl/entity/EntitiesFetcherTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/entity/EntitiesFetcherTest.java
@@ -90,8 +90,8 @@ public class EntitiesFetcherTest {
 
     private static class TestTable extends AbstractDataTable<TestTable> {
 
-        private final TableField<Record, Integer> type = createPKField("type", SQLDataType.INTEGER);
-        private final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER);
+        private final TableField<Record, Integer> type = createPKField("type", SQLDataType.INTEGER.identity(true));
+        private final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER.identity(true));
         private final TableField<Record, String> field1 = createField("field1", SQLDataType.VARCHAR.length(50));
 
         public TestTable(String name) {

--- a/integration-tests/src/test/java/com/kenshoo/pl/entity/EntityForTestComplexKeyParentTable.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/entity/EntityForTestComplexKeyParentTable.java
@@ -9,8 +9,8 @@ public class EntityForTestComplexKeyParentTable extends AbstractDataTable<Entity
 
     public static final EntityForTestComplexKeyParentTable INSTANCE = new EntityForTestComplexKeyParentTable("EntityForTestComplexKeyParent");
 
-    final TableField<Record, Integer> id1 = createPKField("id1", SQLDataType.INTEGER);
-    final TableField<Record, Integer> id2 = createPKField("id2", SQLDataType.INTEGER);
+    final TableField<Record, Integer> id1 = createPKField("id1", SQLDataType.INTEGER.identity(true));
+    final TableField<Record, Integer> id2 = createPKField("id2", SQLDataType.INTEGER.identity(true));
     final TableField<Record, String> field1 = createField("field1", SQLDataType.VARCHAR.length(50));
 
     public EntityForTestComplexKeyParentTable(String name) {

--- a/integration-tests/src/test/java/com/kenshoo/pl/entity/EntityForTestParentTable.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/entity/EntityForTestParentTable.java
@@ -9,7 +9,7 @@ public class EntityForTestParentTable extends AbstractDataTable<EntityForTestPar
 
     public static final EntityForTestParentTable INSTANCE = new EntityForTestParentTable("EntityForTestParent");
 
-    final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER);
+    final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER.identity(true));
     final TableField<Record, String> field1 = createField("field1", SQLDataType.VARCHAR.length(50));
 
     public EntityForTestParentTable(String name) {

--- a/integration-tests/src/test/java/com/kenshoo/pl/entity/EntityForTestSecondaryTable.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/entity/EntityForTestSecondaryTable.java
@@ -12,7 +12,7 @@ public class EntityForTestSecondaryTable extends AbstractDataTable<EntityForTest
 
     public static final EntityForTestSecondaryTable INSTANCE = new EntityForTestSecondaryTable("SECONDARY_DUMMY");
 
-    final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER);
+    final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER.identity(true));
     final TableField<Record, Integer> entityId = createFKField("entity_id", EntityForTestTable.INSTANCE.id);
     final TableField<Record, String> url = createField("entity_url", SQLDataType.VARCHAR.length(100).nullable(false));
     final TableField<Record, String> url_param = createField("url_param", SQLDataType.VARCHAR.length(100));

--- a/integration-tests/src/test/java/com/kenshoo/pl/entity/PLContextSelectTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/entity/PLContextSelectTest.java
@@ -275,7 +275,7 @@ public class PLContextSelectTest {
     private static class TestTable extends AbstractDataTable<TestTable> {
         private static final TestTable INSTANCE = new TestTable("test");
 
-        private final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER);
+        private final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER.identity(true));
         private final TableField<Record, String> field1 = createField("field1", SQLDataType.VARCHAR.length(50));
         private final TableField<Record, Integer> parent_id = createFKField("parent_id", TestParentTable.INSTANCE.id);
 
@@ -296,7 +296,7 @@ public class PLContextSelectTest {
     private static class TestParentTable extends AbstractDataTable<TestParentTable> {
         private static final TestParentTable INSTANCE = new TestParentTable("testParent");
 
-        private final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER);
+        private final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER.identity(true));
         private final TableField<Record, String> field1 = createField("field1", SQLDataType.VARCHAR.length(50));
         private final TableField<Record, String> field2 = createField("field2", SQLDataType.VARCHAR.length(50));
 
@@ -317,7 +317,7 @@ public class PLContextSelectTest {
     private static class TestParentSecondaryTable extends AbstractDataTable<TestParentSecondaryTable> {
         private static final TestParentSecondaryTable INSTANCE = new TestParentSecondaryTable("testParentSecondary");
 
-        private final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER);
+        private final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER.identity(true));
         private final TableField<Record, String> field1 = createField("field1", SQLDataType.VARCHAR.length(50));
         private final TableField<Record, Integer> parent_id = createFKField("parent_id", TestParentTable.INSTANCE.id);
 

--- a/integration-tests/src/test/java/com/kenshoo/pl/entity/TimeoutTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/entity/TimeoutTest.java
@@ -145,7 +145,7 @@ public class TimeoutTest {
 
     private static class TestTable extends AbstractDataTable<TestTable> {
 
-        private final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER);
+        private final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER.identity(true));
         private final TableField<Record, String> field = createField("field", SQLDataType.VARCHAR.length(50));
 
         public TestTable(String name) {

--- a/integration-tests/src/test/java/com/kenshoo/pl/one2many/relatedByNonPK/ChildTable.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/one2many/relatedByNonPK/ChildTable.java
@@ -9,7 +9,7 @@ public class ChildTable extends AbstractDataTable<ChildTable> {
 
     public static final ChildTable INSTANCE = new ChildTable("ChildTable");
 
-    public final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER.identity(true));
+    public final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER.identity(true).identity(true));
     public final TableField<Record, String> type = createFKField("type", ParentTable.INSTANCE.type);
     public final TableField<Record, Integer> idInTarget = createFKField("idInTarget", ParentTable.INSTANCE.idInTarget);
     public final TableField<Record, Integer> ordinal = createField("ordinal", SQLDataType.INTEGER);

--- a/integration-tests/src/test/java/com/kenshoo/pl/one2many/relatedByNonPK/ParentTable.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/one2many/relatedByNonPK/ParentTable.java
@@ -9,7 +9,7 @@ public class ParentTable extends AbstractDataTable<ParentTable> {
 
     public static final ParentTable INSTANCE = new ParentTable("ParentTable");
 
-    public final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER.identity(true));
+    public final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER.identity(true).identity(true));
     public final TableField<Record, String> type = createField("type", SQLDataType.VARCHAR(40));
     public final TableField<Record, Integer> idInTarget = createField("idInTarget", SQLDataType.INTEGER);
     public final TableField<Record, String> name = createField("name", SQLDataType.VARCHAR(40));

--- a/integration-tests/src/test/java/com/kenshoo/pl/one2many/relatedByPK/ChildTable.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/one2many/relatedByPK/ChildTable.java
@@ -12,7 +12,7 @@ public class ChildTable extends AbstractDataTable<ChildTable> {
     public final TableField<Record, Integer> parent_id = createFKField("parent_id", ParentTable.INSTANCE.id);
     public final TableField<Record, Integer> ordinal = createField("ordinal", SQLDataType.INTEGER);
     public final TableField<Record, String> field1 = createField("field1", SQLDataType.VARCHAR(64));
-    public final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER);
+    public final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER.identity(true));
 
     public ChildTable(String name) {
         super(name);

--- a/integration-tests/src/test/java/com/kenshoo/pl/one2many/relatedByPK/GrandChildTable.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/one2many/relatedByPK/GrandChildTable.java
@@ -14,7 +14,7 @@ public class GrandChildTable extends AbstractDataTable<GrandChildTable> {
     }
 
     public final TableField<Record, Integer> child_id = createPKAndFKField("child_id", SQLDataType.INTEGER, ChildTable.INSTANCE.id);
-    public final TableField<Record, String>  color = createPKField("color", SQLDataType.VARCHAR.length(10));
+    public final TableField<Record, String>  color = createPKField("color", SQLDataType.VARCHAR.length(10).identity(true));
 
     @Override
     public GrandChildTable as(String alias) {

--- a/integration-tests/src/test/java/com/kenshoo/pl/one2many/relatedByPK/OtherChildTable.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/one2many/relatedByPK/OtherChildTable.java
@@ -11,7 +11,7 @@ public class OtherChildTable extends AbstractDataTable<OtherChildTable> {
 
     public final TableField<Record, Integer> parent_id = createFKField("parent_id", ParentTable.INSTANCE.id);
     public final TableField<Record, String> name = createField("name", SQLDataType.VARCHAR(64));
-    public final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER);
+    public final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER.identity(true));
 
     public OtherChildTable(String name) {
         super(name);

--- a/integration-tests/src/test/java/com/kenshoo/pl/one2many/relatedByPK/ParentTable.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/one2many/relatedByPK/ParentTable.java
@@ -9,10 +9,10 @@ public class ParentTable extends AbstractDataTable<ParentTable> {
 
     public static final ParentTable INSTANCE = new ParentTable("ParentTable");
 
-    public final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER);
+    public final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER.identity(true));
     public final TableField<Record, Integer> idInTarget = createField("idInTarget", SQLDataType.INTEGER);
     public final TableField<Record, String> name = createField("name", SQLDataType.VARCHAR(40));
-    public final TableField<Record, String> enum_field = createField("enum_field", SQLDataType.VARCHAR(40));
+    public final TableField<Record, String> enum_field = createField("enum_field", SQLDataType.VARCHAR(40).nullable(false));
 
     public ParentTable(String name) {
         super(name);

--- a/integration-tests/src/test/java/com/kenshoo/pl/secondary/FourLevelsWith3rdLevelBackReferencing2ndLevelNoSecondaryTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/secondary/FourLevelsWith3rdLevelBackReferencing2ndLevelNoSecondaryTest.java
@@ -142,7 +142,7 @@ public class FourLevelsWith3rdLevelBackReferencing2ndLevelNoSecondaryTest {
 
         static final Table0 INSTANCE = new Table0("entity0");
 
-        final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER);
+        final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER.identity(true));
         final TableField<Record, Integer> entity12_id = createFKField("entity12_id", Table12.INSTANCE.id);
         final TableField<Record, Integer> entity11_id = createFKField("entity11_id", Table11.INSTANCE.id);
 
@@ -164,7 +164,7 @@ public class FourLevelsWith3rdLevelBackReferencing2ndLevelNoSecondaryTest {
 
         static final Table11 INSTANCE = new Table11("entity11");
 
-        final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER);
+        final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER.identity(true));
 
         Table11(String name) {
             super(name);
@@ -184,7 +184,7 @@ public class FourLevelsWith3rdLevelBackReferencing2ndLevelNoSecondaryTest {
 
         static final Table12 INSTANCE = new Table12("entity12");
 
-        final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER);
+        final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER.identity(true));
         final TableField<Record, Integer> entity2_id = createFKField("entity2_id", Table2.INSTANCE.id);
 
         Table12(String name) {
@@ -205,8 +205,8 @@ public class FourLevelsWith3rdLevelBackReferencing2ndLevelNoSecondaryTest {
 
         static final Table2 INSTANCE = new Table2("entity2");
 
-        final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER);
-        final TableField<Record, String> name = createPKField("name", SQLDataType.VARCHAR(20));
+        final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER.identity(true));
+        final TableField<Record, String> name = createPKField("name", SQLDataType.VARCHAR(20).nullable(false));
         final TableField<Record, Integer> entity3_id = createFKField("entity3_id", Table3.INSTANCE.id);
         final TableField<Record, Integer> entity11_id = createFKField("entity11_id", Table11.INSTANCE.id);
 
@@ -228,7 +228,7 @@ public class FourLevelsWith3rdLevelBackReferencing2ndLevelNoSecondaryTest {
 
         static final Table3 INSTANCE = new Table3("entity3");
 
-        final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER);
+        final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER.identity(true));
         final TableField<Record, String> name = createField("name", SQLDataType.VARCHAR(20));
 
         Table3(String name) {

--- a/integration-tests/src/test/java/com/kenshoo/pl/secondary/MainTable.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/secondary/MainTable.java
@@ -9,7 +9,7 @@ public class MainTable extends AbstractDataTable<MainTable> {
 
     public static final MainTable INSTANCE = new MainTable("main");
 
-    final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER);
+    final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER.identity(true));
     final TableField<Record, Integer> id_in_target = createField("id_in_target", SQLDataType.INTEGER);
     final TableField<Record, String> name = createField("name", SQLDataType.VARCHAR.length(50));
     final TableField<Record, String> type = createField("type", SQLDataType.VARCHAR.length(10));

--- a/integration-tests/src/test/java/com/kenshoo/pl/secondary/ParentWithSecondaryTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/secondary/ParentWithSecondaryTest.java
@@ -130,7 +130,7 @@ public class ParentWithSecondaryTest {
 
         static final ChildTable INSTANCE = new ChildTable("child");
 
-        final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER);
+        final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER.identity(true));
         final TableField<Record, Integer> parent_id = createFKField("parent_id", ParentTable.INSTANCE.id);
 
         ChildTable(String name) {
@@ -151,7 +151,7 @@ public class ParentWithSecondaryTest {
 
         static final ParentTable INSTANCE = new ParentTable("parent");
 
-        final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER);
+        final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER.identity(true));
         final TableField<Record, String> field_1 = createField("field_1", SQLDataType.VARCHAR(20));
 
         ParentTable(String name) {

--- a/integration-tests/src/test/java/com/kenshoo/pl/secondary/ParentWithTwoSecondariesTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/secondary/ParentWithTwoSecondariesTest.java
@@ -132,7 +132,7 @@ public class ParentWithTwoSecondariesTest {
 
         static final ChildTable INSTANCE = new ChildTable("child");
 
-        final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER);
+        final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER.identity(true));
         final TableField<Record, Integer> parent_id = createFKField("parent_id", ParentTable.INSTANCE.id);
 
         ChildTable(String name) {
@@ -153,7 +153,7 @@ public class ParentWithTwoSecondariesTest {
 
         static final ParentTable INSTANCE = new ParentTable("parent");
 
-        final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER);
+        final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER.identity(true));
         final TableField<Record, String> field_1 = createField("field_1", SQLDataType.VARCHAR(20));
 
         ParentTable(String name) {

--- a/integration-tests/src/test/java/com/kenshoo/pl/secondary/ThreeLevelsWithSecondaryForEachOfTop2Test.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/secondary/ThreeLevelsWithSecondaryForEachOfTop2Test.java
@@ -144,7 +144,7 @@ public class ThreeLevelsWithSecondaryForEachOfTop2Test {
 
         static final Table0 INSTANCE = new Table0("entity0");
 
-        final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER);
+        final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER.identity(true));
         final TableField<Record, Integer> entity1_id = createFKField("entity1_id", Table1.INSTANCE.id);
 
         Table0(String name) {
@@ -165,7 +165,7 @@ public class ThreeLevelsWithSecondaryForEachOfTop2Test {
 
         static final Table1 INSTANCE = new Table1("entity1");
 
-        final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER);
+        final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER.identity(true));
         final TableField<Record, Integer> entity2_id = createFKField("entity2_id", Table2.INSTANCE.id);
 
         Table1(String name) {
@@ -207,7 +207,7 @@ public class ThreeLevelsWithSecondaryForEachOfTop2Test {
 
         static final Table2 INSTANCE = new Table2("entity2");
 
-        final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER);
+        final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER.identity(true));
         final TableField<Record, String> field_1 = createField("field_1", SQLDataType.VARCHAR(20));
 
         Table2(String name) {

--- a/integration-tests/src/test/java/com/kenshoo/pl/transaction/Table1.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/transaction/Table1.java
@@ -9,7 +9,7 @@ public class Table1 extends AbstractDataTable<Table1> {
 
     public static final Table1 INSTANCE = new Table1("Table1");
 
-    public final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER);
+    public final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER.identity(true));
     public final TableField<Record, String> name = createField("name", SQLDataType.VARCHAR(40));
 
     public Table1(String name) {

--- a/integration-tests/src/test/java/com/kenshoo/pl/transaction/Table2.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/transaction/Table2.java
@@ -9,7 +9,7 @@ public class Table2 extends AbstractDataTable<Table2> {
 
     public static final Table2 INSTANCE = new Table2("Table2");
 
-    public final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER);
+    public final TableField<Record, Integer> id = createPKField("id", SQLDataType.INTEGER.identity(true));
     public final TableField<Record, String> name = createField("name", SQLDataType.VARCHAR(40));
 
     public Table2(String name) {

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/ChildManualIdTable.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/ChildManualIdTable.java
@@ -9,7 +9,7 @@ public class ChildManualIdTable extends AbstractDataTable<ChildManualIdTable> {
 
     public static final ChildManualIdTable INSTANCE = new ChildManualIdTable();
 
-    public final TableField<Record, Long> id = createPKField("id", SQLDataType.BIGINT);
+    public final TableField<Record, Long> id = createPKField("id", SQLDataType.BIGINT.identity(true));
     public final TableField<Record, Long> parent_id = createFKField("parent_id", MainManualIdTable.INSTANCE.id);
     public final TableField<Record, String> name = createField("name", SQLDataType.VARCHAR(50));
     public final TableField<Record, String> desc = createField("desc", SQLDataType.VARCHAR(50));

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/ChildWithoutIdOfParentManualIdTable.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/ChildWithoutIdOfParentManualIdTable.java
@@ -10,8 +10,8 @@ public class ChildWithoutIdOfParentManualIdTable extends AbstractDataTable<Child
 
     public static final ChildWithoutIdOfParentManualIdTable INSTANCE = new ChildWithoutIdOfParentManualIdTable();
 
-    public final TableField<Record, Long> parent_id = createPKAndFKField("parent_id", SQLDataType.BIGINT, MainManualIdTable.INSTANCE.id);
-    public final TableField<Record, String> name = createPKField("name", SQLDataType.VARCHAR(50));
+    public final TableField<Record, Long> parent_id = createPKAndFKField("parent_id", SQLDataType.BIGINT.identity(true), MainManualIdTable.INSTANCE.id);
+    public final TableField<Record, String> name = createPKField("name", SQLDataType.VARCHAR(50).nullable(false));
     public final TableField<Record, String> desc = createField("desc", SQLDataType.VARCHAR(50));
 
     private ChildWithoutIdOfParentManualIdTable() {

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/ChildWithoutIdOfParentWithoutIdTable.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/ChildWithoutIdOfParentWithoutIdTable.java
@@ -9,8 +9,8 @@ public class ChildWithoutIdOfParentWithoutIdTable extends AbstractDataTable<Chil
 
     public static final ChildWithoutIdOfParentWithoutIdTable INSTANCE = new ChildWithoutIdOfParentWithoutIdTable();
 
-    public final TableField<Record, String> parent_name = createPKAndFKField("parent_name", SQLDataType.VARCHAR(50), MainWithoutIdTable.INSTANCE.name);
-    public final TableField<Record, String> name = createPKField("name", SQLDataType.VARCHAR(50));
+    public final TableField<Record, String> parent_name = createPKAndFKField("parent_name", SQLDataType.VARCHAR(50).nullable(false), MainWithoutIdTable.INSTANCE.name);
+    public final TableField<Record, String> name = createPKField("name", SQLDataType.VARCHAR(50).nullable(false));
     public final TableField<Record, String> desc = createField("desc", SQLDataType.VARCHAR(50));
 
     private ChildWithoutIdOfParentWithoutIdTable() {

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/MainManualIdTable.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/MainManualIdTable.java
@@ -9,7 +9,7 @@ public class MainManualIdTable extends AbstractDataTable<MainManualIdTable> {
 
     public static final MainManualIdTable INSTANCE = new MainManualIdTable();
 
-    public final TableField<Record, Long> id = createPKField("id", SQLDataType.BIGINT);
+    public final TableField<Record, Long> id = createPKField("id", SQLDataType.BIGINT.identity(true));
     public final TableField<Record, String> name = createField("name", SQLDataType.VARCHAR(50));
     public final TableField<Record, String> desc = createField("desc", SQLDataType.VARCHAR(50));
 

--- a/main/src/test/java/com/kenshoo/pl/entity/internal/audit/MainWithoutIdTable.java
+++ b/main/src/test/java/com/kenshoo/pl/entity/internal/audit/MainWithoutIdTable.java
@@ -10,7 +10,7 @@ public class MainWithoutIdTable extends AbstractDataTable<MainWithoutIdTable> {
 
     public static final MainWithoutIdTable INSTANCE = new MainWithoutIdTable();
 
-    public final TableField<Record, String> name = createPKField("name", SQLDataType.VARCHAR(50));
+    public final TableField<Record, String> name = createPKField("name", SQLDataType.VARCHAR(50).nullable(false));
     public final TableField<Record, String> desc = createField("desc", SQLDataType.VARCHAR(50));
     public final TableField<Record, String> desc2 = createField("desc2", SQLDataType.VARCHAR(50));
 


### PR DESCRIPTION
MySql version 8 demand that each created table will have not nullable primary key.
This affects only the tests that creates the tables on the dynamically.
Solution : fix the tables definitions in the tests.