### PR TITLE
Set idField only when it exists to avoid throwing an exception when performing a dummy insert or upsert.

### DIFF
--- a/integration-tests/src/test/java/com/kenshoo/pl/entity/PersistenceLayerTest.java
+++ b/integration-tests/src/test/java/com/kenshoo/pl/entity/PersistenceLayerTest.java
@@ -1062,7 +1062,7 @@ public class PersistenceLayerTest {
         assertThat(insertOnDuplicateUpdateResult.getStats().getAffectedRowsOf(mainTable.getName()).getUpdated(), is(0));
 
         boolean result = insertOnDuplicateUpdateResult.getChangeResults().stream()
-                .allMatch(changeResult -> changeResult.getCommand().get(ID) == null);
+                .allMatch(changeResult -> changeResult.getCommand().safeGet(ID).isAbsent());
 
         assertTrue(result);
     }

--- a/main/src/main/java/com/kenshoo/pl/entity/PersistenceLayer.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/PersistenceLayer.java
@@ -283,7 +283,7 @@ public class PersistenceLayer<ROOT extends EntityType<ROOT>> {
     private void populateIdentityField(final ChangeEntityCommand<ROOT> cmd, final ChangeContext changeContext, final EntityField<ROOT, Object> idField) {
         final CurrentEntityState currentState = Optional.ofNullable(changeContext.getEntity(cmd))
                                       .orElseThrow(() -> new IllegalStateException("Could not find entity of command in the change context"));
-        cmd.set(idField,  currentState.get(idField));
+        cmd.set(idField,  currentState.safeGet(idField).asOptional().orElse(null));
     }
 
     private DSLContext dslContext() {

--- a/main/src/main/java/com/kenshoo/pl/entity/PersistenceLayer.java
+++ b/main/src/main/java/com/kenshoo/pl/entity/PersistenceLayer.java
@@ -283,7 +283,9 @@ public class PersistenceLayer<ROOT extends EntityType<ROOT>> {
     private void populateIdentityField(final ChangeEntityCommand<ROOT> cmd, final ChangeContext changeContext, final EntityField<ROOT, Object> idField) {
         final CurrentEntityState currentState = Optional.ofNullable(changeContext.getEntity(cmd))
                                       .orElseThrow(() -> new IllegalStateException("Could not find entity of command in the change context"));
-        cmd.set(idField,  currentState.safeGet(idField).asOptional().orElse(null));
+        if (currentState.containsField(idField)) {
+            cmd.set(idField, currentState.get(idField));
+        }
     }
 
     private DSLContext dslContext() {


### PR DESCRIPTION
[SEARCH-173084](https://kenshoo.atlassian.net/browse/SEARCH-173084)


PL | fix review mode for create and upsert commands

I faced an issue where the dummy upsert or insert did not work. 
To fix it, we decided to set the primary field only when it exists.

`java.lang.RuntimeException: java.lang.IllegalArgumentException: Field ID of entity "sov keyword" is not fetched
`

[SEARCH-173084]: https://kenshoo.atlassian.net/browse/SEARCH-173084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ