### PR TITLE
Solve impersonator table memory leak

### DIFF
--- a/main/src/main/java/com/kenshoo/pl/data/ImpersonatorTable.java
+++ b/main/src/main/java/com/kenshoo/pl/data/ImpersonatorTable.java
@@ -6,11 +6,7 @@ import com.google.common.collect.Iterables;
 import com.kenshoo.jooq.DataTable;
 import com.kenshoo.jooq.FieldAndValue;
 import org.apache.commons.lang3.ArrayUtils;
-import org.jooq.Field;
-import org.jooq.ForeignKey;
-import org.jooq.Record;
-import org.jooq.TableField;
-import org.jooq.UniqueKey;
+import org.jooq.*;
 import org.jooq.impl.TableImpl;
 
 import java.util.Arrays;
@@ -110,8 +106,13 @@ public class ImpersonatorTable extends TableImpl<Record> implements DataTable {
         if (ArrayUtils.contains(fields, null)) {
             return null;
         }
-        //noinspection unchecked
-        return createForeignKey(foreignKey.getKey(), foreignKey.getTable(), fields);
+        UniqueKey<Record> uniqueKey = cloneUniqueKey(foreignKey.getKey());
+        return createForeignKey(uniqueKey, uniqueKey.getTable(), fields);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static UniqueKey<Record> cloneUniqueKey(UniqueKey<?> uniqueKey) {
+        return createUniqueKey((Table<Record>) uniqueKey.getTable(), (TableField<Record, ?>[]) uniqueKey.getFieldsArray());
     }
 
     private TableField<Record, ?>[] transformFields(TableField<Record, ?>[] originalFields) {


### PR DESCRIPTION
Solve impersonator table memory leak 

Description:
An impersonator table is created each time PL fetches parent fields from DB for a primary table of entity. 
This table is initialized by taking metadata from the primary table.
PL uses JOOQ API, which caches all the references in a target key table (singleton table)  during the generation of foreign key references (see [JOOQ](https://github.com/jOOQ/jOOQ/blob/a02760011cc9953773213c3fb453543c095052b3/jOOQ/src/main/java/org/jooq/impl/Internal.java#L464)).
The cloning target's unique key allows GC to release temporary metadata of the impersonator table.
